### PR TITLE
MRESOLVER-39: Sleep for short duration in spin lock.

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/PartialFile.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/PartialFile.java
@@ -110,7 +110,7 @@ final class PartialFile
 
                     try
                     {
-                        Thread.sleep( Math.max( requestTimeout / 2, 100 ) );
+                        Thread.sleep( 100 );
                     }
                     catch ( InterruptedException e )
                     {


### PR DESCRIPTION
Revert the change to the sleep duration made in
ad50215d27feede0ad0e5eb83ae96c6d6fdcc639 as this causes any thread which
needs to sleep to do so for 900 seconds (15 minutes) by default
(DEFAULT_REQUEST_TIMEOUT / 2) which seems way to long.