### PR TITLE
Refactor NamedLockFactorySelector

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -55,7 +55,8 @@ import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
-import org.eclipse.aether.internal.impl.synccontext.NamedLockFactorySelector;
+import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactorySelector;
+import org.eclipse.aether.internal.impl.synccontext.named.SimpleNamedLockFactorySelector;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
@@ -222,7 +223,7 @@ public final class DefaultServiceLocator
         addService( LocalRepositoryManagerFactory.class, EnhancedLocalRepositoryManagerFactory.class );
         addService( LoggerFactory.class, Slf4jLoggerFactory.class );
         addService( TrackingFileManager.class, DefaultTrackingFileManager.class );
-        addService( NamedLockFactorySelector.class, NamedLockFactorySelector.class );
+        addService( NamedLockFactorySelector.class, SimpleNamedLockFactorySelector.class );
     }
 
     private <T> Entry<T> getEntry( Class<T> type, boolean create )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -43,7 +43,8 @@ import org.eclipse.aether.impl.RepositoryEventDispatcher;
 import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
-import org.eclipse.aether.internal.impl.synccontext.NamedLockFactorySelector;
+import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactorySelector;
+import org.eclipse.aether.internal.impl.synccontext.named.SimpleNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
@@ -158,7 +159,7 @@ public class AetherModule
         .to( EnhancedLocalRepositoryManagerFactory.class ).in( Singleton.class );
         bind( TrackingFileManager.class ).to( DefaultTrackingFileManager.class ).in( Singleton.class );
 
-        bind( NamedLockFactorySelector.class ).in( Singleton.class );
+        bind( NamedLockFactorySelector.class ).to( SimpleNamedLockFactorySelector.class ).in( Singleton.class );
         bind( SyncContextFactory.class ).to( DefaultSyncContextFactory.class ).in( Singleton.class );
         bind( org.eclipse.aether.impl.SyncContextFactory.class )
                 .to( org.eclipse.aether.internal.impl.synccontext.legacy.DefaultSyncContextFactory.class )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
@@ -54,9 +54,7 @@ public final class DefaultSyncContextFactory
     {
         this.namedLockFactoryAdapter = new NamedLockFactoryAdapter(
             selector.getSelectedNameMapper(),
-            selector.getSelectedNamedLockFactory(),
-            selector.waitTime(),
-            selector.waitTimeUnit()
+            selector.getSelectedNamedLockFactory()
         );
     }
 
@@ -72,9 +70,7 @@ public final class DefaultSyncContextFactory
             locator.getService( NamedLockFactorySelector.class ) );
         this.namedLockFactoryAdapter = new NamedLockFactoryAdapter(
             selector.getSelectedNameMapper(),
-            selector.getSelectedNamedLockFactory(),
-            selector.waitTime(),
-            selector.waitTimeUnit()
+            selector.getSelectedNamedLockFactory()
         );
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapter;
+import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactorySelector;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.spi.locator.ServiceLocator;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
@@ -54,8 +55,8 @@ public final class DefaultSyncContextFactory
         this.namedLockFactoryAdapter = new NamedLockFactoryAdapter(
             selector.getSelectedNameMapper(),
             selector.getSelectedNamedLockFactory(),
-            NamedLockFactorySelector.TIME,
-            NamedLockFactorySelector.TIME_UNIT
+            selector.waitTime(),
+            selector.waitTimeUnit()
         );
     }
 
@@ -72,8 +73,8 @@ public final class DefaultSyncContextFactory
         this.namedLockFactoryAdapter = new NamedLockFactoryAdapter(
             selector.getSelectedNameMapper(),
             selector.getSelectedNamedLockFactory(),
-            NamedLockFactorySelector.TIME,
-            NamedLockFactorySelector.TIME_UNIT
+            selector.waitTime(),
+            selector.waitTimeUnit()
         );
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
@@ -80,8 +80,6 @@ public final class NamedLockFactoryAdapter
 
         private final NameMapper lockNaming;
 
-        private final SessionAwareNamedLockFactory sessionAwareNamedLockFactory;
-
         private final NamedLockFactory namedLockFactory;
 
         private final long time;
@@ -97,8 +95,6 @@ public final class NamedLockFactoryAdapter
             this.session = session;
             this.shared = shared;
             this.lockNaming = lockNaming;
-            this.sessionAwareNamedLockFactory = namedLockFactory instanceof SessionAwareNamedLockFactory
-                    ? (SessionAwareNamedLockFactory) namedLockFactory : null;
             this.namedLockFactory = namedLockFactory;
             this.time = time;
             this.timeUnit = timeUnit;
@@ -118,8 +114,7 @@ public final class NamedLockFactoryAdapter
             int acquiredLockCount = 0;
             for ( String key : keys )
             {
-                NamedLock namedLock = sessionAwareNamedLockFactory != null ? sessionAwareNamedLockFactory
-                        .getLock( session, key ) : namedLockFactory.getLock( key );
+                NamedLock namedLock = namedLockFactory.getLock( key );
                 try
                 {
                      LOGGER.trace( "Acquiring {} lock for '{}'",

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
@@ -19,22 +19,33 @@ package org.eclipse.aether.internal.impl.synccontext.named;
  * under the License.
  */
 
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.named.NamedLock;
 import org.eclipse.aether.named.NamedLockFactory;
 
+import java.util.concurrent.TimeUnit;
+
 /**
- * A {@link NamedLockFactory} that wants to make use of {@link RepositorySystemSession}.
+ * Selector for {@link NamedLockFactory} and {@link NameMapper} that selects and exposes selected ones. Essentially
+ * all the named locks configuration is here. Implementations may use different strategies to perform selection.
  */
-public interface SessionAwareNamedLockFactory extends NamedLockFactory
+public interface NamedLockFactorySelector
 {
     /**
-     * Creates or reuses existing {@link NamedLock}. Returns instance MUST BE treated as "resource", best in
-     * try-with-resource block.
-     *
-     * @param session the repository system session, must not be {@code null}
-     * @param name    the lock name, must not be {@code null}
-     * @return named  the lock instance, never {@code null}
+     * Returns the value of wait time, how much a lock blocks, must be greater than 0.
      */
-    NamedLock getLock( RepositorySystemSession session, String name );
+    long waitTime();
+
+    /**
+     * Returns the time unit of {@link #waitTime()} value, never null.
+     */
+    TimeUnit waitTimeUnit();
+
+    /**
+     * Returns the selected {@link NamedLockFactory}, never null.
+     */
+    NamedLockFactory getSelectedNamedLockFactory();
+
+    /**
+     * Returns the selected {@link NameMapper}, never null.
+     */
+    NameMapper getSelectedNameMapper();
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
@@ -21,24 +21,12 @@ package org.eclipse.aether.internal.impl.synccontext.named;
 
 import org.eclipse.aether.named.NamedLockFactory;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * Selector for {@link NamedLockFactory} and {@link NameMapper} that selects and exposes selected ones. Essentially
  * all the named locks configuration is here. Implementations may use different strategies to perform selection.
  */
 public interface NamedLockFactorySelector
 {
-    /**
-     * Returns the value of wait time, how much a lock blocks, must be greater than 0.
-     */
-    long waitTime();
-
-    /**
-     * Returns the time unit of {@link #waitTime()} value, never null.
-     */
-    TimeUnit waitTimeUnit();
-
     /**
      * Returns the selected {@link NamedLockFactory}, never null.
      */

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/SimpleNamedLockFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/SimpleNamedLockFactorySelector.java
@@ -1,0 +1,142 @@
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
+import org.eclipse.aether.named.providers.NoopNamedLockFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple selector implementation that uses Java system properties and sane default values.
+ */
+@Singleton
+@Named
+public final class SimpleNamedLockFactorySelector
+    implements NamedLockFactorySelector
+{
+    private static final long TIME = Long.getLong(
+        "aether.syncContext.named.time", 30L
+    );
+
+    private static final TimeUnit TIME_UNIT = TimeUnit.valueOf( System.getProperty(
+        "aether.syncContext.named.time.unit", TimeUnit.SECONDS.name()
+    ) );
+
+    private static final String FACTORY_NAME = System.getProperty(
+        "aether.syncContext.named.factory", LocalReadWriteLockNamedLockFactory.NAME
+    );
+
+    private static final String NAME_MAPPER_NAME = System.getProperty(
+        "aether.syncContext.named.nameMapper", GAVNameMapper.NAME
+    );
+
+    private final NamedLockFactory namedLockFactory;
+
+    private final NameMapper nameMapper;
+
+    /**
+     * Constructor used with DI, where factories are injected and selected based on key.
+     */
+    @Inject
+    public SimpleNamedLockFactorySelector( final Map<String, NamedLockFactory> factories,
+                                           final Map<String, NameMapper> nameMappers )
+    {
+        this.namedLockFactory = selectNamedLockFactory( factories );
+        this.nameMapper = selectNameMapper( nameMappers );
+    }
+
+    /**
+     * Default constructor for ServiceLocator.
+     */
+    public SimpleNamedLockFactorySelector()
+    {
+        Map<String, NamedLockFactory> factories = new HashMap<>();
+        factories.put( NoopNamedLockFactory.NAME, new NoopNamedLockFactory() );
+        factories.put( LocalReadWriteLockNamedLockFactory.NAME, new LocalReadWriteLockNamedLockFactory() );
+        factories.put( LocalSemaphoreNamedLockFactory.NAME, new LocalSemaphoreNamedLockFactory() );
+        this.namedLockFactory = selectNamedLockFactory( factories );
+
+        Map<String, NameMapper> nameMappers = new HashMap<>();
+        nameMappers.put( StaticNameMapper.NAME, new StaticNameMapper() );
+        nameMappers.put( GAVNameMapper.NAME, new GAVNameMapper() );
+        nameMappers.put( DiscriminatingNameMapper.NAME, new DiscriminatingNameMapper( new GAVNameMapper() ) );
+        this.nameMapper = selectNameMapper( nameMappers );
+    }
+
+    @Override
+    public long waitTime()
+    {
+        return TIME;
+    }
+
+    @Override
+    public TimeUnit waitTimeUnit()
+    {
+        return TIME_UNIT;
+    }
+
+    /**
+     * Returns the selected {@link NamedLockFactory}, never null.
+     */
+    @Override
+    public NamedLockFactory getSelectedNamedLockFactory()
+    {
+        return namedLockFactory;
+    }
+
+    /**
+     * Returns the selected {@link NameMapper}, never null.
+     */
+    @Override
+    public NameMapper getSelectedNameMapper()
+    {
+        return nameMapper;
+    }
+
+    private static NamedLockFactory selectNamedLockFactory( final Map<String, NamedLockFactory> factories )
+    {
+        NamedLockFactory factory = factories.get( FACTORY_NAME );
+        if ( factory == null )
+        {
+            throw new IllegalArgumentException( "Unknown NamedLockFactory name: " + FACTORY_NAME
+                + ", known ones: " + factories.keySet() );
+        }
+        return factory;
+    }
+
+    private static NameMapper selectNameMapper( final Map<String, NameMapper> nameMappers )
+    {
+        NameMapper nameMapper = nameMappers.get( NAME_MAPPER_NAME );
+        if ( nameMapper == null )
+        {
+            throw new IllegalArgumentException( "Unknown NameMapper name: " + NAME_MAPPER_NAME
+                + ", known ones: " + nameMappers.keySet() );
+        }
+        return nameMapper;
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
@@ -35,18 +35,22 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * UT support for {@link SyncContextFactory}.
  */
-public abstract class NamedLockFactoryAdapterTestSupport {
-    private static final long ADAPTER_TIME = 100L;
+public abstract class NamedLockFactoryAdapterTestSupport
+{
+    private static final long ADAPTER_TIME = 1000L;
 
     private static final TimeUnit ADAPTER_TIME_UNIT = TimeUnit.MILLISECONDS;
 
@@ -67,7 +71,7 @@ public abstract class NamedLockFactoryAdapterTestSupport {
 
     public static void createAdapter() {
         Objects.requireNonNull(namedLockFactory, "NamedLockFactory not set");
-        adapter = new NamedLockFactoryAdapter(nameMapper, namedLockFactory, ADAPTER_TIME, ADAPTER_TIME_UNIT);
+        adapter = new NamedLockFactoryAdapter(nameMapper, namedLockFactory);
     }
 
     @AfterClass
@@ -83,6 +87,10 @@ public abstract class NamedLockFactoryAdapterTestSupport {
         LocalRepository localRepository = new LocalRepository(Files.createTempDirectory("test").toFile());
         session = mock(RepositorySystemSession.class);
         when(session.getLocalRepository()).thenReturn(localRepository);
+        HashMap<String, Object> config = new HashMap<>();
+        config.put(NamedLockFactoryAdapter.TIME_KEY, String.valueOf(ADAPTER_TIME));
+        config.put(NamedLockFactoryAdapter.TIME_UNIT_KEY, ADAPTER_TIME_UNIT.name());
+        when(session.getConfigProperties()).thenReturn(config);
     }
 
     @Test
@@ -196,6 +204,37 @@ public abstract class NamedLockFactoryAdapterTestSupport {
                         new Access(false, winners, losers, adapter, session, null)
                 )
         );
+        t1.start();
+        t1.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test
+    public void fullyConsumeLockTime() throws InterruptedException {
+        long start = System.nanoTime();
+        CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner
+        CountDownLatch losers = new CountDownLatch(1); // we expect 1 loser
+        Thread t1 = new Thread(new Access(false, winners, losers, adapter, session, null));
+        Thread t2 = new Thread(new Access(false, winners, losers, adapter, session, null));
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        winners.await();
+        losers.await();
+        long end = System.nanoTime();
+        long duration = end - start;
+        long expectedDuration = ADAPTER_TIME_UNIT.toNanos(ADAPTER_TIME);
+        assertThat(duration, greaterThanOrEqualTo(expectedDuration)); // equal in ideal case
+    }
+
+    @Test
+    public void releasedExclusiveAllowAccess() throws InterruptedException {
+        CountDownLatch winners = new CountDownLatch(2); // we expect 1 winner
+        CountDownLatch losers = new CountDownLatch(0); // we expect 1 loser
+        Thread t1 = new Thread(new Access(false, winners, losers, adapter, session, null));
+        new Access(false, winners, losers, adapter, session, null).run();
         t1.start();
         t1.join();
         winners.await();

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -62,7 +63,7 @@ public abstract class NamedLockFactoryAdapterTestSupport
 
   protected static void setNamedLockFactory(final NamedLockFactory namedLockFactory) {
     adapter = new NamedLockFactoryAdapter(
-            new DiscriminatingNameMapper(new GAVNameMapper()), namedLockFactory, ADAPTER_TIME, ADAPTER_TIME_UNIT
+            new DiscriminatingNameMapper(new GAVNameMapper()), namedLockFactory
     );
   }
 
@@ -79,6 +80,10 @@ public abstract class NamedLockFactoryAdapterTestSupport
     LocalRepository localRepository = new LocalRepository(Files.createTempDirectory("test").toFile());
     session = mock(RepositorySystemSession.class);
     when(session.getLocalRepository()).thenReturn(localRepository);
+    HashMap<String, Object> config = new HashMap<>();
+    config.put(NamedLockFactoryAdapter.TIME_KEY, String.valueOf(ADAPTER_TIME));
+    config.put(NamedLockFactoryAdapter.TIME_UNIT_KEY, ADAPTER_TIME_UNIT.name());
+    when(session.getConfigProperties()).thenReturn(config);
   }
 
   @Test


### PR DESCRIPTION
This PR contains NamedLockFactorySelector related changes:
* NamedLockFactorySelector made a true component iface+impl (was more like a static helper component). This makes it possible to be replaced in case of need (by some integrator).
* avoid initing static final variables from system properties (mvnd)
* refactor source of time parameters used by adapter, they have nothing to do with lock factories. Move it out of selector.
* adapter time related parameters are sourced from Session by adapter itself

Split for simpler review.

-----

Original changes:
* https://github.com/apache/maven-resolver/pull/131
* https://github.com/apache/maven-resolver/pull/134

