### PR TITLE
[MRESOLVER-153] Move out from ResolveTask read/writes

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -323,6 +323,9 @@ public class DefaultMetadataResolver
                         session.getLocalRepositoryManager().getPathForRemoteMetadata(
                                 metadata, request.getRepository(), request.getRequestContext() ) );
 
+                metadataDownloading(
+                        session, trace, result.getRequest().getMetadata(), result.getRequest().getRepository() );
+
                 ResolveTask task =
                     new ResolveTask( session, trace, result, installFile, checks, policy.getChecksumPolicy() );
                 tasks.add( task );
@@ -356,6 +359,19 @@ public class DefaultMetadataResolver
 
                 for ( ResolveTask task : tasks )
                 {
+                    /*
+                     * NOTE: Touch after registration with local repo to ensure concurrent resolution is not
+                     * rejected with "already updated" via session data when actual update to local repo is
+                     * still pending.
+                     */
+                    for ( UpdateCheck<Metadata, MetadataTransferException> check : task.checks )
+                    {
+                        updateCheckManager.touchMetadata( task.session, check.setException( task.exception ) );
+                    }
+
+                    metadataDownloaded( session, task.trace, task.request.getMetadata(), task.request.getRepository(),
+                            task.metadataFile, task.exception );
+
                     task.result.setException( task.exception );
                 }
             }
@@ -515,7 +531,6 @@ public class DefaultMetadataResolver
     class ResolveTask
         implements Runnable
     {
-
         final RepositorySystemSession session;
 
         final RequestTrace trace;
@@ -549,8 +564,6 @@ public class DefaultMetadataResolver
         {
             Metadata metadata = request.getMetadata();
             RemoteRepository requestRepository = request.getRepository();
-
-            metadataDownloading( session, trace, metadata, requestRepository );
 
             try
             {
@@ -595,19 +608,6 @@ public class DefaultMetadataResolver
             {
                 exception = new MetadataTransferException( metadata, requestRepository, e );
             }
-
-            /*
-             * NOTE: Touch after registration with local repo to ensure concurrent resolution is not rejected with
-             * "already updated" via session data when actual update to local repo is still pending.
-             */
-            for ( UpdateCheck<Metadata, MetadataTransferException> check : checks )
-            {
-                updateCheckManager.touchMetadata( session, check.setException( exception ) );
-            }
-
-            metadataDownloaded( session, trace, metadata, requestRepository, metadataFile, exception );
         }
-
     }
-
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MRESOLVER-153

Move out from ResolveTask the read/write of resolver-status.properties
file, perform those serially in caller thread context instead.