### PR TITLE
[MRESOLVER-231] Extend smart checksum support

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/guice/DemoResolverModule.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/guice/DemoResolverModule.java
@@ -21,6 +21,7 @@ package org.apache.maven.resolver.examples.guice;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Named;
@@ -42,6 +43,7 @@ import org.eclipse.aether.impl.guice.AetherModule;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.ChecksumExtractor;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 
 import com.google.inject.AbstractModule;
@@ -80,6 +82,16 @@ class DemoResolverModule
                 .to( BasicRepositoryConnectorFactory.class );
         bind( TransporterFactory.class ).annotatedWith( Names.named( "file" ) ).to( FileTransporterFactory.class );
         bind( TransporterFactory.class ).annotatedWith( Names.named( "http" ) ).to( HttpTransporterFactory.class );
+    }
+
+    /**
+     * Checksum extractors (none).
+     */
+    @Provides
+    @Singleton
+    Map<String, ChecksumExtractor> provideChecksumExtractors()
+    {
+        return Collections.emptyMap();
     }
 
     /**

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/ChecksumExtractor.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/ChecksumExtractor.java
@@ -1,0 +1,55 @@
+package org.eclipse.aether.transport.http;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.HttpUriRequest;
+
+import java.util.Map;
+
+/**
+ * A component extracting included checksums from response of artifact request.
+ *
+ * @since 1.8.0
+ */
+public abstract class ChecksumExtractor
+{
+    /**
+     * Prepares request, if needed.
+     */
+    public void prepareRequest( HttpUriRequest request )
+    {
+        // nothing
+    }
+
+    /**
+     * May control is request to be retried with checksum extractors disabled.
+     */
+    public boolean retryWithoutExtractor( HttpResponseException exception )
+    {
+        return false; // nothing, usually tied to prepareRequest
+    }
+
+    /**
+     * Tries to extract checksums from response headers, if present, otherwise returns {@code null}.
+     */
+    public abstract Map<String, String> extractChecksums( HttpResponse response );
+}

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/Nexus2ChecksumExtractor.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/Nexus2ChecksumExtractor.java
@@ -1,0 +1,59 @@
+package org.eclipse.aether.transport.http;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A component extracting Nexus2 ETag "shielded" style-checksums from response headers.
+ *
+ * @since 1.8.0
+ */
+@Singleton
+@Named( Nexus2ChecksumExtractor.NAME )
+public class Nexus2ChecksumExtractor
+        extends ChecksumExtractor
+{
+    public static final String NAME = "nexus2";
+
+    @Override
+    public Map<String, String> extractChecksums( HttpResponse response )
+    {
+        // Nexus-style, ETag: "{SHA1{d40d68ba1f88d8e9b0040f175a6ff41928abd5e7}}"
+        Header header = response.getFirstHeader( HttpHeaders.ETAG );
+        String etag = header != null ? header.getValue() : null;
+        if ( etag != null )
+        {
+            int start = etag.indexOf( "SHA1{" ), end = etag.indexOf( "}", start + 5 );
+            if ( start >= 0 && end > start )
+            {
+                return Collections.singletonMap( "SHA-1", etag.substring( start + 5, end ) );
+            }
+        }
+        return null;
+    }
+}

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/XChecksumChecksumExtractor.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/XChecksumChecksumExtractor.java
@@ -1,0 +1,91 @@
+package org.eclipse.aether.transport.http;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A component extracting {@code x-} non-standard style checksums from response headers.
+ * Tried headers (in order):
+ * <ul>
+ *     <li>{@code x-checksum-sha1} - Maven Central and other CDNs</li>
+ *     <li>{@code x-checksum-md5} - Maven Central and other CDNs</li>
+ *     <li>{@code x-goog-meta-checksum-sha1} - GCS</li>
+ *     <li>{@code x-goog-meta-checksum-md5} - GCS</li>
+ * </ul>
+ *
+ * @since 1.8.0
+ */
+@Singleton
+@Named( XChecksumChecksumExtractor.NAME )
+public class XChecksumChecksumExtractor
+        extends ChecksumExtractor
+{
+    public static final String NAME = "x-checksum";
+
+    @Override
+    public Map<String, String> extractChecksums( HttpResponse response )
+    {
+        String value;
+        HashMap<String, String> result = new HashMap<>();
+        // Central style: x-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
+        value = extractChecksum( response, "x-checksum-sha1" );
+        if ( value != null )
+        {
+            result.put( "SHA-1", value );
+        }
+        // Central style: x-checksum-md5: 9ad0d8e3482767c122e85f83567b8ce6
+        value = extractChecksum( response, "x-checksum-md5" );
+        if ( value != null )
+        {
+            result.put( "MD5", value );
+        }
+        if ( !result.isEmpty() )
+        {
+            return result;
+        }
+        // Google style: x-goog-meta-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
+        value = extractChecksum( response, "x-goog-meta-checksum-sha1" );
+        if ( value != null )
+        {
+            result.put( "SHA-1", value );
+        }
+        // Central style: x-goog-meta-checksum-sha1: 9ad0d8e3482767c122e85f83567b8ce6
+        value = extractChecksum( response, "x-goog-meta-checksum-md5" );
+        if ( value != null )
+        {
+            result.put( "MD5", value );
+        }
+
+        return result.isEmpty() ? null : result;
+    }
+
+    private String extractChecksum( HttpResponse response, String name )
+    {
+        Header header = response.getFirstHeader( name );
+        return header != null ? header.getValue() : null;
+    }
+}

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpServer.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpServer.java
@@ -85,7 +85,7 @@ public class HttpServer
 
     public enum ChecksumHeader
     {
-        NEXUS
+        NEXUS, XCHECKSUM
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger( HttpServer.class );
@@ -351,6 +351,10 @@ public class HttpServer
                     if ( checksumHeader == ChecksumHeader.NEXUS )
                     {
                         response.setHeader( HttpHeader.ETAG.asString(), "{SHA1{" + checksums.get( "SHA-1" ) + "}}" );
+                    }
+                    else if ( checksumHeader == ChecksumHeader.XCHECKSUM )
+                    {
+                        response.setHeader( "x-checksum-sha1", checksums.get( "SHA-1" ).toString() );
                     }
                 }
                 if ( HttpMethod.HEAD.is( req.getMethod() ) )

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
@@ -507,6 +507,17 @@ public class HttpTransporterTest
     }
 
     @Test
+    public void testGet_Checksums_XChecksum()
+            throws Exception
+    {
+        httpServer.setChecksumHeader( HttpServer.ChecksumHeader.XCHECKSUM );
+        GetTask task = new GetTask( URI.create( "repo/file.txt" ) );
+        transporter.get( task );
+        assertEquals( "test", task.getDataString() );
+        assertEquals( "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", task.getChecksums().get( "SHA-1" ) );
+    }
+
+    @Test
     public void testGet_FileHandleLeak()
         throws Exception
     {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/ChecksumUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/ChecksumUtils.java
@@ -197,4 +197,37 @@ public final class ChecksumUtils
         return buffer.toString();
     }
 
+    /**
+     * Creates a byte array out of hexadecimal representation of the specified bytes. If input string is {@code null},
+     * {@code null} is returned. Input value must have even length (due hex encoding = 2 chars one byte).
+     *
+     * @param hexString The hexString to convert to byte array, may be {@code null}.
+     * @return The byte array of the input or {@code null} if the input was {@code null}.
+     * @since 1.8.0
+     */
+    @SuppressWarnings( "checkstyle:magicnumber" )
+    public static byte[] fromHexString( String hexString )
+    {
+        if ( hexString == null )
+        {
+            return null;
+        }
+        if ( hexString.isEmpty() )
+        {
+            return new byte[] {};
+        }
+        int len = hexString.length();
+        if ( len % 2 != 0 )
+        {
+            throw new IllegalArgumentException( "hexString length not even" );
+        }
+        byte[] data = new byte[ len / 2 ];
+        for ( int i = 0; i < len; i += 2 )
+        {
+            data[ i / 2 ] = (byte) ( ( Character.digit( hexString.charAt( i ), 16 ) << 4 )
+                + Character.digit( hexString.charAt( i + 1 ), 16 ) );
+        }
+        return data;
+    }
+
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/ChecksumUtilTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/ChecksumUtilTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.aether.util.ChecksumUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -209,6 +208,16 @@ public class ChecksumUtilTest
         assertEquals( "00", ChecksumUtils.toHexString( new byte[] { 0 } ) );
         assertEquals( "ff", ChecksumUtils.toHexString( new byte[] { -1 } ) );
         assertEquals( "00017f", ChecksumUtils.toHexString( new byte[] { 0, 1, 127 } ) );
+    }
+
+    @Test
+    public void testFromHexString()
+    {
+        assertNull( ChecksumUtils.toHexString( null ) );
+        assertArrayEquals( new byte[] {}, ChecksumUtils.fromHexString( "" ) );
+        assertArrayEquals( new byte[] { 0 }, ChecksumUtils.fromHexString( "00" ) );
+        assertArrayEquals( new byte[] { -1 } , ChecksumUtils.fromHexString( "ff" ) );
+        assertArrayEquals( new byte[] { 0, 1, 127 }, ChecksumUtils.fromHexString( "00017f" ) );
     }
 
     @Test

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -39,7 +39,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.connector.resumeDownloads` | boolean | Whether to resume partially downloaded files if the download has been interrupted. | `true` | yes
 `aether.connector.resumeThreshold` | long | The size in bytes which a partial download needs to have at least to be resumed. Requires `aether.connector.resumeDownloads` to be `true` to be effective. | `64 * 1024` | yes
 `aether.connector.requestTimeout` | long | Request timeout in milliseconds. | `1800000` | yes
-`aether.connector.smartChecksums` | boolean | Flag indicating that instead of comparing the explicit checksum from the remote repo with the calculated one it will try to extract the reference checksum from the actual artifact requests's response header named `ETag` in format `{SHA1{<checksum>}}`. This only works for HTTP(S) requests and certain transport extensions. In addition it only supports SHA-1. | `true` | no
+`aether.connector.smartChecksums` | boolean | Flag indicating that instead of comparing the external checksum fetched from the remote repo with the calculated one, it should try to extract the reference checksum from the actual artifact requests's response headers (several (strategies supported)[included-checksum-strategies.html]). This only works for transport-http transport. | `true` | no
 `aether.connector.userAgent` | String | The user agent that repository connectors should report to servers. |  `"Aether"` | no
 `aether.connector.wagon.config` | Object | The configuration to use for the Wagon provider. | - | yes (must be used)
 `aether.dependencyCollector.maxCycles` | int | Only up to the given amount cyclic dependencies are emitted. | `10` | no

--- a/src/site/markdown/included-checksum-strategies.md
+++ b/src/site/markdown/included-checksum-strategies.md
@@ -1,0 +1,51 @@
+# Included Checksum Strategies
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+**Note: these below works only with transport-http, does NOT work with transport-wagon!**
+
+By default, resolver will fetch the payload checksum from remote repository. These
+checksums are used to enforce transport validity (ensure that download was not 
+corrupted during transfer).
+
+This implies, that to get one artifact or metadata, resolver 
+needs to issue two HTTP requests: one to get the payload itself, and one to 
+get the reference checksum.
+
+By using "included checksums" feature, we are able to halve the issued HTTP request 
+count, as many services along Maven Central emits the reference checksums in
+the artifact response itself (as HTTP headers), hence, we are able to get the
+artifact and reference checksum using only one HTTP round-trip.
+
+
+## Sonatype Nexus 2
+
+Sonatype Nexus 2 uses SHA-1 hash to generate `ETag` header in "shielded" (à la Plexus Cipher)
+way. Naturally, this means only SHA-1 is available in artifact response header.
+
+Emitted by: Sonatype Nexus2 only.
+
+
+## Non-standard `X-` headers
+
+Maven Central emits headers `x-checksum-sha1` and `x-checksum-md5` along with artifact response. 
+Google GCS on the other hand uses `x-goog-meta-checksum-sha1` and `x-goog-meta-checksum-md5` 
+headers. Resolver will detect these and use their value.
+
+Emitted by: Maven Central, GCS, some CDNs and probably more.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -28,6 +28,7 @@ under the License.
       <item name="Introduction" href="index.html"/>
       <item name="Configuration" href="configuration.html"/>
       <item name="About Checksums" href="about-checksums.html"/>
+      <item name="Included Checksum Strategies" href="included-checksum-strategies.html"/>
       <item name="Maven 3.8.x" href="maven-3.8.x.html"/>
       <item name="JavaDocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>


### PR DESCRIPTION
Refactor and make it pluggable. Also, make it work with Maven Central.

This change broadens "smart checksum" support in Resolver, and
gets them from HTTP response header, if present. So far only
Nexus2 was supported, but this now adds more implementations,
so for example Central is supported now as well, hence, to
download a JAR from Central will now take only 1 HTTP request
and not 2, that effectively **halves count of HTTP requests done
today against central** as well.

This change improves transport-http only, Wagon transport is
a big burden of layers of layers of abstraction of abstraction above
and am unsure how to do this there.

High level changes:
* introduce `ChecksumExtractor` component and provide OOTB 3 implementations for it (the nexus2 was inlined, this is like "factor out nexus2" + add 2 more)
* modify HttpTransporter to use the components
* support nx2, nx3, artifactory, central, google central mirror as all those send inlined checksum

---

https://issues.apache.org/jira/browse/MRESOLVER-231