### PR TITLE
[MRESOLVER-241] Resolver checksum calculation should be driven by layout

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
@@ -36,7 +36,6 @@ import java.util.Set;
 
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithm;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
-import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
 
 import static java.util.Objects.requireNonNull;
 
@@ -92,25 +91,25 @@ final class ChecksumCalculator
     private final File targetFile;
 
     public static ChecksumCalculator newInstance( File targetFile,
-                                                  Collection<RepositoryLayout.ChecksumLocation> checksumLocations )
+                                                  Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
     {
-        if ( checksumLocations == null || checksumLocations.isEmpty() )
+        if ( checksumAlgorithmFactories == null || checksumAlgorithmFactories.isEmpty() )
         {
             return null;
         }
-        return new ChecksumCalculator( targetFile, checksumLocations );
+        return new ChecksumCalculator( targetFile, checksumAlgorithmFactories );
     }
 
     private ChecksumCalculator( File targetFile,
-                                Collection<RepositoryLayout.ChecksumLocation> checksumLocations )
+                                Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
     {
         this.checksums = new ArrayList<>();
         Set<String> algos = new HashSet<>();
-        for ( RepositoryLayout.ChecksumLocation checksumLocation : checksumLocations )
+        for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithmFactories )
         {
-            if ( algos.add( checksumLocation.getChecksumAlgorithmFactory().getName() ) )
+            if ( algos.add( checksumAlgorithmFactory.getName() ) )
             {
-                this.checksums.add( new Checksum( checksumLocation.getChecksumAlgorithmFactory() ) );
+                this.checksums.add( new Checksum( checksumAlgorithmFactory ) );
             }
         }
         this.targetFile = targetFile;

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
@@ -59,6 +59,8 @@ final class ChecksumValidator
 
     private final File dataFile;
 
+    private final Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories;
+
     private final Collection<File> tempFiles;
 
     private final FileProcessor fileProcessor;
@@ -74,6 +76,7 @@ final class ChecksumValidator
     private final Map<File, Object> checksumFiles;
 
     ChecksumValidator( File dataFile,
+                       Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
                        FileProcessor fileProcessor,
                        ChecksumFetcher checksumFetcher,
                        ChecksumPolicy checksumPolicy,
@@ -81,6 +84,7 @@ final class ChecksumValidator
                        Collection<ChecksumLocation> checksumLocations )
     {
         this.dataFile = dataFile;
+        this.checksumAlgorithmFactories = checksumAlgorithmFactories;
         this.tempFiles = new HashSet<>();
         this.fileProcessor = fileProcessor;
         this.checksumFetcher = checksumFetcher;
@@ -94,7 +98,7 @@ final class ChecksumValidator
     {
         if ( checksumPolicy != null )
         {
-            return ChecksumCalculator.newInstance( targetFile, checksumLocations );
+            return ChecksumCalculator.newInstance( targetFile, checksumAlgorithmFactories );
         }
         return null;
     }
@@ -134,27 +138,26 @@ final class ChecksumValidator
             {
                 continue;
             }
-            ChecksumLocation checksumLocation = checksumLocations.stream()
-                    .filter( a -> a.getChecksumAlgorithmFactory().getName().equals( algo ) )
+            ChecksumAlgorithmFactory checksumAlgorithmFactory = checksumAlgorithmFactories.stream()
+                    .filter( a -> a.getName().equals( algo ) )
                     .findFirst()
                     .orElse( null );
-            if ( checksumLocation == null )
+            if ( checksumAlgorithmFactory == null )
             {
                 continue;
             }
 
             String actual = String.valueOf( calculated );
             String expected = entry.getValue().toString();
-            ChecksumAlgorithmFactory factory = checksumLocation.getChecksumAlgorithmFactory();
-            checksumFiles.put( getChecksumFile( factory ), expected );
+            checksumFiles.put( getChecksumFile( checksumAlgorithmFactory ), expected );
 
             if ( !isEqualChecksum( expected, actual ) )
             {
-                checksumPolicy.onChecksumMismatch( factory.getName(), kind,
+                checksumPolicy.onChecksumMismatch( checksumAlgorithmFactory.getName(), kind,
                     new ChecksumFailureException( expected, kind.name(), actual )
                 );
             }
-            else if ( checksumPolicy.onChecksumMatch( factory.getName(), kind ) )
+            else if ( checksumPolicy.onChecksumMatch( checksumAlgorithmFactory.getName(), kind ) )
             {
                 return true;
             }

--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumCalculatorTest.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumCalculatorTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -35,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.aether.internal.test.util.TestFileUtils;
-import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,10 +47,10 @@ public class ChecksumCalculatorTest
 
     private ChecksumCalculator newCalculator( String... algos )
     {
-        List<RepositoryLayout.ChecksumLocation> checksumLocations = new ArrayList<>();
+        List<ChecksumAlgorithmFactory> checksumLocations = new ArrayList<>();
         for ( String algo : algos )
         {
-            checksumLocations.add( new RepositoryLayout.ChecksumLocation( URI.create( "irrelevant" ), selector.select( algo ) ) );
+            checksumLocations.add( selector.select( algo ) );
         }
         return ChecksumCalculator.newInstance( file, checksumLocations );
     }


### PR DESCRIPTION
Refactor checksum calculator and validator to rely on layout
provided checksums (layout always had these), and not by the presence
(or absence) or checksum locations.

Checksum locations should drive only the checksum provision from
remote, and nothing else.