### PR TITLE
[MRESOLVER-234] Provided checksums

### DIFF
--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
@@ -51,7 +51,7 @@ public class TestChecksumAlgorithmSelector
     public static final String TEST_CHECKSUM_VALUE = "01020304";
 
     @Override
-    public Set<String> getChecksumAlgorithmNames()
+    public Set<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
     {
         return Collections.emptySet(); // irrelevant
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -41,6 +41,7 @@ import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.impl.RepositoryConnectorProvider;
 import org.eclipse.aether.impl.RepositoryEventDispatcher;
 import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
+import org.eclipse.aether.internal.impl.FileProvidedChecksumsSource;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
 import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
 import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
@@ -83,6 +84,7 @@ import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory;
 import org.eclipse.aether.named.providers.NoopNamedLockFactory;
+import org.eclipse.aether.spi.connector.checksum.ProvidedChecksumsSource;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
@@ -168,6 +170,9 @@ public class AetherModule
                 .to( EnhancedLocalRepositoryManagerFactory.class ).in( Singleton.class );
         bind( TrackingFileManager.class ).to( DefaultTrackingFileManager.class ).in( Singleton.class );
 
+        bind( ProvidedChecksumsSource.class ).annotatedWith( Names.named( FileProvidedChecksumsSource.NAME ) ) //
+            .to( FileProvidedChecksumsSource.class ).in( Singleton.class );
+
         bind( ChecksumAlgorithmFactory.class ).annotatedWith( Names.named( Md5ChecksumAlgorithmFactory.NAME ) )
                 .to( Md5ChecksumAlgorithmFactory.class );
         bind( ChecksumAlgorithmFactory.class ).annotatedWith( Names.named( Sha1ChecksumAlgorithmFactory.NAME ) )
@@ -205,6 +210,17 @@ public class AetherModule
 
         install( new Slf4jModule() );
 
+    }
+
+    @Provides
+    @Singleton
+    Map<String, ProvidedChecksumsSource> provideChecksumSources(
+        @Named( FileProvidedChecksumsSource.NAME ) ProvidedChecksumsSource fileProvidedChecksumSource
+    )
+    {
+        Map<String, ProvidedChecksumsSource> providedChecksumsSource = new HashMap<>();
+        providedChecksumsSource.put( FileProvidedChecksumsSource.NAME, fileProvidedChecksumSource );
+        return providedChecksumsSource;
     }
 
     @Provides

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
@@ -41,26 +41,26 @@ abstract class AbstractChecksumPolicy
     }
 
     @Override
-    public boolean onChecksumMatch( String algorithm, int kind )
+    public boolean onChecksumMatch( String algorithm, ChecksumKind kind )
     {
         requireNonNull( algorithm, "algorithm cannot be null" );
         return true;
     }
 
     @Override
-    public void onChecksumMismatch( String algorithm, int kind, ChecksumFailureException exception )
+    public void onChecksumMismatch( String algorithm, ChecksumKind kind, ChecksumFailureException exception )
             throws ChecksumFailureException
     {
         requireNonNull( algorithm, "algorithm cannot be null" );
         requireNonNull( exception, "exception cannot be null" );
-        if ( ( kind & KIND_UNOFFICIAL ) == 0 )
+        if ( !kind.isIgnoreOnMismatch() )
         {
             throw exception;
         }
     }
 
     @Override
-    public void onChecksumError( String algorithm, int kind, ChecksumFailureException exception )
+    public void onChecksumError( String algorithm, ChecksumKind kind, ChecksumFailureException exception )
             throws ChecksumFailureException
     {
         requireNonNull( algorithm, "algorithm cannot be null" );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSource.java
@@ -1,0 +1,169 @@
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ProvidedChecksumsSource;
+import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Local filesystem backed {@link ProvidedChecksumsSource} implementation that use specified directory as base
+ * directory, where it expects artifacts checksums on standard Maven2 "local" layout. This implementation uses Artifact
+ * (and Metadata) coordinates solely to form path from baseDir (for Metadata file name is
+ * {@code maven-metadata-local.xml.sha1} in case of SHA-1 checksum).
+ *
+ * @since 1.8.0
+ */
+@Singleton
+@Named( FileProvidedChecksumsSource.NAME )
+public final class FileProvidedChecksumsSource
+    implements ProvidedChecksumsSource
+{
+    public static final String NAME = "file";
+
+    static final String CONFIG_PROP_BASE_DIR = "aether.artifactResolver.providedChecksumsSource.file.baseDir";
+
+    static final String LOCAL_REPO_PREFIX = ".checksums";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( FileProvidedChecksumsSource.class );
+
+    private final FileProcessor fileProcessor;
+
+    private final SimpleLocalRepositoryManager simpleLocalRepositoryManager;
+
+    @Inject
+    public FileProvidedChecksumsSource( FileProcessor fileProcessor )
+    {
+        this.fileProcessor = requireNonNull( fileProcessor );
+        // we really needs just "local layout" from it (relative paths), so baseDir here is irrelevant
+        this.simpleLocalRepositoryManager = new SimpleLocalRepositoryManager( new File( "" ) );
+    }
+
+    @Override
+    public Map<String, String> getProvidedArtifactChecksums( RepositorySystemSession session,
+                                                             ArtifactDownload transfer,
+                                                             List<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
+    {
+        Path baseDir = getBaseDir( session );
+        if ( baseDir == null )
+        {
+            return null;
+        }
+        ArrayList<ChecksumFilePath> checksumFilePaths = new ArrayList<>( checksumAlgorithmFactories.size() );
+        for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithmFactories )
+        {
+            checksumFilePaths.add( new ChecksumFilePath(
+                    simpleLocalRepositoryManager.getPathForArtifact( transfer.getArtifact(), false ) + '.'
+                    + checksumAlgorithmFactory.getFileExtension(), checksumAlgorithmFactory ) );
+        }
+        return getProvidedChecksums( baseDir, checksumFilePaths, ArtifactIdUtils.toId( transfer.getArtifact() ) );
+    }
+
+    /**
+     * May return {@code null}.
+     */
+    private Map<String, String> getProvidedChecksums( Path baseDir,
+                                                      List<ChecksumFilePath> checksumFilePaths,
+                                                      String subjectId )
+    {
+        HashMap<String, String> checksums = new HashMap<>();
+        for ( ChecksumFilePath checksumFilePath : checksumFilePaths )
+        {
+            Path checksumPath =  baseDir.resolve( checksumFilePath.path );
+            if ( Files.isReadable( checksumPath ) )
+            {
+                try
+                {
+                    String checksum = fileProcessor.readChecksum( checksumPath.toFile() );
+                    if ( checksum != null )
+                    {
+                        LOGGER.debug( "Resolved provided checksum '{}:{}' for '{}'",
+                                checksumFilePath.checksumAlgorithmFactory.getName(), checksum, subjectId );
+
+                        checksums.put( checksumFilePath.checksumAlgorithmFactory.getName(), checksum );
+                    }
+                }
+                catch ( IOException e )
+                {
+                    LOGGER.warn( "Could not read provided checksum for '{}' at path '{}'",
+                            subjectId, checksumPath, e );
+                }
+            }
+        }
+        return checksums.isEmpty() ? null : checksums;
+    }
+
+    /**
+     * Returns the base {@link URI} of directory where checksums are laid out, may return {@code null}.
+     */
+    private Path getBaseDir( RepositorySystemSession session )
+    {
+        final String baseDirPath = ConfigUtils.getString( session, null, CONFIG_PROP_BASE_DIR );
+        final Path baseDir;
+        if ( baseDirPath != null )
+        {
+            baseDir = Paths.get( baseDirPath );
+        }
+        else
+        {
+            baseDir = session.getLocalRepository().getBasedir().toPath().resolve( LOCAL_REPO_PREFIX );
+        }
+        if ( !Files.isDirectory( baseDir ) )
+        {
+            return null;
+        }
+        return baseDir;
+    }
+
+    private static final class ChecksumFilePath
+    {
+        private final String path;
+
+        private final ChecksumAlgorithmFactory checksumAlgorithmFactory;
+
+        private ChecksumFilePath( String path, ChecksumAlgorithmFactory checksumAlgorithmFactory )
+        {
+            this.path = path;
+            this.checksumAlgorithmFactory = checksumAlgorithmFactory;
+        }
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -148,9 +147,9 @@ public final class Maven2RepositoryLayoutFactory
         }
 
         @Override
-        public List<String> getChecksumAlgorithmNames()
+        public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
         {
-            return checksumAlgorithms.stream().map( ChecksumAlgorithmFactory::getName ).collect( Collectors.toList() );
+            return checksumAlgorithms;
         }
 
         @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
@@ -23,15 +23,16 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Default implementation.
@@ -73,15 +74,19 @@ public class DefaultChecksumAlgorithmFactorySelector
         {
             throw new IllegalArgumentException(
                     String.format( "Unsupported checksum algorithm %s, supported ones are %s",
-                            algorithmName, getChecksumAlgorithmNames() )
+                            algorithmName,
+                            getChecksumAlgorithmFactories().stream()
+                                                           .map( ChecksumAlgorithmFactory::getName )
+                                                           .collect( toList() )
+                    )
             );
         }
         return factory;
     }
 
     @Override
-    public Set<String> getChecksumAlgorithmNames()
+    public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
     {
-        return new HashSet<>( factories.keySet() );
+        return new ArrayList<>( factories.values() );
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -38,8 +38,6 @@ import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.UpdateCheckManager;
 import org.eclipse.aether.impl.VersionResolver;
-import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
-import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
 import org.eclipse.aether.internal.test.util.TestFileProcessor;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
 import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FailChecksumPolicyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FailChecksumPolicyTest.java
@@ -21,7 +21,7 @@ package org.eclipse.aether.internal.impl;
 
 import static org.junit.Assert.*;
 
-import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
 import org.junit.Before;
@@ -50,8 +50,9 @@ public class FailChecksumPolicyTest
     @Test
     public void testOnChecksumMatch()
     {
-        assertTrue( policy.onChecksumMatch( "SHA-1", 0 ) );
-        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumPolicy.KIND_UNOFFICIAL ) );
+        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumKind.REMOTE_EXTERNAL ) );
+        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumKind.REMOTE_INCLUDED ) );
+        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumKind.PROVIDED ) );
     }
 
     @Test
@@ -60,21 +61,29 @@ public class FailChecksumPolicyTest
     {
         try
         {
-            policy.onChecksumMismatch( "SHA-1", 0, exception );
+            policy.onChecksumMismatch( "SHA-1", ChecksumKind.REMOTE_EXTERNAL, exception );
             fail( "No exception" );
         }
         catch ( ChecksumFailureException e )
         {
             assertSame( exception, e );
         }
-        policy.onChecksumMismatch( "SHA-1", ChecksumPolicy.KIND_UNOFFICIAL, exception );
+        policy.onChecksumMismatch( "SHA-1", ChecksumKind.REMOTE_INCLUDED, exception );
+        try
+        {
+            policy.onChecksumMismatch("SHA-1", ChecksumKind.PROVIDED, exception);
+        }
+        catch ( ChecksumFailureException e)
+        {
+            assertSame( exception, e );
+        }
     }
 
     @Test
     public void testOnChecksumError()
         throws Exception
     {
-        policy.onChecksumError( "SHA-1", 0, exception );
+        policy.onChecksumError( "SHA-1", ChecksumKind.REMOTE_EXTERNAL, exception );
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSourceTest.java
@@ -1,0 +1,107 @@
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.test.util.TestFileProcessor;
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class FileProvidedChecksumsSourceTest
+{
+  private DefaultRepositorySystemSession session;
+
+  private RepositoryLayout repositoryLayout;
+
+  private FileProvidedChecksumsSource subject;
+
+  @Before
+  public void setup() throws NoRepositoryLayoutException, IOException
+  {
+    RemoteRepository repository = new RemoteRepository.Builder("test", "default", "https://irrelevant.com").build();
+    session = TestUtils.newSession();
+    repositoryLayout = new Maven2RepositoryLayoutFactory().newInstance(session, repository);
+    subject = new FileProvidedChecksumsSource(new TestFileProcessor() );
+
+    // populate local repository
+    Path baseDir = session.getLocalRepository().getBasedir().toPath().resolve( FileProvidedChecksumsSource.LOCAL_REPO_PREFIX);
+
+    // artifact: test:test:2.0 => "foobar"
+    {
+      Path test = baseDir.resolve("test/test/2.0/test-2.0.jar.sha1");
+      Files.createDirectories(test.getParent());
+      Files.write(test, "foobar".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void noProvidedArtifactChecksum()
+  {
+    ArtifactDownload transfer = new ArtifactDownload(
+        new DefaultArtifact("test:test:1.0"),
+        "irrelevant",
+        new File("irrelevant"),
+        RepositoryPolicy.CHECKSUM_POLICY_FAIL
+    );
+    Map<String, String> providedChecksums = subject.getProvidedArtifactChecksums(
+        session,
+        transfer,
+        repositoryLayout.getChecksumAlgorithmFactories()
+    );
+    assertNull(providedChecksums);
+  }
+
+  @Test
+  public void haveProvidedArtifactChecksum()
+  {
+    ArtifactDownload transfer = new ArtifactDownload(
+        new DefaultArtifact("test:test:2.0"),
+        "irrelevant",
+        new File("irrelevant"),
+        RepositoryPolicy.CHECKSUM_POLICY_FAIL
+    );
+    Map<String, String> providedChecksums = subject.getProvidedArtifactChecksums(
+        session,
+        transfer,
+        repositoryLayout.getChecksumAlgorithmFactories()
+    );
+    assertNotNull(providedChecksums);
+    assertEquals(providedChecksums.get(Sha1ChecksumAlgorithmFactory.NAME), "foobar");
+  }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.*;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -121,7 +122,11 @@ public class Maven2RepositoryLayoutFactoryTest
     @Test
     public void testChecksumAlgorithmNames()
     {
-        assertEquals( Arrays.asList( "SHA-1", "MD5" ), layout.getChecksumAlgorithmNames() );
+        assertEquals( Arrays.asList( "SHA-1", "MD5" ),
+                layout.getChecksumAlgorithmFactories().stream()
+                      .map( ChecksumAlgorithmFactory::getName )
+                      .collect( Collectors.toList() )
+        );
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
@@ -21,7 +21,7 @@ package org.eclipse.aether.internal.impl;
 
 import static org.junit.Assert.*;
 
-import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
 import org.junit.Before;
@@ -50,8 +50,8 @@ public class WarnChecksumPolicyTest
     @Test
     public void testOnChecksumMatch()
     {
-        assertTrue( policy.onChecksumMatch( "SHA-1", 0 ) );
-        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumPolicy.KIND_UNOFFICIAL ) );
+        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumKind.REMOTE_EXTERNAL ) );
+        assertTrue( policy.onChecksumMatch( "SHA-1", ChecksumKind.REMOTE_INCLUDED ) );
     }
 
     @Test
@@ -60,21 +60,21 @@ public class WarnChecksumPolicyTest
     {
         try
         {
-            policy.onChecksumMismatch( "SHA-1", 0, exception );
+            policy.onChecksumMismatch( "SHA-1", ChecksumKind.REMOTE_EXTERNAL, exception );
             fail( "No exception" );
         }
         catch ( ChecksumFailureException e )
         {
             assertSame( exception, e );
         }
-        policy.onChecksumMismatch( "SHA-1", ChecksumPolicy.KIND_UNOFFICIAL, exception );
+        policy.onChecksumMismatch( "SHA-1", ChecksumKind.REMOTE_INCLUDED, exception );
     }
 
     @Test
     public void testOnChecksumError()
         throws Exception
     {
-        policy.onChecksumError( "SHA-1", 0, exception );
+        policy.onChecksumError( "SHA-1", ChecksumKind.REMOTE_EXTERNAL, exception );
     }
 
     @Test

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
@@ -19,7 +19,7 @@ package org.eclipse.aether.spi.connector.checksum;
  * under the License.
  */
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * Component performing selection of {@link ChecksumAlgorithmFactory} based on known factory names.
@@ -36,9 +36,10 @@ public interface ChecksumAlgorithmFactorySelector
     ChecksumAlgorithmFactory select( String algorithmName );
 
     /**
-     * Returns a set of supported algorithm names. This set represents ALL the algorithms supported by Resolver, and is
-     * NOT in any relation to given repository layout used checksums, returned by method {@link
-     * org.eclipse.aether.spi.connector.layout.RepositoryLayout#getChecksumAlgorithmNames()} (is super set of it).
+     * Returns a collection of supported algorithm names. This set represents ALL the algorithms supported by Resolver,
+     * and is NOT in any relation to given repository layout used checksums, returned by method {@link
+     * org.eclipse.aether.spi.connector.layout.RepositoryLayout#getChecksumAlgorithmFactories()} (in fact, is super set
+     * of it).
      */
-    Set<String> getChecksumAlgorithmNames();
+    Collection<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories();
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ProvidedChecksumsSource.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ProvidedChecksumsSource.java
@@ -1,0 +1,47 @@
+package org.eclipse.aether.spi.connector.checksum;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+
+/**
+ * Component able to provide (expected) checksums beforehand the download happens. Checksum provided by this component
+ * are of kind {@link org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind#PROVIDED}.
+ *
+ * @since 1.8.0
+ */
+public interface ProvidedChecksumsSource
+{
+    /**
+     * May return the provided checksums (for given artifact transfer) from trusted source other than remote
+     * repository, or {@code null}.
+     *
+     * @param transfer The transfer that is about to be executed.
+     * @param checksumAlgorithmFactories The checksum algorithms that are expected.
+     * @return Map of expected checksums, or {@code null}.
+     */
+    Map<String, String> getProvidedArtifactChecksums( RepositorySystemSession session,
+                                                      ArtifactDownload transfer,
+                                                      List<ChecksumAlgorithmFactory> checksumAlgorithmFactories );
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/layout/RepositoryLayout.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/layout/RepositoryLayout.java
@@ -126,12 +126,12 @@ public interface RepositoryLayout
     }
 
     /**
-     * Returns the list of checksum names this instance of layout uses, never {@code null}. The checksum order
-     * represents the order how checksums are validated (hence retrieved).
+     * Returns immutable list of {@link ChecksumAlgorithmFactory} this instance of layout uses, never {@code null}.
+     * The order represents the order how checksums are validated (hence retrieved).
      *
      * @since 1.8.0
      */
-    List<String> getChecksumAlgorithmNames();
+    List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories();
 
     /**
      * Gets the location within a remote repository where the specified artifact resides. The URI is relative to the

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/GetTask.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/GetTask.java
@@ -209,9 +209,10 @@ public final class GetTask
 
     /**
      * Gets the checksums which the remote repository advertises for the resource. The map is keyed by algorithm name
-     * (cf. {@link java.security.MessageDigest#getInstance(String)}) and the values are hexadecimal representations of
-     * the corresponding value. <em>Note:</em> This is optional data that a transporter may return if the underlying
-     * transport protocol provides metadata (e.g. HTTP headers) along with the actual resource data.
+     * and the values are hexadecimal representations of the corresponding value. <em>Note:</em> This is optional
+     * data that a transporter may return if the underlying transport protocol provides metadata (e.g. HTTP headers)
+     * along with the actual resource data. Checksums returned by this method have kind of
+     * {@link org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind#REMOTE_INCLUDED}.
      * 
      * @return The (read-only) checksums advertised for the downloaded resource, possibly empty but never {@code null}.
      */
@@ -225,8 +226,7 @@ public final class GetTask
      * use this method to record checksum information which is readily available while performing the actual download,
      * they should not perform additional transfers to gather this data.
      * 
-     * @param algorithm The name of the checksum algorithm (e.g. {@code "SHA-1"}, cf.
-     *            {@link java.security.MessageDigest#getInstance(String)} ), may be {@code null}.
+     * @param algorithm The name of the checksum algorithm (e.g. {@code "SHA-1"}, may be {@code null}.
      * @param value The hexadecimal representation of the checksum, may be {@code null}.
      * @return This task for chaining, never {@code null}.
      */


### PR DESCRIPTION
This feature allows Resolver to get "provided" checksums ahead
of remote transport (resolution), hence, it may operate with
"good known" checksums for example (or use any other source).

High level changes:
* introduce ProvidedChecksumsSource component
* modify basic connector and checksum validator to support provided checksums
* implement file based checksums source

---

https://issues.apache.org/jira/browse/MRESOLVER-234