### PR TITLE
[MRESOLVER-31] Use the felix bundle plugin to generate OSGi metadata

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}.api</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -51,4 +52,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.connector.basic</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.connector.basic</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -86,6 +87,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -37,6 +37,7 @@
   </description>
 
   <properties>
+    <Automatic-Module-Name>org.apache.maven.resolver.demo.snippets</Automatic-Module-Name>
     <mavenVersion>3.5.0</mavenVersion>
   </properties>
 

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.impl</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.impl</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -99,6 +100,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.spi</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.spi</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -55,4 +56,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.testutil</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.testutil</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -59,4 +60,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.transport.classpath</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.transport.classpath</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -86,6 +87,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.transport.file</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.transport.file</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -82,6 +83,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.transport.http</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
     <jettyVersion>9.2.23.v20171218</jettyVersion>
   </properties>
 
@@ -139,6 +140,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.transport.wagon</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.transport.wagon</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -118,6 +119,19 @@
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -36,7 +36,8 @@
   </description>
 
   <properties>
-    <AutomaticModuleName>org.apache.maven.resolver.util</AutomaticModuleName>
+    <Automatic-Module-Name>org.apache.maven.resolver.util</Automatic-Module-Name>
+    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -60,4 +61,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -348,12 +348,36 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.5.0</version>
+          <configuration>
+            <manifestLocation>${project.build.directory}/osgi</manifestLocation>
+            <instructions>
+              <Bundle-SymbolicName>${Bundle-SymbolicName}</Bundle-SymbolicName>
+              <Bundle-DocURL>${project.url}</Bundle-DocURL>
+              <_removeheaders>Bnd-LastModified,Include-Resource</_removeheaders>
+              <!-- Export all packages except those with "internal" in their names -->
+              <_exportcontents>!*internal*,*</_exportcontents>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <id>bundle-manifest</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
             <archive>
               <manifestEntries>
-                <Automatic-Module-Name>${AutomaticModuleName}</Automatic-Module-Name>
+                <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
               </manifestEntries>
             </archive>
           </configuration>


### PR DESCRIPTION
This restores the OSGi metadata that was lost in the switch from
Eclipse Aether to Maven Resolver and allows maven-resolver to be
used in OSGi runtime environments.

Signed-off-by: Mat Booth <mbooth@apache.org>