### PR TITLE
[MRESOLVER-7] Download dependency POMs in parallel

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -70,7 +70,7 @@ public final class DefaultDependencyNode
     {
         this.dependency = dependency;
         artifact = ( dependency != null ) ? dependency.getArtifact() : null;
-        children = new ArrayList<>( 0 );
+        children = Collections.synchronizedList( new ArrayList<DependencyNode>( 0 ) );
         aliases = Collections.emptyList();
         relocations = Collections.emptyList();
         repositories = Collections.emptyList();
@@ -88,7 +88,7 @@ public final class DefaultDependencyNode
     public DefaultDependencyNode( Artifact artifact )
     {
         this.artifact = artifact;
-        children = new ArrayList<>( 0 );
+        children = Collections.synchronizedList( new ArrayList<DependencyNode>( 0 ) );
         aliases = Collections.emptyList();
         relocations = Collections.emptyList();
         repositories = Collections.emptyList();
@@ -106,7 +106,7 @@ public final class DefaultDependencyNode
     {
         dependency = node.getDependency();
         artifact = node.getArtifact();
-        children = new ArrayList<>( 0 );
+        children = Collections.synchronizedList( new ArrayList<DependencyNode>( 0 ) );
         setAliases( node.getAliases() );
         setRequestContext( node.getRequestContext() );
         setManagedBits( node.getManagedBits() );
@@ -127,7 +127,7 @@ public final class DefaultDependencyNode
     {
         if ( children == null )
         {
-            this.children = new ArrayList<>( 0 );
+            this.children = Collections.synchronizedList( new ArrayList<DependencyNode>( 0 ) );
         }
         else
         {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
@@ -21,12 +21,12 @@ package org.eclipse.aether.internal.impl.collect;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.RepositoryCache;
 import org.eclipse.aether.RepositorySystemSession;
@@ -67,9 +67,9 @@ final class DataPool
 
     private Map<Object, Descriptor> descriptors;
 
-    private final Map<Object, Constraint> constraints = new HashMap<>();
+    private final Map<Object, Constraint> constraints = new ConcurrentHashMap<>();
 
-    private final Map<Object, List<DependencyNode>> nodes = new HashMap<>( 256 );
+    private final Map<Object, List<DependencyNode>> nodes = new ConcurrentHashMap<>( 256 );
 
     @SuppressWarnings( "unchecked" )
     DataPool( RepositorySystemSession session )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollectionContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollectionContext.java
@@ -19,6 +19,7 @@ package org.eclipse.aether.internal.impl.collect;
  * under the License.
  */
 
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -35,11 +36,11 @@ final class DefaultDependencyCollectionContext
 
     private final RepositorySystemSession session;
 
-    private Artifact artifact;
+    private final Artifact artifact;
 
-    private Dependency dependency;
+    private final Dependency dependency;
 
-    private List<Dependency> managedDependencies;
+    private final List<Dependency> managedDependencies;
 
     DefaultDependencyCollectionContext( RepositorySystemSession session, Artifact artifact,
                                                Dependency dependency, List<Dependency> managedDependencies )
@@ -47,7 +48,7 @@ final class DefaultDependencyCollectionContext
         this.session = session;
         this.artifact = ( dependency != null ) ? dependency.getArtifact() : artifact;
         this.dependency = dependency;
-        this.managedDependencies = managedDependencies;
+        this.managedDependencies = Collections.unmodifiableList( managedDependencies );
     }
 
     public RepositorySystemSession getSession()
@@ -68,13 +69,6 @@ final class DefaultDependencyCollectionContext
     public List<Dependency> getManagedDependencies()
     {
         return managedDependencies;
-    }
-
-    public void set( Dependency dependency, List<Dependency> managedDependencies )
-    {
-        artifact = dependency.getArtifact();
-        this.dependency = dependency;
-        this.managedDependencies = managedDependencies;
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
@@ -176,7 +176,7 @@ public class DefaultDependencyCollector
                                              request.getRequestContext() );
                 rangeRequest.setTrace( trace );
                 rangeResult = versionRangeResolver.resolveVersionRange( session, rangeRequest );
-                versions = filterVersions( root, rangeResult, verFilter, new DefaultVersionFilterContext( session ) );
+                versions = filterVersions( root, rangeResult, verFilter, session );
             }
             catch ( VersionRangeResolutionException e )
             {
@@ -250,9 +250,7 @@ public class DefaultDependencyCollector
             DefaultDependencyCollectionContext context =
                 new DefaultDependencyCollectionContext( session, request.getRootArtifact(), root, managedDependencies );
 
-            DefaultVersionFilterContext versionContext = new DefaultVersionFilterContext( session );
-
-            Args args = new Args( session, trace, pool, nodes, context, versionContext, request );
+            Args args = new Args( session, trace, pool, nodes, context, request );
             Results results = new Results( result, session );
 
             process( args, results, dependencies, repositories,
@@ -394,7 +392,7 @@ public class DefaultDependencyCollector
 
             rangeResult = cachedResolveRangeResult( rangeRequest, args.pool, args.session );
 
-            versions = filterVersions( dependency, rangeResult, verFilter, args.versionContext );
+            versions = filterVersions( dependency, rangeResult, verFilter, args.session );
         }
         catch ( VersionRangeResolutionException e )
         {
@@ -645,8 +643,7 @@ public class DefaultDependencyCollector
     }
 
     private static List<? extends Version> filterVersions( Dependency dependency, VersionRangeResult rangeResult,
-                                                           VersionFilter verFilter,
-                                                           DefaultVersionFilterContext verContext )
+                                                           VersionFilter verFilter, RepositorySystemSession session )
         throws VersionRangeResolutionException
     {
         if ( rangeResult.getVersions().isEmpty() )
@@ -659,7 +656,8 @@ public class DefaultDependencyCollector
         List<? extends Version> versions;
         if ( verFilter != null && rangeResult.getVersionConstraint().getRange() != null )
         {
-            verContext.set( dependency, rangeResult );
+            DefaultVersionFilterContext verContext =
+                    new DefaultVersionFilterContext( session, dependency, rangeResult );
             try
             {
                 verFilter.filterVersions( verContext );
@@ -702,13 +700,10 @@ public class DefaultDependencyCollector
 
         final DefaultDependencyCollectionContext collectionContext;
 
-        final DefaultVersionFilterContext versionContext;
-
         final CollectRequest request;
 
         Args( RepositorySystemSession session, RequestTrace trace, DataPool pool, NodeStack nodes,
-                     DefaultDependencyCollectionContext collectionContext, DefaultVersionFilterContext versionContext,
-                     CollectRequest request )
+                     DefaultDependencyCollectionContext collectionContext, CollectRequest request )
         {
             this.session = session;
             this.request = request;
@@ -718,7 +713,6 @@ public class DefaultDependencyCollector
             this.pool = pool;
             this.nodes = nodes;
             this.collectionContext = collectionContext;
-            this.versionContext = versionContext;
         }
 
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
@@ -250,7 +250,7 @@ public class DefaultDependencyCollector
             DefaultDependencyCollectionContext context =
                 new DefaultDependencyCollectionContext( session, request.getRootArtifact(), root, managedDependencies );
 
-            Args args = new Args( session, trace, pool, nodes, context, request );
+            Args args = new Args( session, trace, pool, nodes, request );
             Results results = new Results( result, session );
 
             process( args, results, dependencies, repositories,
@@ -480,8 +480,9 @@ public class DefaultDependencyCollector
                             DependencyTraverser depTraverser, VersionFilter verFilter, Dependency d,
                             ArtifactDescriptorResult descriptorResult, DefaultDependencyNode child )
     {
-        DefaultDependencyCollectionContext context = args.collectionContext;
-        context.set( d, descriptorResult.getManagedDependencies() );
+        DefaultDependencyCollectionContext context =
+                new DefaultDependencyCollectionContext( args.session, d.getArtifact(), d,
+                        descriptorResult.getManagedDependencies() );
 
         DependencySelector childSelector = depSelector != null ? depSelector.deriveChildSelector( context ) : null;
         DependencyManager childManager = depManager != null ? depManager.deriveChildManager( context ) : null;
@@ -698,12 +699,10 @@ public class DefaultDependencyCollector
 
         final NodeStack nodes;
 
-        final DefaultDependencyCollectionContext collectionContext;
-
         final CollectRequest request;
 
         Args( RepositorySystemSession session, RequestTrace trace, DataPool pool, NodeStack nodes,
-                     DefaultDependencyCollectionContext collectionContext, CollectRequest request )
+              CollectRequest request )
         {
             this.session = session;
             this.request = request;
@@ -712,7 +711,6 @@ public class DefaultDependencyCollector
             this.trace = trace;
             this.pool = pool;
             this.nodes = nodes;
-            this.collectionContext = collectionContext;
         }
 
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
@@ -244,13 +244,10 @@ public class DefaultDependencyCollector
         {
             DataPool pool = new DataPool( session );
 
-            NodeStack nodes = new NodeStack();
-            nodes.push( node );
-
             DefaultDependencyCollectionContext context =
                 new DefaultDependencyCollectionContext( session, request.getRootArtifact(), root, managedDependencies );
 
-            Args args = new Args( session, trace, pool, nodes, request );
+            Args args = new Args( session, trace, pool, new NodeStack( node ), request );
             Results results = new Results( result, session );
 
             process( args, results, dependencies, repositories,
@@ -502,13 +499,9 @@ public class DefaultDependencyCollector
         if ( children == null )
         {
             args.pool.putChildren( key, child.getChildren() );
-
-            args.nodes.push( child );
-
-            process( args, results, descriptorResult.getDependencies(), childRepos, childSelector, childManager,
+            Args childArgs = new Args( args.session, args.trace, args.pool, args.nodes.push( child ), args.request );
+            process( childArgs, results, descriptorResult.getDependencies(), childRepos, childSelector, childManager,
                      childTraverser, childFilter );
-
-            args.nodes.pop();
         }
         else
         {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContext.java
@@ -41,19 +41,15 @@ final class DefaultVersionFilterContext
 {
     private final RepositorySystemSession session;
 
-    private Dependency dependency;
+    private final Dependency dependency;
 
-    VersionRangeResult result;
+    private final VersionRangeResult result;
 
-    private List<Version> versions;
+    private final List<Version> versions;
 
-    DefaultVersionFilterContext( RepositorySystemSession session )
+    DefaultVersionFilterContext( RepositorySystemSession session, Dependency dependency, VersionRangeResult result )
     {
         this.session = session;
-    }
-
-    public void set( Dependency dependency, VersionRangeResult result )
-    {
         this.dependency = dependency;
         this.result = result;
         this.versions = new ArrayList<>( result.getVersions() );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/NodeStack.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/NodeStack.java
@@ -30,45 +30,39 @@ import org.eclipse.aether.graph.DependencyNode;
 final class NodeStack
 {
 
-    @SuppressWarnings( {"unchecked", "checkstyle:magicnumber" } )
-    // CHECKSTYLE_OFF: MagicNumber
-    private DependencyNode[] nodes = new DependencyNode[96];
-    // CHECKSTYLE_ON: MagicNumber
+    private final DependencyNode[] nodes;
 
-    private int size;
+    NodeStack( DependencyNode node )
+    {
+        this( new DependencyNode[1] );
+        nodes[0] = node;
+    }
+
+    private NodeStack( DependencyNode[] nodes )
+    {
+        this.nodes = nodes;
+    }
 
     public DependencyNode top()
     {
-        if ( size <= 0 )
+        if ( nodes.length == 0 )
         {
             throw new IllegalStateException( "stack empty" );
         }
-        return nodes[size - 1];
+        return nodes[nodes.length - 1];
     }
 
-    public void push( DependencyNode node )
+    public NodeStack push( DependencyNode node )
     {
-        if ( size >= nodes.length )
-        {
-            DependencyNode[] tmp = new DependencyNode[size + 64];
-            System.arraycopy( nodes, 0, tmp, 0, nodes.length );
-            nodes = tmp;
-        }
-        nodes[size++] = node;
-    }
-
-    public void pop()
-    {
-        if ( size <= 0 )
-        {
-            throw new IllegalStateException( "stack empty" );
-        }
-        size--;
+        DependencyNode[] copyNodes = new DependencyNode[nodes.length + 1];
+        System.arraycopy( nodes, 0, copyNodes, 0, nodes.length );
+        copyNodes[copyNodes.length - 1] = node;
+        return new NodeStack( copyNodes );
     }
 
     public int find( Artifact artifact )
     {
-        for ( int i = size - 1; i >= 0; i-- )
+        for ( int i = nodes.length - 1; i >= 0; i-- )
         {
             DependencyNode node = nodes[i];
 
@@ -110,7 +104,7 @@ final class NodeStack
 
     public int size()
     {
-        return size;
+        return nodes.length;
     }
 
     public DependencyNode get( int index )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/ObjectPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/ObjectPool.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl.collect;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -31,7 +32,8 @@ import java.util.WeakHashMap;
 class ObjectPool<T>
 {
 
-    private final Map<Object, Reference<T>> objects = new WeakHashMap<>( 256 );
+    private final Map<Object, Reference<T>> objects =
+            Collections.synchronizedMap( new WeakHashMap<Object, Reference<T>>( 256 ) );
 
     public synchronized T intern( T object )
     {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCycleTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCycleTest.java
@@ -35,8 +35,7 @@ public class DefaultDependencyCycleTest
     @Test
     public void testToString()
     {
-        NodeStack nodeStack = new NodeStack();
-        nodeStack.push( new DefaultDependencyNode( FOO_DEPENDENCY ) );
+        NodeStack nodeStack = new NodeStack(new DefaultDependencyNode( FOO_DEPENDENCY ));
         DependencyCycle cycle = new DefaultDependencyCycle( nodeStack, 1, BAR_DEPENDENCY );
 
         assertEquals( "group-id:foo:jar -> group-id:bar:jar", cycle.toString() );

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContextTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContextTest.java
@@ -39,15 +39,14 @@ import static org.junit.Assert.assertTrue;
 public class DefaultVersionFilterContextTest
 {
     private static final Dependency FOO_DEPENDENCY = new Dependency( new DefaultArtifact( "group-id:foo:1.0" ), "test" );
-    private static final Dependency BAR_DEPENDENCY = new Dependency( new DefaultArtifact( "group-id:bar:1.0" ), "test" );
 
     @Test
     public void iteratorOneItem()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         assertTrue( iterator.hasNext() );
@@ -57,10 +56,9 @@ public class DefaultVersionFilterContextTest
     @Test
     public void getCountOneItem()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         assertEquals(1, context.getCount());
     }
@@ -68,10 +66,10 @@ public class DefaultVersionFilterContextTest
     @Test
     public void getOneItem()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         assertEquals( Collections.singletonList( new TestVersion( "1.0") ), context.get() );
     }
@@ -79,10 +77,10 @@ public class DefaultVersionFilterContextTest
     @Test
     public void iteratorDelete()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         iterator.next();
@@ -94,10 +92,10 @@ public class DefaultVersionFilterContextTest
     @Test(expected = NoSuchElementException.class)
     public void nextBeyondEnd()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         iterator.next();
@@ -107,10 +105,10 @@ public class DefaultVersionFilterContextTest
     @Test
     public void removeOneOfOne()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         iterator.next();
@@ -122,11 +120,11 @@ public class DefaultVersionFilterContextTest
     @Test
     public void removeOneOfTwo()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
         result.addVersion( new TestVersion( "2.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context =
+                new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         iterator.next();
@@ -138,33 +136,16 @@ public class DefaultVersionFilterContextTest
     @Test
     public void removeOneOfThree()
     {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
         VersionRangeResult result = new VersionRangeResult( new VersionRangeRequest() );
         result.addVersion( new TestVersion( "1.0" ) );
         result.addVersion( new TestVersion( "2.0" ) );
         result.addVersion( new TestVersion( "3.0" ) );
-        context.set( FOO_DEPENDENCY, result );
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession(), FOO_DEPENDENCY, result );
 
         Iterator<Version> iterator = context.iterator();
         iterator.next();
         iterator.remove();
 
         assertEquals( Arrays.asList( new TestVersion( "2.0" ), new TestVersion( "3.0" ) ), context.get() );
-    }
-
-    @Test
-    public void setTwice()
-    {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext( new DefaultRepositorySystemSession() );
-        VersionRangeResult fooResult = new VersionRangeResult( new VersionRangeRequest() );
-        fooResult.addVersion( new TestVersion( "1.0" ) );
-        context.set( FOO_DEPENDENCY, fooResult );
-
-        VersionRangeResult barResult = new VersionRangeResult( new VersionRangeRequest() );
-        barResult.addVersion( new TestVersion( "1.0" ) );
-        barResult.addVersion( new TestVersion( "2.0" ) );
-        context.set( BAR_DEPENDENCY, barResult );
-
-        assertEquals( Arrays.asList( new TestVersion( "1.0" ), new TestVersion( "2.0" ) ), context.get() );
     }
 }


### PR DESCRIPTION
Updates `DefaultDependencyCollector` to process descriptors concurrently.

Updated implementation does breadth-first traversal of the dependency graph and processes each dependency in a separate thread. 
Order of the children nodes then restored to match order in descriptor of parent.

By default uses 5 threads, which can be changed using either `maven.descriptor.threads` or `maven.artifact.threads` property.

All the unit and integration tests are green. The change was also tested locally on a reasonable codebase (~1100 modules with lots dependencies) with 24 modules processed concurrently (-T1C).

**Important note**: a few times out of dosens of tests I observed an exception that seems to be related to the change (stack trace attached), however I couldn't really piece it together how it's possible, so ideas are welcome. 
<details><summary>Stack Trace</summary>
<p>

```java
[ERROR] Failed to execute goal on project project-name: Could not resolve dependencies for project group-id:project-name:jar:2.16.1-SNAPSHOT: Failed to collect dependencies at dep-group-id:dep-art-id:jar:v2.9.0: Failed to read artifact descriptor for dep-group-id:dep-art-id:jar:v2.9.0: Could not transfer artifact dep-group-id:dep-art-id:pom:v2.9.0 from/to repo-name (https://private.nexus.url.com/repository/maven-public): /path/to/local_repo/v2.9.0/dep-art-id-v2.9.0.pom.part (No such file or directory) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project project-name: Could not resolve dependencies for project group-id:project-name:jar:2.16.1-SNAPSHOT: Failed to collect dependencies at dep-group-id:dep-art-id:jar:v2.9.0
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:269)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:147)
    at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:248)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:202)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.apache.maven.project.DependencyResolutionException: Could not resolve dependencies for project group-id:project-name:jar:2.16.1-SNAPSHOT: Failed to collect dependencies at dep-group-id:dep-art-id:jar:v2.9.0
    at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve (DefaultProjectDependenciesResolver.java:179)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:243)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:147)
    at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:248)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:202)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.eclipse.aether.collection.DependencyCollectionException: Failed to collect dependencies at dep-group-id:dep-art-id:jar:v2.9.0
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.collectDependencies (DefaultDependencyCollector.java:299)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.collectDependencies (DefaultRepositorySystem.java:284)
    at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve (DefaultProjectDependenciesResolver.java:170)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:243)
    at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:147)
    at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:248)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:202)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.eclipse.aether.resolution.ArtifactDescriptorException: Failed to read artifact descriptor for dep-group-id:dep-art-id:jar:v2.9.0
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom (DefaultArtifactDescriptorReader.java:259)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor (DefaultArtifactDescriptorReader.java:175)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.resolveCachedArtifactDescriptor (DefaultDependencyCollector.java:617)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.getArtifactDescriptorResult (DefaultDependencyCollector.java:602)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.processDependency (DefaultDependencyCollector.java:491)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.access$000 (DefaultDependencyCollector.java:87)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector$1.run (DefaultDependencyCollector.java:395)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: Could not transfer artifact dep-group-id:dep-art-id:pom:v2.9.0 from/to repo-name (https://private.nexus.url.com/repository/maven-public): /path/to/local_repo/v2.9.0/dep-art-id-v2.9.0.pom.part (No such file or directory)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:425)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:229)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:207)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom (DefaultArtifactDescriptorReader.java:244)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor (DefaultArtifactDescriptorReader.java:175)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.resolveCachedArtifactDescriptor (DefaultDependencyCollector.java:617)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.getArtifactDescriptorResult (DefaultDependencyCollector.java:602)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.processDependency (DefaultDependencyCollector.java:491)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.access$000 (DefaultDependencyCollector.java:87)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector$1.run (DefaultDependencyCollector.java:395)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact dep-group-id:dep-art-id:pom:v2.9.0 from/to repo-name (https://private.nexus.url.com/repository/maven-public): /path/to/local_repo/v2.9.0/dep-art-id-v2.9.0.pom.part (No such file or directory)
    at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed (ArtifactTransportListener.java:52)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run (BasicRepositoryConnector.java:369)
    at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run (RunnableErrorForwarder.java:75)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute (BasicRepositoryConnector.java:628)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get (BasicRepositoryConnector.java:262)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads (DefaultArtifactResolver.java:514)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:402)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:229)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:207)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom (DefaultArtifactDescriptorReader.java:244)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor (DefaultArtifactDescriptorReader.java:175)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.resolveCachedArtifactDescriptor (DefaultDependencyCollector.java:617)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.getArtifactDescriptorResult (DefaultDependencyCollector.java:602)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.processDependency (DefaultDependencyCollector.java:491)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.access$000 (DefaultDependencyCollector.java:87)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector$1.run (DefaultDependencyCollector.java:395)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: java.io.FileNotFoundException: /path/to/local_repo/v2.9.0/dep-art-id-v2.9.0.pom.part (No such file or directory)
    at java.io.FileInputStream.open0 (Native Method)
    at java.io.FileInputStream.open (FileInputStream.java:216)
    at java.io.FileInputStream.<init> (FileInputStream.java:157)
    at org.eclipse.aether.internal.impl.DefaultFileProcessor.copy (DefaultFileProcessor.java:163)
    at org.eclipse.aether.internal.impl.DefaultFileProcessor.copy (DefaultFileProcessor.java:151)
    at org.eclipse.aether.internal.impl.DefaultFileProcessor.move (DefaultFileProcessor.java:252)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask (BasicRepositoryConnector.java:482)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run (BasicRepositoryConnector.java:364)
    at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run (RunnableErrorForwarder.java:75)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute (BasicRepositoryConnector.java:628)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get (BasicRepositoryConnector.java:262)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads (DefaultArtifactResolver.java:514)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:402)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:229)
    at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:207)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom (DefaultArtifactDescriptorReader.java:244)
    at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor (DefaultArtifactDescriptorReader.java:175)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.resolveCachedArtifactDescriptor (DefaultDependencyCollector.java:617)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.getArtifactDescriptorResult (DefaultDependencyCollector.java:602)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.processDependency (DefaultDependencyCollector.java:491)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.access$000 (DefaultDependencyCollector.java:87)
    at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector$1.run (DefaultDependencyCollector.java:395)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)

```

</p>
</details>

- Reviewing individual commits might be easier.
- Some unit tests will be added if there are no objections WRT overall approach.