### PR TITLE
Example of Artifact Transform API change

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
@@ -36,7 +36,7 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
-import org.eclipse.aether.transform.FileTransformerManager;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 
 /**
  * A special repository system session to enable decorating or proxying another session. To do so, clients have to
@@ -213,7 +213,7 @@ public abstract class AbstractForwardingRepositorySystemSession
     }
     
     @Override
-    public FileTransformerManager getFileTransformerManager()
+    public ArtifactTransformerManager getFileTransformerManager()
     {
         return getSession().getFileTransformerManager();
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -47,8 +47,8 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
-import org.eclipse.aether.transform.FileTransformer;
-import org.eclipse.aether.transform.FileTransformerManager;
+import org.eclipse.aether.transform.ArtifactTransformer;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 
 /**
  * A simple repository system session.
@@ -78,7 +78,7 @@ public final class DefaultRepositorySystemSession
 
     private LocalRepositoryManager localRepositoryManager;
 
-    private FileTransformerManager fileTransformerManager;
+    private ArtifactTransformerManager fileTransformerManager;
 
     private WorkspaceReader workspaceReader;
 
@@ -329,12 +329,12 @@ public final class DefaultRepositorySystemSession
     }
 
     @Override
-    public FileTransformerManager getFileTransformerManager()
+    public ArtifactTransformerManager getFileTransformerManager()
     {
         return fileTransformerManager;
     }
 
-    public DefaultRepositorySystemSession setFileTransformerManager( FileTransformerManager fileTransformerManager )
+    public DefaultRepositorySystemSession setFileTransformerManager( ArtifactTransformerManager fileTransformerManager )
     {
         failIfReadOnly();
         this.fileTransformerManager = fileTransformerManager;
@@ -862,12 +862,12 @@ public final class DefaultRepositorySystemSession
 
     }
 
-    static final class NullFileTransformerManager implements FileTransformerManager
+    static final class NullFileTransformerManager implements ArtifactTransformerManager
     {
-        public static final FileTransformerManager INSTANCE = new NullFileTransformerManager();
+        public static final ArtifactTransformerManager INSTANCE = new NullFileTransformerManager();
 
         @Override
-        public Collection<FileTransformer> getTransformersForArtifact( Artifact artifact )
+        public Collection<ArtifactTransformer> getTransformersForArtifact( Artifact artifact )
         {
             return Collections.emptyList();
         }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -37,7 +37,7 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
-import org.eclipse.aether.transform.FileTransformerManager;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 
 /**
  * Defines settings and components that control the repository system. Once initialized, the session object itself is
@@ -266,6 +266,6 @@ public interface RepositorySystemSession
      * 
      * @return the manager, never {@code null}
      */
-    FileTransformerManager getFileTransformerManager();
+    ArtifactTransformerManager getFileTransformerManager();
 
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformer.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformer.java
@@ -1,0 +1,41 @@
+package org.eclipse.aether.transform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * Can transform an artifact just before installing/deploying
+ * 
+ * @author Robert Scholte
+ * @since 1.3.0
+ */
+public interface ArtifactTransformer
+{
+    /**
+     * Transform the target location  
+     * 
+     * @param artifact the original artifact
+     * @return the transformed artifact
+     */
+    TransformedArtifact transformArtifact( Artifact artifact ) throws TransformException, IOException;
+}

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformerManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformerManager.java
@@ -19,36 +19,27 @@ package org.eclipse.aether.transform;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.Collection;
 
 import org.eclipse.aether.artifact.Artifact;
 
 /**
- * Can transform a file while installing/deploying
+ * Manager the FileTransformers 
  * 
  * @author Robert Scholte
  * @since 1.3.0
  */
-public interface FileTransformer
+public interface ArtifactTransformerManager
 {
     /**
-     * Transform the target location  
-     * 
-     * @param artifact the original artifact
-     * @return the transformed artifact
+     * <p>
+     * All transformers for this specific artifact. Be aware that if you want to create additional files, but also want
+     * to the original to be deployed, you must add an explicit transformer for that file too (one that doesn't
+     * transform the artifact and data).
+     * </p>
+     *
+     * @param artifact the artifact
+     * @return a collection of FileTransformers to apply on the artifact, never {@code null}
      */
-    Artifact transformArtifact( Artifact artifact );
-    
-    /**
-     * Transform the data
-     * 
-     * @param file the file with the original data
-     * @return the transformed data
-     * @throws IOException If an I/O error occurred
-     * @throws TransformException If the file could not be transformed
-     */
-    InputStream transformData( File file )
-        throws IOException, TransformException;
+    Collection<ArtifactTransformer> getTransformersForArtifact( Artifact artifact );
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformedArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformedArtifact.java
@@ -19,31 +19,20 @@ package org.eclipse.aether.transform;
  * under the License.
  */
 
-import java.util.Collection;
+import java.io.Closeable;
 
 import org.eclipse.aether.artifact.Artifact;
 
 /**
- * Manager the FileTransformers 
+ * The transformed artifact. This instance is handled by resolver as a resource, {@link #close()} is called immediately
+ * after install/deploy happened, allowing this instance to perform any kind of cleanup.
  * 
- * @author Robert Scholte
- * @since 1.3.0
+ * @since TBD
  */
-public interface FileTransformerManager
+public interface TransformedArtifact extends Closeable
 {
     /**
-     * <p>
-     * All transformers for this specific artifact. Be aware that if you want to create additional files, but also want
-     * to the original to be deployed, you must add an explicit transformer for that file too (one that doesn't
-     * transform the artifact and data).
-     * </p>
-     * 
-     * <p><strong>IMPORTANT</strong> When using a fileTransformer, the content of the file is stored in memory to ensure
-     * that file content and checksums stay in sync!
-     * </p>
-     * 
-     * @param artifact the artifact
-     * @return a collection of FileTransformers to apply on the artifact, never {@code null}
+     * Returns the transformed artifact, never {@code null}.
      */
-    Collection<FileTransformer> getTransformersForArtifact( Artifact artifact );
+    Artifact getArtifact();
 }

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -21,10 +21,8 @@ package org.eclipse.aether.connector.basic;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,7 +63,6 @@ import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transfer.TransferResource;
-import org.eclipse.aether.transform.FileTransformer;
 import org.eclipse.aether.util.ConfigUtils;
 import org.eclipse.aether.util.concurrency.RunnableErrorForwarder;
 import org.eclipse.aether.util.concurrency.WorkerThreadFactory;
@@ -312,8 +309,7 @@ final class BasicRepositoryConnector
             List<RepositoryLayout.ChecksumLocation> checksumLocations =
                     layout.getChecksumLocations( transfer.getArtifact(), true, location );
 
-            Runnable task = new PutTaskRunner( location, transfer.getFile(), transfer.getFileTransformer(),
-                    checksumLocations, listener );
+            Runnable task = new PutTaskRunner( location, transfer.getFile(), checksumLocations, listener );
             task.run();
         }
 
@@ -537,33 +533,13 @@ final class BasicRepositoryConnector
 
         private final File file;
 
-        private final FileTransformer fileTransformer;
-
         private final Collection<RepositoryLayout.ChecksumLocation> checksumLocations;
 
         PutTaskRunner( URI path, File file, List<RepositoryLayout.ChecksumLocation> checksumLocations,
                        TransferTransportListener<?> listener )
         {
-            this( path, file, null, checksumLocations, listener );
-        }
-
-        /**
-         * <strong>IMPORTANT</strong> When using a fileTransformer, the content of the file is stored in memory to
-         * ensure that file content and checksums stay in sync!
-         *
-         * @param path
-         * @param file
-         * @param fileTransformer
-         * @param checksumLocations
-         * @param listener
-         */
-        PutTaskRunner( URI path, File file, FileTransformer fileTransformer,
-                       List<RepositoryLayout.ChecksumLocation> checksumLocations,
-                       TransferTransportListener<?> listener )
-        {
             super( path, listener );
             this.file = requireNonNull( file, "source file cannot be null" );
-            this.fileTransformer = fileTransformer;
             this.checksumLocations = safe( checksumLocations );
         }
 
@@ -572,29 +548,8 @@ final class BasicRepositoryConnector
         protected void runTask()
                 throws Exception
         {
-            if ( fileTransformer != null )
-            {
-                // transform data once to byte array, ensure constant data for checksum
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                byte[] buffer = new byte[1024];
-
-                try ( InputStream transformData = fileTransformer.transformData( file ) )
-                {
-                    for ( int read; ( read = transformData.read( buffer, 0, buffer.length ) ) != -1; )
-                    {
-                        baos.write( buffer, 0, read );
-                    }
-                }
-
-                byte[] bytes = baos.toByteArray();
-                transporter.put( new PutTask( path ).setDataBytes( bytes ).setListener( listener ) );
-                uploadChecksums( file, bytes );
-            }
-            else
-            {
-                transporter.put( new PutTask( path ).setDataFile( file ).setListener( listener ) );
-                uploadChecksums( file, null );
-            }
+            transporter.put( new PutTask( path ).setDataFile( file ).setListener( listener ) );
+            uploadChecksums( file, null );
         }
 
         /**

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
@@ -25,11 +25,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -58,8 +55,6 @@ import org.eclipse.aether.spi.connector.MetadataDownload;
 import org.eclipse.aether.spi.connector.MetadataUpload;
 import org.eclipse.aether.spi.connector.RepositoryConnector;
 import org.eclipse.aether.transfer.MetadataNotFoundException;
-import org.eclipse.aether.transform.FileTransformer;
-import org.eclipse.aether.util.artifact.SubArtifact;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -391,36 +386,4 @@ public class DefaultDeployerTest
         TestFileUtils.readProps( metadataFile, props );
         assertNull( props.toString(), props.get( "old" ) );
     }
-
-    @Test
-    public void testFileTransformer() throws Exception
-    {
-        final Artifact transformedArtifact = new SubArtifact( artifact, null, "raj" );
-        FileTransformer transformer = new FileTransformer()
-        {
-            @Override
-            public InputStream transformData( File file )
-            {
-                return new ByteArrayInputStream( "transformed data".getBytes( StandardCharsets.UTF_8 ) );
-            }
-            
-            @Override
-            public Artifact transformArtifact( Artifact artifact )
-            {
-                return transformedArtifact;
-            }
-        };
-        
-        StubFileTransformerManager fileTransformerManager = new StubFileTransformerManager();
-        fileTransformerManager.addFileTransformer( "jar", transformer );
-        session.setFileTransformerManager( fileTransformerManager );
-        
-        request = new DeployRequest();
-        request.addArtifact( artifact );
-        deployer.deploy( session, request );
-        
-        Artifact putArtifact = connector.getActualArtifactPutRequests().get( 0 );
-        assertEquals( transformedArtifact, putArtifact );
-    }
-
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -26,13 +26,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -50,8 +45,6 @@ import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.Metadata.Nature;
-import org.eclipse.aether.transform.FileTransformer;
-import org.eclipse.aether.util.artifact.SubArtifact;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -419,44 +412,5 @@ public class DefaultInstallerTest
 
         assertEquals( "artifact timestamp was not set to src file", artifact.getFile().lastModified(),
                       localArtifactFile.lastModified() );
-    }
-    
-    @Test
-    public void testFileTransformer() throws Exception
-    {
-        final Artifact transformedArtifact = new SubArtifact( artifact, null, "raj" );
-        FileTransformer transformer = new FileTransformer()
-        {
-            @Override
-            public InputStream transformData( File file )
-            {
-                return new ByteArrayInputStream( "transformed data".getBytes( StandardCharsets.UTF_8 ) );
-            }
-            
-            @Override
-            public Artifact transformArtifact( Artifact artifact )
-            {
-                return transformedArtifact;
-            }
-        };
-        
-        StubFileTransformerManager fileTransformerManager = new StubFileTransformerManager();
-        fileTransformerManager.addFileTransformer( "jar", transformer );
-        session.setFileTransformerManager( fileTransformerManager );
-        
-        request = new InstallRequest();
-        request.addArtifact( artifact );
-        installer.install( session, request );
-        
-        assertFalse( localArtifactFile.exists() );
-        
-        String transformedArtifactPath = session.getLocalRepositoryManager().getPathForLocalArtifact( transformedArtifact );
-        File transformedArtifactFile = new File( session.getLocalRepository().getBasedir(), transformedArtifactPath );
-        assertTrue( transformedArtifactFile.exists() );
-        
-        try ( BufferedReader r = new BufferedReader( new FileReader( transformedArtifactFile ) ) )
-        {
-            assertEquals( "transformed data", r.readLine() );
-        }
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubFileTransformerManager.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubFileTransformerManager.java
@@ -25,24 +25,24 @@ import java.util.HashSet;
 import java.util.Map;
 
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.transform.FileTransformer;
-import org.eclipse.aether.transform.FileTransformerManager;
+import org.eclipse.aether.transform.ArtifactTransformer;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 
-public class StubFileTransformerManager implements FileTransformerManager
+public class StubFileTransformerManager implements ArtifactTransformerManager
 {
-    private Map<String, Collection<FileTransformer>> fileTransformers = new HashMap<>();
+    private Map<String, Collection<ArtifactTransformer>> fileTransformers = new HashMap<>();
     
     @Override
-    public Collection<FileTransformer> getTransformersForArtifact( Artifact artifact )
+    public Collection<ArtifactTransformer> getTransformersForArtifact( Artifact artifact )
     {
         return fileTransformers.get( artifact.getExtension() );
     }
     
-    public void addFileTransformer( String extension, FileTransformer fileTransformer )
+    public void addFileTransformer( String extension, ArtifactTransformer fileTransformer )
     {
         if ( !fileTransformers.containsKey( extension ) )
         {
-            fileTransformers.put( extension, new HashSet<FileTransformer>() );
+            fileTransformers.put( extension, new HashSet<ArtifactTransformer>() );
         }
         fileTransformers.get( extension ).add( fileTransformer );
     }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactUpload.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactUpload.java
@@ -25,7 +25,6 @@ import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.transfer.ArtifactTransferException;
 import org.eclipse.aether.transfer.TransferListener;
-import org.eclipse.aether.transform.FileTransformer;
 
 /**
  * An upload of an artifact to a remote repository. A repository connector processing this upload has to use
@@ -34,8 +33,6 @@ import org.eclipse.aether.transform.FileTransformer;
 public final class ArtifactUpload
     extends ArtifactTransfer
 {
-    private FileTransformer fileTransformer;
-
     /**
      * Creates a new uninitialized upload.
      */
@@ -54,24 +51,6 @@ public final class ArtifactUpload
     {
         setArtifact( artifact );
         setFile( file );
-    }
-
-    /**
-     * <p>Creates a new upload with the specified properties.</p> 
-     * 
-     * <p><strong>IMPORTANT</strong> When using a fileTransformer, the
-     * content of the file is stored in memory to ensure that file content and checksums stay in sync!
-     * </p>
-     * 
-     * @param artifact The artifact to upload, may be {@code null}.
-     * @param file The local file to upload the artifact from, may be {@code null}.
-     * @param fileTransformer The file transformer, may be {@code null}.
-     */
-    public ArtifactUpload( Artifact artifact, File file, FileTransformer fileTransformer )
-    {
-        setArtifact( artifact );
-        setFile( file );
-        setFileTransformer( fileTransformer );
     }
 
     @Override
@@ -109,29 +88,10 @@ public final class ArtifactUpload
         return this;
     }
     
-    public ArtifactUpload setFileTransformer( FileTransformer fileTransformer )
-    {
-        this.fileTransformer = fileTransformer;
-        return this;
-    }
-    
-    public FileTransformer getFileTransformer()
-    {
-        return fileTransformer;
-    }
-
     @Override
     public String toString()
     {
-        if ( getFileTransformer() != null )
-        {
-            return getArtifact() + " >>> " + getFileTransformer().transformArtifact( getArtifact() )
-                + " - " + getFile();
-        }
-        else
-        {
-            return getArtifact() + " - " + getFile();
-        }
+        return getArtifact() + " - " + getFile();
     }
 
 }


### PR DESCRIPTION
From resolver's perspective nothing changes (no extra IO, in
memory copy and so on), it is just the matter that
trasformation result is handled as resource (closed once not needed).
It allows implementor to implement whatever cleanup is needed
from their side.

This is just an example, renaming did not fully happened (members are still named fileTransformer)