### PR TITLE
Update TrackingFileManager.java to help with MRESOLVER-153

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
@@ -53,7 +53,17 @@ class TrackingFileManager
             stream = new FileInputStream( file );
 
             Properties props = new Properties();
-            props.load( stream );
+            
+            if (System.getProperty("spot_file_with_malformed_encoding").equals("true")) {
+                try {
+                    props.load(stream);
+                } catch (Throwable t) {
+                    System.out.println("\nfile: " + file + "\n");
+                    System.exit(1);
+                }
+            } else {
+                props.load(stream);
+            }
 
             return props;
         }


### PR DESCRIPTION
This PR is to spot files that have malformed encoding by setting the system property "spot_file_with_malformed_encoding" on the mvn command-line ...
`mvn -Dspot_file_with_malformed_encoding=true`
This should help with https://issues.apache.org/jira/browse/MRESOLVER-153