### PR TITLE
Please merge MRESOLVER-10 and MRESOLVER-33 into master.

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDependencyCollectorTest.java
@@ -43,6 +43,7 @@ import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
+import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyCycle;
 import org.eclipse.aether.graph.DependencyNode;
@@ -58,6 +59,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
+import org.eclipse.aether.util.graph.manager.TransitiveDependencyManager;
 import org.eclipse.aether.util.graph.version.HighestVersionFilter;
 import org.junit.Before;
 import org.junit.Test;
@@ -482,6 +484,34 @@ public class DefaultDependencyCollectorTest
     }
 
     @Test
+    public void testDependencyManagement_TransitiveDependencyManager()
+        throws DependencyCollectionException, IOException
+    {
+        collector.setArtifactDescriptorReader( newReader( "managed/" ) );
+        parser = new DependencyGraphParser( "artifact-descriptions/managed/" );
+        session.setDependencyManager( new TransitiveDependencyManager() );
+        final Dependency root = newDep( "gid:root:ext:ver", "compile" );
+        CollectRequest request = new CollectRequest( root, Arrays.asList( repository ) );
+        request.addManagedDependency( newDep( "gid:root:ext:must-retain-core-management" ) );
+        CollectResult result = collector.collectDependencies( session, request );
+
+        final DependencyNode expectedTree = parser.parseResource( "management-tree.txt" );
+        assertEqualSubtree( expectedTree, result.getRoot() );
+
+        // Same test for root artifact (POM) request.
+        final CollectRequest rootArtifactRequest = new CollectRequest();
+        rootArtifactRequest.setRepositories( Arrays.asList( repository ) );
+        rootArtifactRequest.setRootArtifact( new DefaultArtifact( "gid:root:ext:ver" ) );
+        rootArtifactRequest.addDependency( newDep( "gid:direct:ext:ver", "compile" ) );
+        rootArtifactRequest.addManagedDependency( newDep( "gid:root:ext:must-retain-core-management" ) );
+        rootArtifactRequest.addManagedDependency( newDep( "gid:direct:ext:must-retain-core-management" ) );
+        rootArtifactRequest.addManagedDependency( newDep( "gid:transitive-1:ext:managed-by-root" ) );
+        session.setDependencyManager( new TransitiveDependencyManager() );
+        result = collector.collectDependencies( session, rootArtifactRequest );
+        assertEqualSubtree( expectedTree, this.toDependencyResult( result.getRoot(), "compile", null ) );
+    }
+
+    @Test
     public void testVersionFilter()
         throws Exception
     {
@@ -489,6 +519,24 @@ public class DefaultDependencyCollectorTest
         CollectRequest request = new CollectRequest().setRoot( newDep( "gid:aid:1" ) );
         CollectResult result = collector.collectDependencies( session, request );
         assertEquals( 1, result.getRoot().getChildren().size() );
+    }
+
+    private DependencyNode toDependencyResult( final DependencyNode root, final String rootScope,
+                                               final Boolean optional )
+    {
+        // Make the root artifact resultion result a dependency resolution result for the subtree check.
+        assertNull( "Expected root artifact resolution result.", root.getDependency() );
+        final DefaultDependencyNode defaultNode =
+            new DefaultDependencyNode( new Dependency( root.getArtifact(), rootScope ) );
+
+        defaultNode.setChildren( root.getChildren() );
+
+        if ( optional != null )
+        {
+            defaultNode.setOptional( optional );
+        }
+
+        return defaultNode;
     }
 
     static class TestDependencyManager

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/default-management-tree.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/default-management-tree.txt
@@ -1,0 +1,6 @@
+gid:root:ext:ver compile
++- gid:direct:ext:managed-by-dominant-request compile
+   +- gid:transitive-1:ext:managed-by-root compile
+      +- gid:transitive-2:ext:managed-by-direct compile
+         +- gid:transitive-3:ext:managed-by-transitive-1 compile
+            +- gid:transitive-4:ext:managed-by-transitive-2 compile

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_direct_managed-by-dominant-request.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_direct_managed-by-dominant-request.ini
@@ -1,0 +1,5 @@
+[dependencies]
+gid:transitive-1:ext:ver
+[manageddependencies]
+gid:transitive-1:ext:must-retain-core-management
+gid:transitive-2:ext:managed-by-direct

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_direct_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_direct_ver.ini
@@ -1,0 +1,5 @@
+[dependencies]
+gid:transitive-1:ext:ver
+[manageddependencies]
+gid:transitive-1:ext:must-retain-core-management
+gid:transitive-2:ext:managed-by-direct

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_root_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_root_ver.ini
@@ -1,0 +1,5 @@
+[dependencies]
+gid:direct:ext:ver
+[manageddependencies]
+gid:direct:ext:must-retain-core-management
+gid:transitive-1:ext:managed-by-root

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_root_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_root_ver.ini
@@ -1,5 +1,5 @@
 [dependencies]
 gid:direct:ext:ver
 [manageddependencies]
-gid:direct:ext:must-retain-core-management
+gid:direct:ext:must-be-ignored-for-maven-2-and-3-compat
 gid:transitive-1:ext:managed-by-root

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-1_managed-by-root.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-1_managed-by-root.ini
@@ -1,0 +1,5 @@
+[dependencies]
+gid:transitive-2:ext:ver
+[manageddependencies]
+gid:transitive-2:ext:must-retain-core-management
+gid:transitive-3:ext:managed-by-transitive-1

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-2_managed-by-direct.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-2_managed-by-direct.ini
@@ -1,0 +1,5 @@
+[dependencies]
+gid:transitive-3:ext:ver
+[manageddependencies]
+gid:transitive-3:ext:must-retain-core-management
+gid:transitive-4:ext:managed-by-transitive-2

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-3_managed-by-transitive-1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-3_managed-by-transitive-1.ini
@@ -1,0 +1,4 @@
+[dependencies]
+gid:transitive-4:ext:ver
+[manageddependencies]
+gid:transitive-4:ext:must-retain-core-management

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-4_managed-by-transitive-2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/gid_transitive-4_managed-by-transitive-2.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/management-tree.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/managed/management-tree.txt
@@ -1,0 +1,6 @@
+gid:root:ext:ver compile
++- gid:direct:ext:ver compile
+   +- gid:transitive-1:ext:managed-by-root compile
+      +- gid:transitive-2:ext:managed-by-direct compile
+         +- gid:transitive-3:ext:managed-by-transitive-1 compile
+            +- gid:transitive-4:ext:managed-by-transitive-2 compile

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -1,0 +1,320 @@
+package org.eclipse.aether.util.graph.manager;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencyManagement;
+import org.eclipse.aether.collection.DependencyManager;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+/**
+ * A dependency manager managing dependencies on all levels supporting transitive dependency management.
+ * <p>
+ * <b>Note:</b>Unlike the {@code ClassicDependencyManager} and the {@code TransitiveDependencyManager} this
+ * implementation applies management also on the first level. This is considered the resolver default behaviour. It
+ * ignores all management overrides supported by the {@code MavenModelBuilder}.
+ * </p>
+ *
+ * @author Christian Schulte
+ * @since 1.2.0
+ */
+public final class DefaultDependencyManager
+    implements DependencyManager
+{
+
+    private final Map<Object, String> managedVersions;
+
+    private final Map<Object, String> managedScopes;
+
+    private final Map<Object, Boolean> managedOptionals;
+
+    private final Map<Object, String> managedLocalPaths;
+
+    private final Map<Object, Collection<Exclusion>> managedExclusions;
+
+    private int hashCode;
+
+    /**
+     * Creates a new dependency manager without any management information.
+     */
+    public DefaultDependencyManager()
+    {
+        this( Collections.<Object, String>emptyMap(), Collections.<Object, String>emptyMap(),
+              Collections.<Object, Boolean>emptyMap(), Collections.<Object, String>emptyMap(),
+              Collections.<Object, Collection<Exclusion>>emptyMap() );
+    }
+
+    private DefaultDependencyManager( final Map<Object, String> managedVersions,
+                                      final Map<Object, String> managedScopes,
+                                      final Map<Object, Boolean> managedOptionals,
+                                      final Map<Object, String> managedLocalPaths,
+                                      final Map<Object, Collection<Exclusion>> managedExclusions )
+    {
+        super();
+        this.managedVersions = managedVersions;
+        this.managedScopes = managedScopes;
+        this.managedOptionals = managedOptionals;
+        this.managedLocalPaths = managedLocalPaths;
+        this.managedExclusions = managedExclusions;
+    }
+
+    public DependencyManager deriveChildManager( final DependencyCollectionContext context )
+    {
+        Map<Object, String> versions = this.managedVersions;
+        Map<Object, String> scopes = this.managedScopes;
+        Map<Object, Boolean> optionals = this.managedOptionals;
+        Map<Object, String> localPaths = this.managedLocalPaths;
+        Map<Object, Collection<Exclusion>> exclusions = this.managedExclusions;
+
+        for ( Dependency managedDependency : context.getManagedDependencies() )
+        {
+            Artifact artifact = managedDependency.getArtifact();
+            Object key = getKey( artifact );
+
+            String version = artifact.getVersion();
+            if ( version.length() > 0 && !versions.containsKey( key ) )
+            {
+                if ( versions == this.managedVersions )
+                {
+                    versions = new HashMap<Object, String>( this.managedVersions );
+                }
+                versions.put( key, version );
+            }
+
+            String scope = managedDependency.getScope();
+            if ( scope.length() > 0 && !scopes.containsKey( key ) )
+            {
+                if ( scopes == this.managedScopes )
+                {
+                    scopes = new HashMap<Object, String>( this.managedScopes );
+                }
+                scopes.put( key, scope );
+            }
+
+            Boolean optional = managedDependency.getOptional();
+            if ( optional != null && !optionals.containsKey( key ) )
+            {
+                if ( optionals == this.managedOptionals )
+                {
+                    optionals = new HashMap<Object, Boolean>( this.managedOptionals );
+                }
+                optionals.put( key, optional );
+            }
+
+            String localPath = managedDependency.getArtifact().getProperty( ArtifactProperties.LOCAL_PATH, null );
+            if ( localPath != null && !localPaths.containsKey( key ) )
+            {
+                if ( localPaths == this.managedLocalPaths )
+                {
+                    localPaths = new HashMap<Object, String>( this.managedLocalPaths );
+                }
+                localPaths.put( key, localPath );
+            }
+
+            if ( !managedDependency.getExclusions().isEmpty() )
+            {
+                if ( exclusions == this.managedExclusions )
+                {
+                    exclusions = new HashMap<Object, Collection<Exclusion>>( this.managedExclusions );
+                }
+                Collection<Exclusion> managed = exclusions.get( key );
+                if ( managed == null )
+                {
+                    managed = new LinkedHashSet<Exclusion>();
+                    exclusions.put( key, managed );
+                }
+                managed.addAll( managedDependency.getExclusions() );
+            }
+        }
+
+        return new DefaultDependencyManager( versions, scopes, optionals, localPaths, exclusions );
+    }
+
+    public DependencyManagement manageDependency( Dependency dependency )
+    {
+        DependencyManagement management = null;
+
+        Object key = getKey( dependency.getArtifact() );
+
+        String version = managedVersions.get( key );
+        if ( version != null )
+        {
+            if ( management == null )
+            {
+                management = new DependencyManagement();
+            }
+            management.setVersion( version );
+        }
+
+        String scope = managedScopes.get( key );
+        if ( scope != null )
+        {
+            if ( management == null )
+            {
+                management = new DependencyManagement();
+            }
+            management.setScope( scope );
+
+            if ( !JavaScopes.SYSTEM.equals( scope )
+                     && dependency.getArtifact().getProperty( ArtifactProperties.LOCAL_PATH, null ) != null )
+            {
+                Map<String, String> properties =
+                    new HashMap<String, String>( dependency.getArtifact().getProperties() );
+
+                properties.remove( ArtifactProperties.LOCAL_PATH );
+                management.setProperties( properties );
+            }
+        }
+
+        if ( ( scope != null && JavaScopes.SYSTEM.equals( scope ) )
+                 || ( scope == null && JavaScopes.SYSTEM.equals( dependency.getScope() ) ) )
+        {
+            String localPath = managedLocalPaths.get( key );
+            if ( localPath != null )
+            {
+                if ( management == null )
+                {
+                    management = new DependencyManagement();
+                }
+
+                Map<String, String> properties =
+                    new HashMap<String, String>( dependency.getArtifact().getProperties() );
+
+                properties.put( ArtifactProperties.LOCAL_PATH, localPath );
+                management.setProperties( properties );
+            }
+        }
+
+        Boolean optional = managedOptionals.get( key );
+        if ( optional != null )
+        {
+            if ( management == null )
+            {
+                management = new DependencyManagement();
+            }
+            management.setOptional( optional );
+        }
+
+        Collection<Exclusion> exclusions = managedExclusions.get( key );
+        if ( exclusions != null )
+        {
+            if ( management == null )
+            {
+                management = new DependencyManagement();
+            }
+            Collection<Exclusion> result = new LinkedHashSet<Exclusion>( dependency.getExclusions() );
+            result.addAll( exclusions );
+            management.setExclusions( result );
+        }
+
+        return management;
+    }
+
+    private Object getKey( Artifact a )
+    {
+        return new Key( a );
+    }
+
+    @Override
+    public boolean equals( final Object obj )
+    {
+        boolean equal = obj instanceof DefaultDependencyManager;
+
+        if ( equal )
+        {
+            final DefaultDependencyManager that = (DefaultDependencyManager) obj;
+            equal = this.managedVersions.equals( that.managedVersions )
+                        && this.managedScopes.equals( that.managedScopes )
+                        && this.managedOptionals.equals( that.managedOptionals )
+                        && this.managedExclusions.equals( that.managedExclusions );
+
+        }
+
+        return equal;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        if ( this.hashCode == 0 )
+        {
+            int hash = 17;
+            hash = hash * 31 + this.managedVersions.hashCode();
+            hash = hash * 31 + this.managedScopes.hashCode();
+            hash = hash * 31 + this.managedOptionals.hashCode();
+            hash = hash * 31 + this.managedExclusions.hashCode();
+            this.hashCode = hash;
+        }
+        return this.hashCode;
+    }
+
+    static class Key
+    {
+
+        private final Artifact artifact;
+
+        private final int hashCode;
+
+        public Key( final Artifact artifact )
+        {
+            this.artifact = artifact;
+
+            int hash = 17;
+            hash = hash * 31 + artifact.getGroupId().hashCode();
+            hash = hash * 31 + artifact.getArtifactId().hashCode();
+            this.hashCode = hash;
+        }
+
+        @Override
+        public boolean equals( final Object obj )
+        {
+            boolean equal = obj instanceof Key;
+
+            if ( equal )
+            {
+                final Key that = (Key) obj;
+                return this.artifact.getArtifactId().equals( that.artifact.getArtifactId() )
+                           && this.artifact.getGroupId().equals( that.artifact.getGroupId() )
+                           && this.artifact.getExtension().equals( that.artifact.getExtension() )
+                           && this.artifact.getClassifier().equals( that.artifact.getClassifier() );
+
+            }
+
+            return equal;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return this.hashCode;
+        }
+
+    }
+
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -1,0 +1,323 @@
+package org.eclipse.aether.util.graph.manager;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencyManagement;
+import org.eclipse.aether.collection.DependencyManager;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+/**
+ * A dependency manager managing transitive dependencies supporting transitive dependency management.
+ *
+ * @author Christian Schulte
+ * @since 1.2.0
+ */
+public final class TransitiveDependencyManager
+    implements DependencyManager
+{
+
+    private final Map<Object, String> managedVersions;
+
+    private final Map<Object, String> managedScopes;
+
+    private final Map<Object, Boolean> managedOptionals;
+
+    private final Map<Object, String> managedLocalPaths;
+
+    private final Map<Object, Collection<Exclusion>> managedExclusions;
+
+    private final int depth;
+
+    private int hashCode;
+
+    /**
+     * Creates a new dependency manager without any management information.
+     */
+    public TransitiveDependencyManager()
+    {
+        this( 0, Collections.<Object, String>emptyMap(), Collections.<Object, String>emptyMap(),
+              Collections.<Object, Boolean>emptyMap(), Collections.<Object, String>emptyMap(),
+              Collections.<Object, Collection<Exclusion>>emptyMap() );
+    }
+
+    private TransitiveDependencyManager( final int depth,
+                                         final Map<Object, String> managedVersions,
+                                         final Map<Object, String> managedScopes,
+                                         final Map<Object, Boolean> managedOptionals,
+                                         final Map<Object, String> managedLocalPaths,
+                                         final Map<Object, Collection<Exclusion>> managedExclusions )
+    {
+        super();
+        this.depth = depth;
+        this.managedVersions = managedVersions;
+        this.managedScopes = managedScopes;
+        this.managedOptionals = managedOptionals;
+        this.managedLocalPaths = managedLocalPaths;
+        this.managedExclusions = managedExclusions;
+    }
+
+    public DependencyManager deriveChildManager( final DependencyCollectionContext context )
+    {
+        Map<Object, String> versions = this.managedVersions;
+        Map<Object, String> scopes = this.managedScopes;
+        Map<Object, Boolean> optionals = this.managedOptionals;
+        Map<Object, String> localPaths = this.managedLocalPaths;
+        Map<Object, Collection<Exclusion>> exclusions = this.managedExclusions;
+
+        for ( Dependency managedDependency : context.getManagedDependencies() )
+        {
+            Artifact artifact = managedDependency.getArtifact();
+            Object key = getKey( artifact );
+
+            String version = artifact.getVersion();
+            if ( version.length() > 0 && !versions.containsKey( key ) )
+            {
+                if ( versions == this.managedVersions )
+                {
+                    versions = new HashMap<Object, String>( this.managedVersions );
+                }
+                versions.put( key, version );
+            }
+
+            String scope = managedDependency.getScope();
+            if ( scope.length() > 0 && !scopes.containsKey( key ) )
+            {
+                if ( scopes == this.managedScopes )
+                {
+                    scopes = new HashMap<Object, String>( this.managedScopes );
+                }
+                scopes.put( key, scope );
+            }
+
+            Boolean optional = managedDependency.getOptional();
+            if ( optional != null && !optionals.containsKey( key ) )
+            {
+                if ( optionals == this.managedOptionals )
+                {
+                    optionals = new HashMap<Object, Boolean>( this.managedOptionals );
+                }
+                optionals.put( key, optional );
+            }
+
+            String localPath = managedDependency.getArtifact().getProperty( ArtifactProperties.LOCAL_PATH, null );
+            if ( localPath != null && !localPaths.containsKey( key ) )
+            {
+                if ( localPaths == this.managedLocalPaths )
+                {
+                    localPaths = new HashMap<Object, String>( this.managedLocalPaths );
+                }
+                localPaths.put( key, localPath );
+            }
+
+            if ( !managedDependency.getExclusions().isEmpty() )
+            {
+                if ( exclusions == this.managedExclusions )
+                {
+                    exclusions = new HashMap<Object, Collection<Exclusion>>( this.managedExclusions );
+                }
+                Collection<Exclusion> managed = exclusions.get( key );
+                if ( managed == null )
+                {
+                    managed = new LinkedHashSet<Exclusion>();
+                    exclusions.put( key, managed );
+                }
+                managed.addAll( managedDependency.getExclusions() );
+            }
+        }
+
+        return new TransitiveDependencyManager( this.depth + 1, versions, scopes, optionals, localPaths,
+                                                exclusions );
+
+    }
+
+    public DependencyManagement manageDependency( Dependency dependency )
+    {
+        DependencyManagement management = null;
+
+        Object key = getKey( dependency.getArtifact() );
+
+        if ( this.depth >= 2 )
+        {
+            String version = managedVersions.get( key );
+            if ( version != null )
+            {
+                if ( management == null )
+                {
+                    management = new DependencyManagement();
+                }
+                management.setVersion( version );
+            }
+
+            String scope = managedScopes.get( key );
+            if ( scope != null )
+            {
+                if ( management == null )
+                {
+                    management = new DependencyManagement();
+                }
+                management.setScope( scope );
+
+                if ( !JavaScopes.SYSTEM.equals( scope )
+                         && dependency.getArtifact().getProperty( ArtifactProperties.LOCAL_PATH, null ) != null )
+                {
+                    Map<String, String> properties =
+                        new HashMap<String, String>( dependency.getArtifact().getProperties() );
+                    properties.remove( ArtifactProperties.LOCAL_PATH );
+                    management.setProperties( properties );
+                }
+            }
+
+            if ( ( scope != null && JavaScopes.SYSTEM.equals( scope ) )
+                     || ( scope == null && JavaScopes.SYSTEM.equals( dependency.getScope() ) ) )
+            {
+                String localPath = managedLocalPaths.get( key );
+                if ( localPath != null )
+                {
+                    if ( management == null )
+                    {
+                        management = new DependencyManagement();
+                    }
+                    Map<String, String> properties =
+                        new HashMap<String, String>( dependency.getArtifact().getProperties() );
+                    properties.put( ArtifactProperties.LOCAL_PATH, localPath );
+                    management.setProperties( properties );
+                }
+            }
+
+            Boolean optional = managedOptionals.get( key );
+            if ( optional != null )
+            {
+                if ( management == null )
+                {
+                    management = new DependencyManagement();
+                }
+                management.setOptional( optional );
+            }
+        }
+
+        Collection<Exclusion> exclusions = managedExclusions.get( key );
+        if ( exclusions != null )
+        {
+            if ( management == null )
+            {
+                management = new DependencyManagement();
+            }
+            Collection<Exclusion> result = new LinkedHashSet<Exclusion>( dependency.getExclusions() );
+            result.addAll( exclusions );
+            management.setExclusions( result );
+        }
+
+        return management;
+    }
+
+    private Object getKey( Artifact a )
+    {
+        return new Key( a );
+    }
+
+    @Override
+    public boolean equals( final Object obj )
+    {
+        boolean equal = obj instanceof TransitiveDependencyManager;
+
+        if ( equal )
+        {
+            final TransitiveDependencyManager that = (TransitiveDependencyManager) obj;
+            return this.depth == that.depth
+                       && this.managedVersions.equals( that.managedVersions )
+                       && this.managedScopes.equals( that.managedScopes )
+                       && this.managedOptionals.equals( that.managedOptionals )
+                       && this.managedExclusions.equals( that.managedExclusions );
+
+        }
+
+        return equal;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        if ( this.hashCode == 0 )
+        {
+            int hash = 17;
+            hash = hash * 31 + this.depth;
+            hash = hash * 31 + this.managedVersions.hashCode();
+            hash = hash * 31 + this.managedScopes.hashCode();
+            hash = hash * 31 + this.managedOptionals.hashCode();
+            hash = hash * 31 + this.managedExclusions.hashCode();
+            this.hashCode = hash;
+        }
+        return this.hashCode;
+    }
+
+    static class Key
+    {
+
+        private final Artifact artifact;
+
+        private final int hashCode;
+
+        public Key( final Artifact artifact )
+        {
+            this.artifact = artifact;
+
+            int hash = 17;
+            hash = hash * 31 + artifact.getGroupId().hashCode();
+            hash = hash * 31 + artifact.getArtifactId().hashCode();
+            this.hashCode = hash;
+        }
+
+        @Override
+        public boolean equals( final Object obj )
+        {
+            boolean equal = obj instanceof Key;
+
+            if ( equal )
+            {
+                final Key that = (Key) obj;
+                return this.artifact.getArtifactId().equals( that.artifact.getArtifactId() )
+                           && this.artifact.getGroupId().equals( that.artifact.getGroupId() )
+                           && this.artifact.getExtension().equals( that.artifact.getExtension() )
+                           && this.artifact.getClassifier().equals( that.artifact.getClassifier() );
+
+            }
+
+            return equal;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return this.hashCode;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request just adds two new classes to the Maven Resolver without changing anything else. Those two classes are related to MRESOLVER-10 and MRESOLVER-33. It would be cool if this could be merged to the master branch @Apache. The resolver should provide those implementations. If Maven does not choose to use them, so be it. The Maven Resolver already provides other useful implementations not used by Maven. No reason not to merge this.