### PR TITLE
[MRESOLVER-239] Update dependencies

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
@@ -37,12 +37,8 @@
   </description>
 
   <prerequisites>
-    <maven>3.5.0</maven>
+    <maven>${mavenVersion}</maven>
   </prerequisites>
-
-  <properties>
-    <mavenVersion>3.5.0</mavenVersion>
-  </properties>
 
   <dependencies>
     <dependency>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -38,7 +38,6 @@
 
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.demo.snippets</Automatic-Module-Name>
-    <mavenVersion>3.8.3</mavenVersion>
   </properties>
 
   <dependencyManagement>

--- a/maven-resolver-demos/pom.xml
+++ b/maven-resolver-demos/pom.xml
@@ -36,6 +36,10 @@
     Maven Artifact Resolver demos, showing concrete code to use Maven Artifact Resolver with Maven repositories.
   </description>
 
+  <properties>
+    <mavenVersion>3.8.4</mavenVersion>
+  </properties>
+
   <modules>
     <module>maven-resolver-demo-snippets</module>
     <module>maven-resolver-demo-maven-plugin</module>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>4.1.2</version>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>3.16.8</version>
+      <version>3.15.6</version>
       <exclusions>
         <exclusion>
           <groupId>javax.cache</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>3.15.6</version>
+      <version>3.16.8</version>
       <exclusions>
         <exclusion>
           <groupId>javax.cache</groupId>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.14</version>
+      <version>4.4.15</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>3.4.3</version>
+      <version>3.5.1</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <guiceVersion>4.2.3</guiceVersion>
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
-    <slf4jVersion>1.7.32</slf4jVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
     <project.build.outputTimestamp>2021-12-19T18:51:20Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
Maven Resolver demos both used Maven but declared different versions, lift to parent module maven version. Also, update the dependencies where applicable.

Changes:

* update demos Maven version in demos to 3.8.4
* update resolver impl Commons Lang to 3.12.0 (was 3.8.1)
* update resolver named locks Hazelcast to 5.0.1 (was 4.1.2)
* update transport http httpCore to 4.4.15 (was 4.4.14)
* update transport wagon Wagon to 3.5.1 (was 3.4.3)
* update slf4j (globally) to 1.7.36 (was 1.7.32)

---

https://issues.apache.org/jira/browse/MRESOLVER-239