### PR TITLE
Introduce ResolverLock, layer on top of low level Named Locks

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/NamedSyncContextFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/NamedSyncContextFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapp
 import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapter;
+import org.eclipse.aether.internal.impl.synccontext.named.ResolverLockFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.StaticNameMapper;
 import org.eclipse.aether.named.NamedLockFactory;
 import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
@@ -107,7 +108,7 @@ public final class NamedSyncContextFactory
             throw new IllegalArgumentException( "Unknown NamedLockFactory name: " + FACTORY_NAME
                     + ", known ones: " + factories.keySet() );
         }
-        return new NamedLockFactoryAdapter( nameMapper, factory, TIME, TIME_UNIT );
+        return new NamedLockFactoryAdapter( new ResolverLockFactory( nameMapper, factory ), TIME, TIME_UNIT );
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/DiscriminatingNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/DiscriminatingNameMapper.java
@@ -34,19 +34,16 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Discriminating {@link NameMapper}, that wraps another {@link NameMapper} and adds a "discriminator" as prefix, that
  * makes lock names unique including the hostname and local repository (by default). The discriminator may be passed
  * in via {@link RepositorySystemSession} or is automatically calculated based on the local hostname and repository
  * path. The implementation retains order of collection elements as it got it from
- * {@link NameMapper#nameLocks(RepositorySystemSession, Collection, Collection)} method.
+ * {@link NameMapper#nameLock(RepositorySystemSession, Artifact)} method.
  * <p>
  * The default setup wraps {@link GAVNameMapper}, but manually may be created any instance needed.
  */
@@ -84,13 +81,17 @@ public class DiscriminatingNameMapper implements NameMapper
     }
 
     @Override
-    public Collection<String> nameLocks( final RepositorySystemSession session,
-                                         final Collection<? extends Artifact> artifacts,
-                                         final Collection<? extends Metadata> metadatas )
+    public String nameLock( final RepositorySystemSession session, final Artifact artifact )
     {
         String discriminator = createDiscriminator( session );
-        return nameMapper.nameLocks( session, artifacts, metadatas ).stream().map( s -> discriminator + ":" + s )
-                         .collect( toList() );
+        return discriminator + ":" + nameMapper.nameLock( session, artifact );
+    }
+
+    @Override
+    public String nameLock( final RepositorySystemSession session, Metadata metadata )
+    {
+        String discriminator = createDiscriminator( session );
+        return discriminator + ":" + nameMapper.nameLock( session, metadata );
     }
 
     private String getHostname()

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -25,8 +25,6 @@ import org.eclipse.aether.metadata.Metadata;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.Collection;
-import java.util.TreeSet;
 
 /**
  * Artifact GAV {@link NameMapper}, uses artifact and metadata coordinates to name their corresponding locks. Is not
@@ -39,44 +37,29 @@ public class GAVNameMapper implements NameMapper
     public static final String NAME = "gav";
 
     @Override
-    public Collection<String> nameLocks( final RepositorySystemSession session,
-                                         final Collection<? extends Artifact> artifacts,
-                                         final Collection<? extends Metadata> metadatas )
+    public String nameLock( final RepositorySystemSession session, final Artifact artifact )
     {
-        // Deadlock prevention: https://stackoverflow.com/a/16780988/696632
-        // We must acquire multiple locks always in the same order!
-        Collection<String> keys = new TreeSet<>();
-        if ( artifacts != null )
-        {
-            for ( Artifact artifact : artifacts )
-            {
-                String key = "artifact:" + artifact.getGroupId()
-                             + ":" + artifact.getArtifactId()
-                             + ":" + artifact.getBaseVersion();
-                keys.add( key );
-            }
-        }
+        return "artifact:" + artifact.getGroupId()
+               + ":" + artifact.getArtifactId()
+               + ":" + artifact.getBaseVersion();
+    }
 
-        if ( metadatas != null )
+    @Override
+    public String nameLock( final RepositorySystemSession session, final Metadata metadata )
+    {
+        StringBuilder key = new StringBuilder( "metadata:" );
+        if ( !metadata.getGroupId().isEmpty() )
         {
-            for ( Metadata metadata : metadatas )
+            key.append( metadata.getGroupId() );
+            if ( !metadata.getArtifactId().isEmpty() )
             {
-                StringBuilder key = new StringBuilder( "metadata:" );
-                if ( !metadata.getGroupId().isEmpty() )
+                key.append( ':' ).append( metadata.getArtifactId() );
+                if ( !metadata.getVersion().isEmpty() )
                 {
-                    key.append( metadata.getGroupId() );
-                    if ( !metadata.getArtifactId().isEmpty() )
-                    {
-                        key.append( ':' ).append( metadata.getArtifactId() );
-                        if ( !metadata.getVersion().isEmpty() )
-                        {
-                            key.append( ':' ).append( metadata.getVersion() );
-                        }
-                    }
+                    key.append( ':' ).append( metadata.getVersion() );
                 }
-                keys.add( key.toString() );
             }
         }
-        return keys;
+        return key.toString();
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapper.java
@@ -23,8 +23,6 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
 
-import java.util.Collection;
-
 /**
  * Component mapping lock names to passed in artifacts and metadata as required.
  */
@@ -37,6 +35,7 @@ public interface NameMapper
      * same criteria) to avoid deadlocks by acquiring locks in same order, essentially disregarding the order of
      * the input collections.
      */
-    Collection<String> nameLocks( RepositorySystemSession session, Collection<? extends Artifact> artifacts,
-                                  Collection<? extends Metadata> metadatas );
+    String nameLock( RepositorySystemSession session, Artifact artifact );
+
+    String nameLock( RepositorySystemSession session, Metadata metadata );
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLock.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLock.java
@@ -1,0 +1,122 @@
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.named.NamedLock;
+
+import java.io.Closeable;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolver lock.
+ */
+public final class ResolverLock implements Closeable
+{
+    private final String key;
+
+    private final NamedLock namedLock;
+
+    private final boolean requestedShared;
+
+    private final boolean effectiveShared;
+
+    public ResolverLock( final String key,
+                         final NamedLock namedLock,
+                         final boolean requestedShared,
+                         final boolean effectiveShared )
+    {
+        this.key = Objects.requireNonNull( key );
+        this.namedLock = Objects.requireNonNull( namedLock );
+        this.requestedShared = requestedShared;
+        this.effectiveShared = effectiveShared;
+    }
+
+    public String key()
+    {
+        return key;
+    }
+
+    public boolean isRequestedShared()
+    {
+        return requestedShared;
+    }
+
+    public boolean isEffectiveShared()
+    {
+        return effectiveShared;
+    }
+
+    public boolean tryLock( final long time, final TimeUnit unit ) throws InterruptedException
+    {
+        if ( effectiveShared )
+        {
+            return namedLock.lockShared( time, unit );
+        }
+        else
+        {
+            return namedLock.lockExclusively( time, unit );
+        }
+    }
+
+    public void unlock()
+    {
+        namedLock.unlock();
+    }
+
+    @Override
+    public void close()
+    {
+        namedLock.close();
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ResolverLock that = (ResolverLock) o;
+        return key.equals( that.key );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( key );
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName()
+               + "{"
+               + "key='" + key + '\''
+               + ", namedLock=" + namedLock
+               + ", requestedShared=" + requestedShared
+               + ", effectiveShared=" + effectiveShared
+               + '}';
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLockFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLockFactory.java
@@ -92,14 +92,14 @@ public final class ResolverLockFactory
     {
         LocalArtifactRequest request = new LocalArtifactRequest( artifact, null, null );
         LocalArtifactResult result = session.getLocalRepositoryManager().find( session, request );
-        return result.isAvailable();
+        return result.getFile() != null;
     }
 
     private boolean isMetadataAvailable( final RepositorySystemSession session, final Metadata metadata )
     {
         LocalMetadataRequest request = new LocalMetadataRequest( metadata, null, null );
         LocalMetadataResult result = session.getLocalRepositoryManager().find( session, request );
-        return !result.isStale();
+        return result.getFile() != null;
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLockFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ResolverLockFactory.java
@@ -1,0 +1,112 @@
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.named.NamedLock;
+import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.repository.LocalArtifactRequest;
+import org.eclipse.aether.repository.LocalArtifactResult;
+import org.eclipse.aether.repository.LocalMetadataRequest;
+import org.eclipse.aether.repository.LocalMetadataResult;
+import org.eclipse.aether.spi.synccontext.SyncContextHint;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.TreeSet;
+
+/**
+ * Component mapping lock names to passed in artifacts and metadata as required.
+ */
+public final class ResolverLockFactory
+{
+    private final NameMapper nameMapper;
+
+    private final NamedLockFactory namedLockFactory;
+
+    public ResolverLockFactory( final NameMapper nameMapper, final NamedLockFactory namedLockFactory )
+    {
+        this.nameMapper = Objects.requireNonNull( nameMapper );
+        this.namedLockFactory = Objects.requireNonNull( namedLockFactory );
+    }
+
+    public Collection<ResolverLock> resolverLocks( final RepositorySystemSession session,
+                                                   final boolean shared,
+                                                   final Collection<? extends Artifact> artifacts,
+                                                   final Collection<? extends Metadata> metadatas )
+    {
+        TreeSet<ResolverLock> result = new TreeSet<>( Comparator.comparing( ResolverLock::key ) );
+        boolean effectiveShared = shared;
+        boolean mayOverride = SyncContextHint.Scope.RESOLVE.equals( SyncContextHint.SCOPE.get() );
+
+        if ( artifacts != null )
+        {
+            for ( Artifact artifact : artifacts )
+            {
+                NamedLock namedLock = namedLockFactory.getLock( nameMapper.nameLock( session, artifact ) );
+                if ( mayOverride && !shared )
+                {
+                    effectiveShared = isArtifactAvailable( session, artifact );
+                }
+                result.add( new ResolverLock( artifact.toString(), namedLock, shared, effectiveShared ) );
+            }
+        }
+
+        if ( metadatas != null )
+        {
+            for ( Metadata metadata : metadatas )
+            {
+                NamedLock namedLock = namedLockFactory.getLock( nameMapper.nameLock( session, metadata ) );
+                if ( mayOverride && !shared )
+                {
+                    effectiveShared = isMetadataAvailable( session, metadata );
+                }
+                result.add( new ResolverLock( metadata.toString(), namedLock, shared, effectiveShared ) );
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isArtifactAvailable( final RepositorySystemSession session, final Artifact artifact )
+    {
+        LocalArtifactRequest request = new LocalArtifactRequest( artifact, null, null );
+        LocalArtifactResult result = session.getLocalRepositoryManager().find( session, request );
+        return result.isAvailable();
+    }
+
+    private boolean isMetadataAvailable( final RepositorySystemSession session, final Metadata metadata )
+    {
+        LocalMetadataRequest request = new LocalMetadataRequest( metadata, null, null );
+        LocalMetadataResult result = session.getLocalRepositoryManager().find( session, request );
+        return !result.isStale();
+    }
+
+    /**
+     * Performs a clean shut down of the factory.
+     */
+    public void shutdown()
+    {
+        namedLockFactory.shutdown();
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/StaticNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/StaticNameMapper.java
@@ -27,8 +27,6 @@ import org.eclipse.aether.util.ConfigUtils;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -65,10 +63,14 @@ public class StaticNameMapper implements NameMapper
     }
 
     @Override
-    public Collection<String> nameLocks( final RepositorySystemSession session,
-                                         final Collection<? extends Artifact> artifacts,
-                                         final Collection<? extends Metadata> metadatas )
+    public String nameLock( final RepositorySystemSession session, Artifact artifact )
     {
-        return Collections.singletonList( ConfigUtils.getString( session, name, CONFIG_PROP_NAME ) );
+        return ConfigUtils.getString( session, name, CONFIG_PROP_NAME );
+    }
+
+    @Override
+    public String nameLock( final RepositorySystemSession session, Metadata metadata )
+    {
+        return ConfigUtils.getString( session, name, CONFIG_PROP_NAME );
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
@@ -67,7 +67,7 @@ public abstract class NamedLockFactoryAdapterTestSupport {
 
     public static void createAdapter() {
         Objects.requireNonNull(namedLockFactory, "NamedLockFactory not set");
-        adapter = new NamedLockFactoryAdapter(nameMapper, namedLockFactory, ADAPTER_TIME, ADAPTER_TIME_UNIT);
+        adapter = new NamedLockFactoryAdapter(new ResolverLockFactory( nameMapper, namedLockFactory ), ADAPTER_TIME, ADAPTER_TIME_UNIT);
     }
 
     @AfterClass

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
@@ -25,6 +25,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapter;
+import org.eclipse.aether.internal.impl.synccontext.named.ResolverLockFactory;
 import org.eclipse.aether.named.NamedLockFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
@@ -62,7 +63,8 @@ public abstract class NamedLockFactoryAdapterTestSupport
 
   protected static void setNamedLockFactory(final NamedLockFactory namedLockFactory) {
     adapter = new NamedLockFactoryAdapter(
-            new DiscriminatingNameMapper(new GAVNameMapper()), namedLockFactory, ADAPTER_TIME, ADAPTER_TIME_UNIT
+            new ResolverLockFactory( new DiscriminatingNameMapper(new GAVNameMapper()), namedLockFactory ),
+            ADAPTER_TIME, ADAPTER_TIME_UNIT
     );
   }
 

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/synccontext/SyncContextHint.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/synccontext/SyncContextHint.java
@@ -1,0 +1,36 @@
+package org.eclipse.aether.spi.synccontext;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hint for sync scope implemented as "hack" to not modify SyncContextFactory API.
+ */
+public final class SyncContextHint
+{
+    /**
+     * The scope for which {@link org.eclipse.aether.SyncContext} is to be used.
+     */
+    public enum Scope
+    {
+        RESOLVE, DEPLOY, INSTALL
+    }
+
+    public static final InheritableThreadLocal<Scope> SCOPE = new InheritableThreadLocal<>();
+}


### PR DESCRIPTION
The resolver lock adds a thin layer above low lever named locks,
does not leak actualy named lock names, but is keyed by artifact,
hence lock ordering is stable (is based on Artifact not on name mapper).
Finally, resolver lock factory is able to spice up the logic for locking
that is now "hacked in" to not alter SyncContextFactory API.

This is EXPERIMENT for testing reasons only.