### PR TITLE
[MRESOLVER-160] Deprecate service locator

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -76,7 +76,10 @@ import org.eclipse.aether.spi.synccontext.SyncContextFactory;
  * 
  * <em>Note:</em> This class is not thread-safe. Clients are expected to create the service locator and the repository
  * system on a single thread.
+ *
+ * @deprecated Use some out-of-the-box DI implementation instead.
  */
+@Deprecated
 public final class DefaultServiceLocator
     implements ServiceLocator
 {


### PR DESCRIPTION
Deprecate service locator implementation as well, as integrators
usually extend this class (see Maven for example), and they don't
deal with deprecated interfaces directly, so the fact they are deprecated
may be missed at first sight.

By deprecating this implementation as well, the integrators
will get a warning in their build and/or IDEs, so intent will be
more obvious.