### PR TITLE
[EXPERIMENT] Proper remote repository scoping during dependency resolution

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryManager.java
@@ -55,6 +55,12 @@ public interface RemoteRepositoryManager
                                                   List<RemoteRepository> recessiveRepositories,
                                                   boolean recessiveIsRaw );
 
+    List<RemoteRepository> aggregateRepositories( RepositorySystemSession session,
+                                                  List<RemoteRepository> dominantRepositories,
+                                                  List<RemoteRepository> recessiveRepositories,
+                                                  boolean recessiveIsRaw,
+                                                  boolean prepend );
+
     /**
      * Gets the effective repository policy for the specified remote repository by merging the applicable
      * snapshot/release policy of the repository with global settings from the supplied session.

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -129,6 +129,15 @@ public class DefaultRemoteRepositoryManager
                                                          List<RemoteRepository> recessiveRepositories,
                                                          boolean recessiveIsRaw )
     {
+        return aggregateRepositories( session, dominantRepositories, recessiveRepositories, recessiveIsRaw, false );
+    }
+
+    public List<RemoteRepository> aggregateRepositories( RepositorySystemSession session,
+                                                         List<RemoteRepository> dominantRepositories,
+                                                         List<RemoteRepository> recessiveRepositories,
+                                                         boolean recessiveIsRaw,
+                                                         boolean prepend )
+    {
         if ( recessiveRepositories.isEmpty() )
         {
             return dominantRepositories;
@@ -201,7 +210,14 @@ public class DefaultRemoteRepositoryManager
                 }
             }
 
-            result.add( repository );
+            if ( prepend )
+            {
+                result.add( 0, repository );
+            }
+            else
+            {
+                result.add( repository );
+            }
         }
 
         return result;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
@@ -491,7 +491,7 @@ public class DefaultDependencyCollector
             args.ignoreRepos
                 ? repositories
                 : remoteRepositoryManager.aggregateRepositories( args.session, repositories,
-                                                                 descriptorResult.getRepositories(), true );
+                                                                 descriptorResult.getRepositories(), true, true );
 
         Object key =
             args.pool.toKey( d.getArtifact(), childRepos, childSelector, childManager, childTraverser, childFilter );

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubRemoteRepositoryManager.java
@@ -43,6 +43,15 @@ public class StubRemoteRepositoryManager
         return dominantRepositories;
     }
 
+    public List<RemoteRepository> aggregateRepositories( RepositorySystemSession session,
+                                                         List<RemoteRepository> dominantRepositories,
+                                                         List<RemoteRepository> recessiveRepositories,
+                                                         boolean recessiveIsRaw,
+                                                         boolean prepend )
+    {
+        return dominantRepositories;
+    }
+
     public RepositoryPolicy getPolicy( RepositorySystemSession session, RemoteRepository repository, boolean releases,
                                        boolean snapshots )
     {


### PR DESCRIPTION
Introduce new method remote repository manager to allow make possible repositories to be added not only to TAIL but also to HEAD of remote repository list. 

This PR is NOT meant for merge as is, is more just an example.