### PR TITLE
[MRESOLVER-68] Add cache around TrackingFileManager.getLock(File)

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -144,6 +144,24 @@ public final class ConfigurationProperties
      */
     public static final boolean DEFAULT_PERSISTED_CHECKSUMS = true;
 
+    /**
+     * The prefix for configuration for internal components.
+     */
+    private static final String PREFIX_INTERNAL = PREFIX_AETHER + "internal.";
+
+    /**
+     * The size of the file lock name cache, used by the TrackingFileManager to map Files to their interned, canonical
+     * names.
+     *
+     * @see #DEFAULT_TRACKING_FILE_MANAGER_FILE_LOCK_CACHE_SIZE
+     */
+    public static final String TRACKING_FILE_MANAGER_FILE_LOCK_CACHE_SIZE = PREFIX_INTERNAL + "trackingFileManager.fileLockCacheSize";
+
+    /**
+     * The default size if {@link #TRACKING_FILE_MANAGER_FILE_LOCK_CACHE_SIZE} isn't set.
+     */
+    public static final long DEFAULT_TRACKING_FILE_MANAGER_FILE_LOCK_CACHE_SIZE = 1024L;
+
     private ConfigurationProperties()
     {
         // hide constructor

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -174,6 +174,18 @@ public final class ConfigurationProperties
      */
     public static final long DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_CACHE_SIZE = 1024L;
 
+    /**
+     * The number of seconds to keep entries in the properties cache, used by the TrackingFileManager to map Files to their parsed properties.
+     *
+     * @see #DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_CACHE_SIZE
+     */
+    public static final String TRACKING_FILE_MANAGER_FILE_PROPERTIES_EXPIRE_AFTER_ACCESS = PREFIX_INTERNAL + "trackingFileManager.propertiesExpireAfterWrite";
+
+    /**
+     * The default number of seconds if {@link #TRACKING_FILE_MANAGER_FILE_PROPERTIES_EXPIRE_AFTER_ACCESS} isn't set.
+     */
+    public static final long DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_EXPIRE_AFTER_ACCESS = 60L;
+
     private ConfigurationProperties()
     {
         // hide constructor

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -162,6 +162,18 @@ public final class ConfigurationProperties
      */
     public static final long DEFAULT_TRACKING_FILE_MANAGER_FILE_LOCK_CACHE_SIZE = 1024L;
 
+    /**
+     * The size of the properties cache, used by the TrackingFileManager to map Files to their parsed properties.
+     *
+     * @see #DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_CACHE_SIZE
+     */
+    public static final String TRACKING_FILE_MANAGER_FILE_PROPERTIES_CACHE_SIZE = PREFIX_INTERNAL + "trackingFileManager.propertiesCacheSize";
+
+    /**
+     * The default size if {@link #TRACKING_FILE_MANAGER_FILE_PROPERTIES_CACHE_SIZE} isn't set.
+     */
+    public static final long DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_CACHE_SIZE = 1024L;
+
     private ConfigurationProperties()
     {
         // hide constructor

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -75,7 +75,7 @@ class EnhancedLocalRepositoryManager
             filename = "_remote.repositories";
         }
         trackingFilename = filename;
-        trackingFileManager = new TrackingFileManager();
+        trackingFileManager = new TrackingFileManager( session );
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
@@ -42,6 +42,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manages potentially concurrent accesses to a properties file.
@@ -87,9 +88,13 @@ class TrackingFileManager
         long propertiesCacheMaxSize = ConfigUtils.getLong( configurationProperties,
                 ConfigurationProperties.DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_CACHE_SIZE,
                 ConfigurationProperties.TRACKING_FILE_MANAGER_FILE_PROPERTIES_CACHE_SIZE );
+        long propertiesCacheExpireAfterAccess = ConfigUtils.getLong( configurationProperties,
+                ConfigurationProperties.DEFAULT_TRACKING_FILE_MANAGER_PROPERTIES_EXPIRE_AFTER_ACCESS,
+                ConfigurationProperties.TRACKING_FILE_MANAGER_FILE_PROPERTIES_EXPIRE_AFTER_ACCESS );
 
         propertiesCache = CacheBuilder.newBuilder()
                 .maximumSize( propertiesCacheMaxSize )
+                .expireAfterAccess( propertiesCacheExpireAfterAccess, TimeUnit.SECONDS )
                 .build( new CacheLoader<File, Properties>()
         {
             @Override

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/TrackingFileManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/TrackingFileManagerTest.java
@@ -54,6 +54,7 @@ public class TrackingFileManagerTest
         assertEquals( "value2", props.get( "key2" ) );
 
         assertTrue( "Leaked file: " + propFile, propFile.delete() );
+        tfm.getPropertiesCache().invalidate( propFile );
 
         props = tfm.read( propFile );
         assertNull( String.valueOf( props ), props );
@@ -71,6 +72,7 @@ public class TrackingFileManagerTest
             File propFile = TestFileUtils.createTempFile( "#COMMENT\nkey1=value1\nkey2 : value2" );
             assertNotNull( tfm.read( propFile ) );
             assertTrue( "Leaked file: " + propFile, propFile.delete() );
+            tfm.getPropertiesCache().invalidate( propFile );
         }
 
         int size = tfm.getFileLockCache().asMap().size();


### PR DESCRIPTION
 * Greatly speeds up Windows filesystem interactions