### PR TITLE
Fix bindings and do test them

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.demo.snippets</Automatic-Module-Name>
-    <mavenVersion>3.5.0</mavenVersion>
+    <mavenVersion>3.5.4</mavenVersion>
   </properties>
 
   <dependencyManagement>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
@@ -47,7 +47,7 @@ public class DeployArtifacts
         System.out.println( "------------------------------------------------------------" );
         System.out.println( DeployArtifacts.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
@@ -47,7 +47,7 @@ public class DeployArtifacts
         System.out.println( "------------------------------------------------------------" );
         System.out.println( DeployArtifacts.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindAvailableVersions.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindAvailableVersions.java
@@ -47,7 +47,7 @@ public class FindAvailableVersions
         System.out.println( "------------------------------------------------------------" );
         System.out.println( FindAvailableVersions.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindAvailableVersions.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindAvailableVersions.java
@@ -47,7 +47,7 @@ public class FindAvailableVersions
         System.out.println( "------------------------------------------------------------" );
         System.out.println( FindAvailableVersions.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindNewestVersion.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindNewestVersion.java
@@ -44,7 +44,7 @@ public class FindNewestVersion
         System.out.println( "------------------------------------------------------------" );
         System.out.println( FindNewestVersion.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindNewestVersion.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/FindNewestVersion.java
@@ -44,7 +44,7 @@ public class FindNewestVersion
         System.out.println( "------------------------------------------------------------" );
         System.out.println( FindNewestVersion.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyHierarchy.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyHierarchy.java
@@ -49,7 +49,7 @@ public class GetDependencyHierarchy
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDependencyHierarchy.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         DefaultRepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyHierarchy.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyHierarchy.java
@@ -49,7 +49,7 @@ public class GetDependencyHierarchy
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDependencyHierarchy.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         DefaultRepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyTree.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyTree.java
@@ -46,7 +46,7 @@ public class GetDependencyTree
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDependencyTree.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyTree.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDependencyTree.java
@@ -46,7 +46,7 @@ public class GetDependencyTree
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDependencyTree.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDirectDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDirectDependencies.java
@@ -45,7 +45,7 @@ public class GetDirectDependencies
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDirectDependencies.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDirectDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/GetDirectDependencies.java
@@ -45,7 +45,7 @@ public class GetDirectDependencies
         System.out.println( "------------------------------------------------------------" );
         System.out.println( GetDirectDependencies.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
@@ -46,7 +46,7 @@ public class InstallArtifacts
         System.out.println( "------------------------------------------------------------" );
         System.out.println( InstallArtifacts.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
@@ -46,7 +46,7 @@ public class InstallArtifacts
         System.out.println( "------------------------------------------------------------" );
         System.out.println( InstallArtifacts.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
@@ -44,7 +44,7 @@ public class ResolveArtifact
         System.out.println( "------------------------------------------------------------" );
         System.out.println( ResolveArtifact.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
@@ -44,7 +44,7 @@ public class ResolveArtifact
         System.out.println( "------------------------------------------------------------" );
         System.out.println( ResolveArtifact.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -51,7 +51,7 @@ public class ResolveTransitiveDependencies
         System.out.println( "------------------------------------------------------------" );
         System.out.println( ResolveTransitiveDependencies.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory( args ) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -51,7 +51,7 @@ public class ResolveTransitiveDependencies
         System.out.println( "------------------------------------------------------------" );
         System.out.println( ResolveTransitiveDependencies.class.getSimpleName() );
 
-        RepositorySystem system = Booter.newRepositorySystem();
+        RepositorySystem system = Booter.newRepositorySystem( Booter.selectFactory(args) );
 
         RepositorySystemSession session = Booter.newRepositorySystemSession( system );
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/guice/DemoResolverModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/guice/DemoResolverModule.java
@@ -37,6 +37,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 
+/**
+ * Guice module for Demo Resolver snippets.
+ */
 class DemoResolverModule
     extends AbstractModule
 {
@@ -44,6 +47,10 @@ class DemoResolverModule
     @Override
     protected void configure()
     {
+        // NOTE: see org.eclipse.aether.impl.guice.AetherModule javadoc:
+        // AetherModule alone is "ready-made" but incomplete. To have a complete resolver, we
+        // actually need org.apache.maven.repository.internal.MavenResolverModule that install
+        // AetherModule and binds the missing components making module complete.
         install( new MavenResolverModule() );
         // alternatively, use the Guice Multibindings extensions
         bind( RepositoryConnectorFactory.class ).annotatedWith( Names.named( "basic" ) )

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/Resolver.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/Resolver.java
@@ -54,10 +54,10 @@ public class Resolver
 
     private LocalRepository localRepository;
 
-    public Resolver( String remoteRepository, String localRepository )
+    public Resolver( String factory, String remoteRepository, String localRepository )
     {
         this.remoteRepository = remoteRepository;
-        this.repositorySystem = Booter.newRepositorySystem();
+        this.repositorySystem = Booter.newRepositorySystem( factory );
         this.localRepository = new LocalRepository( localRepository );
     }
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
@@ -40,7 +40,8 @@ public class ResolverDemo
         throws DependencyResolutionException
     {
         Resolver resolver = new Resolver(
-            factory,"http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
+            factory,
+            "http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
                 
         ResolverResult result = resolver.resolve( "com.mycompany.app", "super-app", "1.0" );
 
@@ -61,7 +62,8 @@ public class ResolverDemo
         throws InstallationException, DeploymentException
     {
         Resolver resolver = new Resolver(
-            factory,"http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
+            factory,
+            "http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
         
         Artifact artifact = new DefaultArtifact( "com.mycompany.super", "super-core", "jar", "0.1-SNAPSHOT" );
         artifact = artifact.setFile( new File( "jar-from-whatever-process.jar" ) );

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
@@ -36,10 +36,11 @@ import org.eclipse.aether.util.artifact.SubArtifact;
 public class ResolverDemo
 {
 
-    public void resolve() 
+    public void resolve( final String factory )
         throws DependencyResolutionException
     {
-        Resolver resolver = new Resolver( "http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
+        Resolver resolver = new Resolver(
+            factory,"http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
                 
         ResolverResult result = resolver.resolve( "com.mycompany.app", "super-app", "1.0" );
 
@@ -56,10 +57,11 @@ public class ResolverDemo
         String classpath = result.getResolvedClassPath();        
     }
     
-    public void installAndDeploy() 
+    public void installAndDeploy( final String factory )
         throws InstallationException, DeploymentException
     {
-        Resolver resolver = new Resolver( "http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
+        Resolver resolver = new Resolver(
+            factory,"http://localhost:8081/nexus/content/groups/public", "target/aether-repo" );
         
         Artifact artifact = new DefaultArtifact( "com.mycompany.super", "super-core", "jar", "0.1-SNAPSHOT" );
         artifact = artifact.setFile( new File( "jar-from-whatever-process.jar" ) );

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/MavenDemoModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/MavenDemoModule.java
@@ -42,7 +42,8 @@ import org.eclipse.aether.impl.VersionRangeResolver;
 import org.eclipse.aether.impl.VersionResolver;
 
 /**
- * Module completing Resolver with component implementations found in Maven's maven-resolver-provider.
+ * Module with component implementations found in Maven's maven-resolver-provider and maven-model-builder. This module
+ * binds ONLY components found OUTSIDE resolver.
  */
 public class MavenDemoModule
     extends AbstractModule

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/MavenDemoModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/MavenDemoModule.java
@@ -1,0 +1,76 @@
+package org.apache.maven.resolver.examples.sisu;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.name.Names;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.ModelBuilder;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
+import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.MetadataGeneratorFactory;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
+
+/**
+ * Module completing Resolver with component implementations found in Maven's maven-resolver-provider.
+ */
+public class MavenDemoModule
+    extends AbstractModule
+{
+    protected void configure()
+    {
+        bind( ArtifactDescriptorReader.class )
+            .to( DefaultArtifactDescriptorReader.class ).in( Singleton.class );
+        bind( VersionResolver.class )
+            .to( DefaultVersionResolver.class ).in( Singleton.class );
+        bind( VersionRangeResolver.class )
+            .to( DefaultVersionRangeResolver.class ).in( Singleton.class );
+        bind( MetadataGeneratorFactory.class ).annotatedWith( Names.named( "snapshot" ) )
+            .to( SnapshotMetadataGeneratorFactory.class ).in( Singleton.class );
+        bind( MetadataGeneratorFactory.class ).annotatedWith( Names.named( "versions" ) )
+            .to( VersionsMetadataGeneratorFactory.class ).in( Singleton.class );
+        bind( ModelBuilder.class ).toInstance( ( new DefaultModelBuilderFactory() ).newInstance() );
+    }
+
+    @Provides
+    @Singleton
+    Set<MetadataGeneratorFactory> provideMetadataGeneratorFactories(
+        @Named( "snapshot" ) MetadataGeneratorFactory snapshot,
+        @Named( "versions" ) MetadataGeneratorFactory versions )
+    {
+        Set<MetadataGeneratorFactory> factories = new HashSet( 2 );
+        factories.add( snapshot );
+        factories.add( versions );
+        return Collections.unmodifiableSet( factories );
+    }
+}

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
@@ -29,7 +29,7 @@ import org.eclipse.sisu.inject.MutableBeanLocator;
 import org.eclipse.sisu.wire.ParameterKeys;
 
 /**
- * A factory for repository system instances that employs Eclipse Sisu to wire up the system's components.
+ * Sisu module for demo snippets.
  */
 public class SisuRepositorySystemDemoModule implements Module
 {

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import org.apache.maven.repository.internal.MavenResolverModule;
 import org.eclipse.sisu.bean.LifecycleModule;
 import org.eclipse.sisu.inject.MutableBeanLocator;
 import org.eclipse.sisu.wire.ParameterKeys;
@@ -37,7 +36,12 @@ public class SisuRepositorySystemDemoModule implements Module
     public void configure( final Binder binder )
     {
         binder.install( new LifecycleModule() );
-        binder.install( new MavenResolverModule() );
+        // NOTE: this module below is needed due following:, while maven-resolver-provider:3.5.4 DOES have SISU index,
+        // the also needed module maven-model-builder:3.5.4 DOES NOT have SISU index (has plexus/components.xml).
+        // To keep things simple, and not bring in deprecated Plexus, we rather install custom Guicemodule
+        // (MavenDemoModule) to provide the "missing components" (while resolver components are discovered by SISU)
+        // making resolver complete.
+        binder.install( new MavenDemoModule() );
         binder.bind( ParameterKeys.PROPERTIES ).toInstance( System.getProperties() );
         binder.bind( ShutdownThread.class ).asEagerSingleton();
     }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/sisu/SisuRepositorySystemDemoModule.java
@@ -36,11 +36,13 @@ public class SisuRepositorySystemDemoModule implements Module
     public void configure( final Binder binder )
     {
         binder.install( new LifecycleModule() );
-        // NOTE: this module below is needed due following:, while maven-resolver-provider:3.5.4 DOES have SISU index,
+        // NOTE: this module below is needed due following: while maven-resolver-provider:3.5.4 DOES have SISU index,
         // the also needed module maven-model-builder:3.5.4 DOES NOT have SISU index (has plexus/components.xml).
         // To keep things simple, and not bring in deprecated Plexus, we rather install custom Guicemodule
         // (MavenDemoModule) to provide the "missing components" (while resolver components are discovered by SISU)
         // making resolver complete.
+        // To demo SISU, resolver is completed with components discovered by SISU (using SISU index, that all
+        // resolver modules have), and the handful components registered directly to Guice in MavenDemoModule module.
         binder.install( new MavenDemoModule() );
         binder.bind( ParameterKeys.PROPERTIES ).toInstance( System.getProperties() );
         binder.bind( ShutdownThread.class ).asEagerSingleton();

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -41,9 +41,10 @@ public class Booter
 
     public static final String SISU = "sisu";
 
-    public static String selectFactory(String[] args)
+    public static String selectFactory( String[] args )
     {
-        if ( args == null || args.length == 0 ) {
+        if ( args == null || args.length == 0 )
+        {
             return MANUAL;
         }
         else
@@ -54,14 +55,15 @@ public class Booter
 
     public static RepositorySystem newRepositorySystem( final String factory )
     {
-        if (MANUAL.equals(factory)) {
+        if ( MANUAL.equals( factory ) )
+        {
             return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
         }
-        else if (GUICE.equals(factory))
+        else if ( GUICE.equals( factory ) )
         {
             return org.apache.maven.resolver.examples.guice.GuiceRepositorySystemFactory.newRepositorySystem();
         }
-        else if (SISU.equals(factory))
+        else if ( SISU.equals( factory ) )
         {
             return org.apache.maven.resolver.examples.sisu.SisuRepositorySystemFactory.newRepositorySystem();
         }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -35,7 +35,7 @@ import org.eclipse.aether.repository.RemoteRepository;
  */
 public class Booter
 {
-    public static final String MANUAL = "manual";
+    public static final String SERVICE_LOCATOR = "serviceLocator";
 
     public static final String GUICE = "guice";
 
@@ -45,7 +45,7 @@ public class Booter
     {
         if ( args == null || args.length == 0 )
         {
-            return MANUAL;
+            return SERVICE_LOCATOR;
         }
         else
         {
@@ -55,7 +55,7 @@ public class Booter
 
     public static RepositorySystem newRepositorySystem( final String factory )
     {
-        if ( MANUAL.equals( factory ) )
+        if ( SERVICE_LOCATOR.equals( factory ) )
         {
             return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
         }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -55,21 +55,16 @@ public class Booter
 
     public static RepositorySystem newRepositorySystem( final String factory )
     {
-        if ( SERVICE_LOCATOR.equals( factory ) )
+        switch ( factory ) 
         {
-            return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
-        }
-        else if ( GUICE.equals( factory ) )
-        {
-            return org.apache.maven.resolver.examples.guice.GuiceRepositorySystemFactory.newRepositorySystem();
-        }
-        else if ( SISU.equals( factory ) )
-        {
-            return org.apache.maven.resolver.examples.sisu.SisuRepositorySystemFactory.newRepositorySystem();
-        }
-        else
-        {
-            throw new IllegalArgumentException( "Unknown factory: " + factory );
+            case SERVICE_LOCATOR:
+                return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
+            case GUICE:
+                return org.apache.maven.resolver.examples.guice.GuiceRepositorySystemFactory.newRepositorySystem();
+            case SISU:
+                return org.apache.maven.resolver.examples.sisu.SisuRepositorySystemFactory.newRepositorySystem();
+            default:
+                throw new IllegalArgumentException( "Unknown factory: " + factory );
         }
     }
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -35,12 +35,40 @@ import org.eclipse.aether.repository.RemoteRepository;
  */
 public class Booter
 {
+    public static final String MANUAL = "manual";
 
-    public static RepositorySystem newRepositorySystem()
+    public static final String GUICE = "guice";
+
+    public static final String SISU = "sisu";
+
+    public static String selectFactory(String[] args)
     {
-        return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
-        // return org.apache.maven.resolver.examples.guice.GuiceRepositorySystemFactory.newRepositorySystem();
-        // return org.apache.maven.resolver.examples.sisu.SisuRepositorySystemFactory.newRepositorySystem();
+        if ( args == null || args.length == 0 ) {
+            return MANUAL;
+        }
+        else
+        {
+            return args[0];
+        }
+    }
+
+    public static RepositorySystem newRepositorySystem( final String factory )
+    {
+        if (MANUAL.equals(factory)) {
+            return org.apache.maven.resolver.examples.manual.ManualRepositorySystemFactory.newRepositorySystem();
+        }
+        else if (GUICE.equals(factory))
+        {
+            return org.apache.maven.resolver.examples.guice.GuiceRepositorySystemFactory.newRepositorySystem();
+        }
+        else if (SISU.equals(factory))
+        {
+            return org.apache.maven.resolver.examples.sisu.SisuRepositorySystemFactory.newRepositorySystem();
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unknown factory: " + factory );
+        }
     }
 
     public static DefaultRepositorySystemSession newRepositorySystemSession( RepositorySystem system )

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/test/java/org/apache/maven/resolver/examples/AllResolverDemosTest.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/test/java/org/apache/maven/resolver/examples/AllResolverDemosTest.java
@@ -29,7 +29,7 @@ public class AllResolverDemosTest
 {
     @Test
     public void serviceLocator() throws Exception {
-        AllResolverDemos.main( new String[] {Booter.MANUAL} );
+        AllResolverDemos.main( new String[] {Booter.SERVICE_LOCATOR} );
     }
 
     @Test

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/test/java/org/apache/maven/resolver/examples/AllResolverDemosTest.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/test/java/org/apache/maven/resolver/examples/AllResolverDemosTest.java
@@ -8,9 +8,9 @@ package org.apache.maven.resolver.examples;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,6 +19,7 @@ package org.apache.maven.resolver.examples;
  * under the License.
  */
 
+import org.apache.maven.resolver.examples.util.Booter;
 import org.junit.Test;
 
 /**
@@ -27,7 +28,17 @@ import org.junit.Test;
 public class AllResolverDemosTest
 {
     @Test
-    public void runMain() throws Exception {
-        AllResolverDemos.main( new String[0] );
+    public void serviceLocator() throws Exception {
+        AllResolverDemos.main( new String[] {Booter.MANUAL} );
+    }
+
+    @Test
+    public void guice() throws Exception {
+        AllResolverDemos.main( new String[] {Booter.GUICE} );
+    }
+
+    @Test
+    public void sisu() throws Exception {
+        AllResolverDemos.main( new String[] {Booter.SISU} );
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -209,7 +209,8 @@ public final class DefaultServiceLocator
         addService( UpdateCheckManager.class, DefaultUpdateCheckManager.class );
         addService( UpdatePolicyAnalyzer.class, DefaultUpdatePolicyAnalyzer.class );
         addService( FileProcessor.class, DefaultFileProcessor.class );
-        addService( org.eclipse.aether.impl.SyncContextFactory.class, DefaultSyncContextFactory.class );
+        addService( org.eclipse.aether.impl.SyncContextFactory.class,
+            org.eclipse.aether.internal.impl.synccontext.legacy.DefaultSyncContextFactory.class );
         addService( SyncContextFactory.class, DefaultSyncContextFactory.class );
         addService( RepositoryEventDispatcher.class, DefaultRepositoryEventDispatcher.class );
         addService( OfflineController.class, DefaultOfflineController.class );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -52,7 +52,6 @@ import org.eclipse.aether.internal.impl.synccontext.named.StaticNameMapper;
 import org.eclipse.aether.named.NamedLockFactory;
 import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
-import org.eclipse.aether.spi.synccontext.SyncContextFactory;
 import org.eclipse.aether.impl.UpdateCheckManager;
 import org.eclipse.aether.impl.UpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
@@ -83,6 +82,7 @@ import org.eclipse.aether.spi.connector.transport.TransporterProvider;
 import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.spi.log.LoggerFactory;
+import org.eclipse.aether.spi.synccontext.SyncContextFactory;
 import org.slf4j.ILoggerFactory;
 
 import com.google.inject.AbstractModule;
@@ -146,8 +146,6 @@ public class AetherModule
         .to( DefaultUpdatePolicyAnalyzer.class ).in( Singleton.class );
         bind( FileProcessor.class ) //
         .to( DefaultFileProcessor.class ).in( Singleton.class );
-        bind( SyncContextFactory.class ) //
-        .to( org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory.class ).in( Singleton.class );
         bind( RepositoryEventDispatcher.class ) //
         .to( DefaultRepositoryEventDispatcher.class ).in( Singleton.class );
         bind( OfflineController.class ) //

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -147,7 +147,7 @@ public class AetherModule
         bind( FileProcessor.class ) //
         .to( DefaultFileProcessor.class ).in( Singleton.class );
         bind( SyncContextFactory.class ) //
-        .to( DefaultSyncContextFactory.class ).in( Singleton.class );
+        .to( org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory.class ).in( Singleton.class );
         bind( RepositoryEventDispatcher.class ) //
         .to( DefaultRepositoryEventDispatcher.class ).in( Singleton.class );
         bind( OfflineController.class ) //
@@ -159,6 +159,10 @@ public class AetherModule
         bind( LocalRepositoryManagerFactory.class ).annotatedWith( Names.named( "enhanced" ) ) //
         .to( EnhancedLocalRepositoryManagerFactory.class ).in( Singleton.class );
 
+        bind( SyncContextFactory.class ).to( DefaultSyncContextFactory.class ).in( Singleton.class );
+        bind( org.eclipse.aether.impl.SyncContextFactory.class )
+                .to( org.eclipse.aether.internal.impl.synccontext.legacy.DefaultSyncContextFactory.class )
+                .in( Singleton.class );
         bind( SyncContextFactoryDelegate.class ).annotatedWith( Names.named( NoLockSyncContextFactory.NAME ) )
                 .to( NoLockSyncContextFactory.class ).in( Singleton.class );
         bind( SyncContextFactoryDelegate.class ).annotatedWith( Names.named( GlobalSyncContextFactory.NAME ) )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 @Singleton
 @Named
 public final class DefaultSyncContextFactory
-        implements SyncContextFactory, org.eclipse.aether.impl.SyncContextFactory
+        implements SyncContextFactory
 {
     private static final String SYNC_CONTEXT_FACTORY_NAME = System.getProperty(
             "aether.syncContext.impl", NamedSyncContextFactory.NAME

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/legacy/DefaultSyncContextFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/legacy/DefaultSyncContextFactory.java
@@ -1,0 +1,71 @@
+package org.eclipse.aether.internal.impl.synccontext.legacy;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.spi.locator.Service;
+import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.spi.synccontext.SyncContextFactory;
+
+/**
+ * Deprecated {@link org.eclipse.aether.impl.SyncContextFactory} implementation that delegates to proper
+ * {@link SyncContextFactory} implementation. Used in Guice/SISU where we cannot bind same instance to two keys,
+ * this component "bridges" from deprecated to current.
+ *
+ * @deprecated Use the proper class from SPI module.
+ */
+@Singleton
+@Named
+@Deprecated
+public final class DefaultSyncContextFactory
+        implements org.eclipse.aether.impl.SyncContextFactory, Service
+{
+    private SyncContextFactory delegate;
+
+    public DefaultSyncContextFactory()
+    {
+        // default ctor for ServiceLocator
+    }
+
+    @Inject
+    public DefaultSyncContextFactory( final SyncContextFactory delegate )
+    {
+        this.delegate = Objects.requireNonNull( delegate );
+    }
+
+    @Override
+    public void initService( final ServiceLocator locator )
+    {
+        this.delegate = Objects.requireNonNull( locator.getService( SyncContextFactory.class ) );
+    }
+
+    @Override
+    public SyncContext newInstance( final RepositorySystemSession session, final boolean shared )
+    {
+        return delegate.newInstance( session, shared );
+    }
+}


### PR DESCRIPTION
So far with c17902add6435d228038c6ed5d117604dc66bd41 we did run "demo snippets" (can be understood as some sort of "integration testing", but also as backward compatibility testing, as it used Maven Resolver provider 3.5.0). As during recent work discovered, there were some problems with three kinds of "bindings" we provide: service locator, guice and sisu. This PR fixes those, and also changes the introduced test, by expanding it to run demos using serviceLocator, Guice and SISU.

Changes:
- up demo snippets maven-resolver-provider to 3.5.4 (was 3.5.0, contained relevant bugs re binding)
- modify booter and demos to be able to select factory
- modify existing UT to run same demos with all 3 factories
- to be able to retain binary backward compat across all 3 factories, smaller changes were needed in impl module: introduced "deprecated" DefaultSyncContextFactory as well, that delegates to "latest" syncContextFactory. This is must to make things work same way in all factories. Hence, SL, guice and sisu also does this same thing, effective component dependencies are now same across all 3 factories.