### PR TITLE
[MRESOLVER-42] Use pre-compiled pattern in DefaultArtifact constructor

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
@@ -33,6 +33,8 @@ import java.util.regex.Pattern;
 public final class DefaultArtifact
     extends AbstractArtifact
 {
+    private static final Pattern COORDINATE_PATTERN =
+        Pattern.compile( "([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)" );
 
     private final String groupId;
 
@@ -70,8 +72,7 @@ public final class DefaultArtifact
      */
     public DefaultArtifact( String coords, Map<String, String> properties )
     {
-        Pattern p = Pattern.compile( "([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)" );
-        Matcher m = p.matcher( coords );
+        Matcher m = COORDINATE_PATTERN.matcher( coords );
         if ( !m.matches() )
         {
             throw new IllegalArgumentException( "Bad artifact coordinates " + coords


### PR DESCRIPTION
Compiling a pattern is a rather expensive operation and doing it
a user-convenient constructor is very hurtful. Cache the compiled
pattern in a static final field, just like other classes in this
artifact do.

Signed-off-by: Robert Varga <nite@hq.sk>