### PR TITLE
[1.6.x][MRESOLVER-235] Fix dependency management issue

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollectorTest.java
@@ -643,4 +643,32 @@ public class DefaultDependencyCollectorTest
 
     }
 
+    @Test
+    public void testMng7003()
+            throws Exception
+    {
+        session.setDependencyManager(new ClassicDependencyManager());
+        {
+            CollectRequest request = new CollectRequest().setRoot(newDep("mng7003:module:1"));
+            CollectResult result = collector.collectDependencies(session, request);
+            DependencyNode root = result.getRoot();
+            DependencyNode api = path(root, 0, 0);
+            assertEquals("1.7", api.getArtifact().getBaseVersion());
+        }
+        {
+            CollectRequest request = new CollectRequest().setRoot(newDep("mng7003:usage:1"));
+            CollectResult result = collector.collectDependencies(session, request);
+            DependencyNode root = result.getRoot();
+            DependencyNode api = path(root, 0, 0, 0);
+            assertEquals("1.7", api.getArtifact().getBaseVersion());
+        }
+        {
+            CollectRequest request = new CollectRequest().setRoot(newDep("mng7003:usage:2"));
+            CollectResult result = collector.collectDependencies(session, request);
+            DependencyNode root = result.getRoot();
+            DependencyNode api = path(root, 0, 0, 0);
+            assertEquals("1.9", api.getArtifact().getBaseVersion());
+        }
+    }
+
 }

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_a_0.1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_a_0.1.ini
@@ -1,0 +1,8 @@
+[dependencies]
+mng4720:b:ext:0.1
+mng4720:c:ext:0.1
+-mng4720:void
+
+[manageddependencies]
+mng4720:c:ext:0.1
+-mng4720:d

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_b_0.1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_b_0.1.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_c_0.1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_c_0.1.ini
@@ -1,0 +1,2 @@
+[dependencies]
+mng4720:d:ext:0.1

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_d_0.1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_d_0.1.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_test_0.1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng4720_test_0.1.ini
@@ -1,0 +1,7 @@
+[dependencies]
+mng4720:a:ext:0.1
+-mng4720:void
+
+[manageddependencies]
+mng4720:a:ext:0.1
+-mng4720:b

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.7.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.7.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.8.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.8.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.9.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_api_1.9.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_impl_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_impl_1.ini
@@ -1,0 +1,2 @@
+[dependencies]
+mng7003:api:jar:1.8

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_module_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_module_1.ini
@@ -1,0 +1,5 @@
+[dependencies]
+mng7003:impl:jar:1
+
+[manageddependencies]
+mng7003:api:jar:1.7

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_usage_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_usage_1.ini
@@ -1,0 +1,3 @@
+[dependencies]
+mng7003:module:jar:1
+

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_usage_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/mng7003_usage_2.ini
@@ -1,0 +1,5 @@
+[dependencies]
+mng7003:module:jar:1
+
+[manageddependencies]
+mng7003:api:jar:1.9

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -80,6 +80,12 @@ public final class ClassicDependencyManager
 
     public DependencyManager deriveChildManager( DependencyCollectionContext context )
     {
+        if ( depth == 1 )
+        {
+            return new ClassicDependencyManager( depth + 1, managedVersions, managedScopes, managedOptionals,
+                                                 managedLocalPaths, managedExclusions );
+        }
+
         Map<Object, String> managedVersions = this.managedVersions;
         Map<Object, String> managedScopes = this.managedScopes;
         Map<Object, Boolean> managedOptionals = this.managedOptionals;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -80,12 +80,6 @@ public final class ClassicDependencyManager
 
     public DependencyManager deriveChildManager( DependencyCollectionContext context )
     {
-        if ( depth == 1 )
-        {
-            return new ClassicDependencyManager( depth + 1, managedVersions, managedScopes, managedOptionals,
-                                                 managedLocalPaths, managedExclusions );
-        }
-
         Map<Object, String> managedVersions = this.managedVersions;
         Map<Object, String> managedScopes = this.managedScopes;
         Map<Object, Boolean> managedOptionals = this.managedOptionals;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -80,16 +80,6 @@ public final class ClassicDependencyManager
 
     public DependencyManager deriveChildManager( DependencyCollectionContext context )
     {
-        if ( depth >= 2 )
-        {
-            return this;
-        }
-        else if ( depth == 1 )
-        {
-            return new ClassicDependencyManager( depth + 1, managedVersions, managedScopes, managedOptionals,
-                                                 managedLocalPaths, managedExclusions );
-        }
-
         Map<Object, String> managedVersions = this.managedVersions;
         Map<Object, String> managedScopes = this.managedScopes;
         Map<Object, Boolean> managedOptionals = this.managedOptionals;


### PR DESCRIPTION
This PR provides a fix for MRESOLVER-235 / MNG-7003.
However, the fix breaks two ITs: mng4720 and mng4396.
For mng4720, so core of the IT is not broken, but as specifically commented in the IT see https://github.com/apache/maven-integration-testing/blob/master/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4720DependencyManagementExclusionMergeTest.java#L70, one of the dependency is not included anymore.
The PR contains unit tests that replicate the ITs for mng4720 and for MNG-7003 (available at https://github.com/gnodet/maven-integration-testing/tree/MNG-7003).  I'm not sure there's any way to fix both at the same time.