### PR TITLE
Null implementations shall return null

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -816,7 +816,7 @@ public final class DefaultRepositorySystemSession
         public Proxy getProxy( RemoteRepository repository )
         {
             requireNonNull( repository, "repository cannot be null" );
-            return repository.getProxy();
+            return null;
         }
 
     }
@@ -844,7 +844,7 @@ public final class DefaultRepositorySystemSession
         public Authentication getAuthentication( RemoteRepository repository )
         {
             requireNonNull( repository, "repository cannot be null" );
-            return repository.getAuthentication();
+            return null;
         }
 
     }


### PR DESCRIPTION
@cstamas This breaks stuff and should be in 2.x only. The motivation is that if the class name says `Null...` it shall return `null` and not be a `Default...` impl. WDYT?