### PR TITLE
MNG-6803: Fix race condition in DefaultArtifactResolver via "Retry"

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -220,6 +220,7 @@ public class DefaultArtifactResolverTest
 
         };
 
+        connector.fail = true;
         connector.setExpectGet( artifact );
         repositoryConnectorProvider.setConnector( connector );
 
@@ -528,6 +529,7 @@ public class DefaultArtifactResolverTest
             }
 
         };
+        connector.fail = true;
         repositoryConnectorProvider.setConnector( connector );
 
         RecordingRepositoryListener listener = new RecordingRepositoryListener();


### PR DESCRIPTION
With "Retry" I mean that resolve() looks into the local repository again after performing the downloads.