### PR TITLE
Introduce caching for tracking files.

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LRUCache.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LRUCache.java
@@ -1,0 +1,384 @@
+package org.eclipse.aether.internal.impl;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Simple LRU cache with size and time bounds.
+ * 
+ * Semantics are: If ttl is positive than entries will be expired after given
+ * ttl (no matter if they are read or not). If maxSize is positive than those
+ * number of entries will be never exceeded. Expiry of entry is effectively
+ * signalled by returning null value from the cache, although the cache does not
+ * decrease in size immediately, as the implementation will expunge expired
+ * entires once per 10seconds.
+ *
+ * The implementation keeps a simple unordered hash map of cached entries plus a
+ * double-ended linked list that is reordered upon put/get operations. The tail
+ * of list is the least recently used element. The head is the most recently
+ * used element.
+ * 
+ * <strong>Class is not thread safe. Use
+ * {@link Collections#synchronizedMap(Map)}.</strong>
+ * 
+ * <strong>The iteration order of views is unspecified - it is not according to
+ * usage</strong>
+ * 
+ * <strong>Iteration over views should not be mixed with get/put/remove/clear
+ * operations on the map as it will lead to
+ * {@link ConcurrentModificationException}</strong>
+ * 
+ * <strong>Values of elements during iteration may become expired and they will
+ * turn into null, however the expunging process is not triggered during
+ * iteration.</strong>
+ *
+ * @param <K> key type, it should follow {@link HashMap} semantics
+ * @param <V> value type, any object will do (only {@link Object#equals(Object)}
+ *        is used to provide {@link #containsValue(Object)})
+ */
+public class LRUCache<K, V> implements Map<K, V> {
+
+    // expunge expired elements once per 10s
+    private static final int EXPUNGE_TIMEOUT = 10000;
+
+    // internal entry in the cache
+    static class E<K, V> {
+
+        // key of entry
+        K key;
+
+        // valu ef entry
+        V value;
+
+        // timestamp of modification (not updated on access)
+        long ts;
+
+        // next element in linked list
+        E<K, V> next;
+
+        // previous element in linked list
+        E<K, V> prev;
+
+        public E(K key, V value) {
+            super();
+            this.key = key;
+            this.value = value;
+            this.ts = System.currentTimeMillis();
+        }
+
+        public boolean isExpired(int ttl) {
+            return ttl > 0 && System.currentTimeMillis() - this.ts > ttl;
+        }
+
+        public V update(V value, int ttl) {
+            V oldValue = getValue(ttl);
+            this.value = value;
+            this.ts = System.currentTimeMillis();
+            return oldValue;
+        }
+
+        public V getValue(int ttl) {
+            if (!isExpired(ttl)) {
+                return this.value;
+            } else {
+                return null;
+            }
+        }
+
+        // just to provide containsValue
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof E) {
+                E e = (E) obj;
+                return Objects.equals(e.value, this.value);
+            } else {
+                return false;
+            }
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+    }
+
+    // maximum size, must be positive to be effective
+    int maxSize;
+
+    // maximum time to live, must be positive to be effective
+    int ttl;
+
+    // last timestamp of expiry check on elements
+    long lastExpungeTs;
+
+    // actual cache entries
+    Map<K, E<K, V>> map;
+
+    // linked list head
+    E<K, V> head;
+
+    // linked list tail
+    E<K, V> tail;
+
+    /**
+     * Construct new cache instance optionally bounded in size and ttl of elements.
+     * 
+     * @param maxSize maximum size or 0 for unlimited
+     * @param ttl     maximum ttl of elements in ms or 0 for unlimited
+     */
+    public LRUCache(int maxSize, int ttl) {
+        this.lastExpungeTs = System.currentTimeMillis();
+        this.maxSize = maxSize;
+        this.ttl = ttl;
+        this.map = new HashMap<>();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        E<K, V> entry = map.get(key);
+        V oldValue = null;
+        if (entry != null) {
+            oldValue = entry.update(value, ttl);
+            LRUListSetHead(entry);
+        } else {
+            entry = new E<>(key, value);
+            map.put(key, entry);
+            LRUListSetHead(entry);
+            expungeLRU();
+        }
+
+        expungeExpired();
+
+        return oldValue;
+    }
+
+    /**
+     * Remove LRU elements so that size < maxSize (unless maxSize is 0)
+     */
+    private void expungeLRU() {
+        if (maxSize > 0 && map.size() > maxSize) {
+            map.remove(tail.key);
+            LRUListRemove(tail);
+        }
+    }
+
+    /**
+     * Remove expired elements so that their ts is not older than given ttl (unless
+     * ttl = 0).
+     */
+    private void expungeExpired() {
+        if (ttl > 0) {
+            long now = System.currentTimeMillis();
+            if (lastExpungeTs + EXPUNGE_TIMEOUT < now) {
+                lastExpungeTs = now;
+                for (Iterator<Entry<K, E<K, V>>> it = map.entrySet().iterator(); it.hasNext();) {
+                    Entry<K, E<K, V>> mapEntry = it.next();
+                    E<K, V> cacheEntry = mapEntry.getValue();
+                    if (cacheEntry.isExpired(ttl)) {
+                        LRUListRemove(cacheEntry);
+                        it.remove();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove element from LRU list.
+     * 
+     * @param e
+     */
+    private void LRUListRemove(E<K, V> e) {
+        if (e.next != null) {
+            e.next.prev = e.prev;
+        }
+        if (e.prev != null) {
+            e.prev.next = e.next;
+        }
+        if (e == head) {
+            head = e.next;
+        }
+        if (e == tail) {
+            tail = e.prev;
+        }
+        e.next = null;
+        e.prev = null;
+    }
+
+    /**
+     * Set given element as head of LRU list.
+     * 
+     * @param e
+     */
+    private void LRUListSetHead(E<K, V> e) {
+        // first remove from LRU list (could check if its already head but its
+        // unlikely).
+        LRUListRemove(e);
+        // if existing head then update links
+        if (head != null) {
+            e.next = head;
+            head.prev = e;
+        }
+        head = e;
+        // set also tail if not present
+        if (tail == null) {
+            tail = e;
+        }
+    }
+
+    @Override
+    public V get(Object key) {
+        E<K, V> entry = map.get(key);
+        if (entry != null) {
+            LRUListSetHead(entry);
+            V value = entry.getValue(ttl);
+            expungeExpired();
+            return value;
+        } else {
+            expungeExpired();
+            return null;
+        }
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        E<K, V> el = map.remove(key);
+        if (el != null) {
+            LRUListRemove(el);
+        }
+        return el != null ? el.getValue(ttl) : null;
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        for (Entry<? extends K, ? extends V> mapEntry : m.entrySet()) {
+            put(mapEntry.getKey(), mapEntry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+        // clear LRU list
+        head = null;
+        tail = null;
+        lastExpungeTs = System.currentTimeMillis();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        expungeExpired();
+        return Collections.unmodifiableSet(map.keySet());
+    }
+
+    @Override
+    public Collection<V> values() {
+        expungeExpired();
+        return new AbstractCollection<V>() {
+
+            @Override
+            public Iterator<V> iterator() {
+                return new Iterator<V>() {
+
+                    Iterator<E<K, V>> it = map.values().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return it.hasNext();
+                    }
+
+                    @Override
+                    public V next() {
+                        E<K, V> e = it.next();
+                        return e.getValue(ttl);
+                    }
+
+                };
+            }
+
+            @Override
+            public int size() {
+                return map.size();
+            }
+        };
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        expungeExpired();
+        return new AbstractSet<Entry<K, V>>() {
+
+            @Override
+            public Iterator<Entry<K, V>> iterator() {
+                return new Iterator<Map.Entry<K, V>>() {
+                    Iterator<E<K, V>> it = map.values().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return it.hasNext();
+                    }
+
+                    @Override
+                    public Entry<K, V> next() {
+                        final E<K, V> entry = it.next();
+                        return new Map.Entry<K, V>() {
+
+                            @Override
+                            public K getKey() {
+                                return entry.getKey();
+                            }
+
+                            @Override
+                            public V getValue() {
+                                return entry.getValue(ttl);
+                            }
+
+                            @Override
+                            public V setValue(V value) {
+                                V oldValue = entry.update(value, ttl);
+                                LRUListSetHead(entry);
+                                return oldValue;
+                            }
+                        };
+                    }
+
+                };
+
+            }
+
+            @Override
+            public int size() {
+                return map.size();
+            }
+
+        };
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/LRUCacheTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/LRUCacheTest.java
@@ -1,0 +1,60 @@
+package org.eclipse.aether.internal.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class LRUCacheTest {
+    
+    @Test
+    public void testSizeBound( ){
+        LRUCache<String, Integer> cache = new LRUCache<>(10, 0);
+        for(int i = 0;i<20;i++) {
+            cache.put("#"+i, i);
+        }
+        assertEquals(10, cache.size());
+        assertEquals(null, cache.get("#0")); // expunged
+        assertEquals(Integer.valueOf(10), cache.get("#10")); // not expunged
+        
+        // second time its the same
+        for(int i = 0;i<20;i++) {
+            cache.put("#"+i, i);
+        }
+        assertEquals(10, cache.size());
+        assertEquals(null, cache.get("#0")); // expunged
+        assertEquals(Integer.valueOf(10), cache.get("#10")); // not expunged
+        
+        // now we are going to 'touch' #0 to prevent expunging
+        for(int i = 0;i<20;i++) {
+            cache.put("#"+i, i);
+            cache.get("#0");
+        }
+        assertEquals(10, cache.size());
+        assertEquals(Integer.valueOf(0), cache.get("#0")); // not expunged
+        assertEquals(null, cache.get("#10")); // expunged 
+
+    }
+    
+    @Test
+    public void testTimeBound( ) throws InterruptedException{
+        LRUCache<String, Integer> cache = new LRUCache<>(0, 100);
+        cache.put("#10", 10);
+        assertEquals(1, cache.size());
+        assertEquals(Integer.valueOf(10), cache.get("#10")); // not expired
+        assertEquals(1, cache.size());
+        Thread.sleep(50);
+        assertEquals(1, cache.size());
+        assertEquals(Integer.valueOf(10), cache.get("#10")); // not expired
+        assertEquals(1, cache.size());
+        Thread.sleep(200);
+        assertEquals(1, cache.size());
+        assertEquals(null, cache.get("#10")); // expired
+        assertEquals(1, cache.size());
+        Thread.sleep(10000);
+        assertEquals(1, cache.size()); // not expunged yet
+        assertEquals(null, cache.get("#10")); // expired
+        assertEquals(0, cache.size()); // and now expunged
+        
+    }
+
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/TrackingFileManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/TrackingFileManagerTest.java
@@ -55,6 +55,7 @@ public class TrackingFileManagerTest
 
         assertTrue( "Leaked file: " + propFile, propFile.delete() );
 
+        tfm.expire(propFile);
         props = tfm.read( propFile );
         assertNull( String.valueOf( props ), props );
     }
@@ -68,6 +69,7 @@ public class TrackingFileManagerTest
         for ( int i = 0; i < 1000; i++ )
         {
             File propFile = TestFileUtils.createTempFile( "#COMMENT\nkey1=value1\nkey2 : value2" );
+            tfm.expunge(propFile);
             assertNotNull( tfm.read( propFile ) );
             assertTrue( "Leaked file: " + propFile, propFile.delete() );
         }
@@ -142,6 +144,7 @@ public class TrackingFileManagerTest
                     {
                         for ( int i = 0; i < 1000; i++ )
                         {
+                            tfm.expunge(file); // required since otherwise it would be a cached file
                             assertNotNull( tfm.read( file ) );
                         }
                     }


### PR DESCRIPTION
Reason:
The tracking file manager typically in large m2e projects will be used
hundreds of times (due to hundreds of artifacts). If the projects are
refreshed the files are re-read again and again. This could amount to as
much as 43% of time spent in m2e MavenBuilder (in my scenario on Windows
platform)

Changes:
This commit introduces the read cache for tracking files assuming that
those files do not change frequently (or at all).
The cache entries are verified once per minute if the underlying file
had changed its lastModified timestamp and if so they are re-read. If
the file timestamp had not changed the entry is valid for one more
minute.

Additionally since on Windows canonicalization is expensive operation it
is also being cached.

Cached properties are defensively copied when returned.

TODOs:
 - the cache is unbounded and there is no clearing policy based on LRU
 and maximum size (for instance). However for typical usages this will
 not be a problem since number of artifacts is probably couple of
 thousands and should not pose a problem for memory.

I'm making this PR without much hope of approving it. The tracking files performance may not be something that is perceived as problematic by maintainers of this library, but I've stumbled on this issue while profiling m2e builds which are taking quite long (and I've decided to do something about it).
