### PR TITLE
[MRESOLVER-34] Update to latest dependences

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
@@ -82,7 +82,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>1.5</version>
+            <version>3.0.1</version>
             <configuration>
               <debug>false</debug>
               <projectsDirectory>src/it</projectsDirectory>

--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/src/it/resolve-artifact/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/src/it/resolve-artifact/pom.xml
@@ -41,7 +41,7 @@
               <goal>resolve-artifact</goal>
             </goals>
             <configuration>
-              <artifactCoords>junit:junit:3.8.2</artifactCoords>
+              <artifactCoords>junit:junit:4.12</artifactCoords>
             </configuration>
           </execution>
         </executions>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -45,12 +45,12 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>2.1</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.6.2</version>
+        <version>${slf4jVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -92,6 +92,7 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <version>${sisuVersion}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -101,6 +102,7 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-guice</artifactId>
+      <version>3.2.6</version>
       <classifier>no_aop</classifier>
       <optional>true</optional>
     </dependency>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -37,7 +37,7 @@
 
   <properties>
     <AutomaticModuleName>org.apache.maven.resolver.transport.http</AutomaticModuleName>
-    <jettyVersion>9.2.9.v20150224</jettyVersion>
+    <jettyVersion>9.2.22.v20170606</jettyVersion>
   </properties>
 
   <dependencies>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.6</version>
+      <version>4.4.8</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
+      <version>3.1.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
org.apache.httpcomponents:httpcore .................... 4.4.6 -> 4.4.8
org.codehaus.plexus:plexus-utils ..................... 3.0.24 -> 3.1.0
org.eclipse.sisu:org.eclipse.sisu.plexus .............. 0.1.1 -> 0.3.3
org.sonatype.sisu:sisu-guice .......................... 3.1.6 -> 3.2.6

org.eclipse.jetty:jetty-server .... 9.2.9.v20150224 -> 9.2.22.v20170606
org.eclipse.jetty:jetty-servlet ... 9.2.9.v20150224 -> 9.2.22.v20170606
org.eclipse.jetty:jetty-util ...... 9.2.9.v20150224 -> 9.2.22.v20170606

Plugins:
maven-invoker-plugin:3.0.1
junit:junit:4.12
org.eclipse.sisu.plexus:0.3.3