### PR TITLE
[MRESOLVER-244] Deprecate FileTransformer API

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/FileTransformer.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/FileTransformer.java
@@ -30,7 +30,10 @@ import org.eclipse.aether.artifact.Artifact;
  * 
  * @author Robert Scholte
  * @since 1.3.0
+ * @deprecated Without any direct replacement for now. This API is OOM-prone, and also lacks a lot of context about
+ * transforming.
  */
+@Deprecated
 public interface FileTransformer
 {
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/FileTransformerManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/FileTransformerManager.java
@@ -28,7 +28,10 @@ import org.eclipse.aether.artifact.Artifact;
  * 
  * @author Robert Scholte
  * @since 1.3.0
+ * @deprecated Without any direct replacement for now. This API is OOM-prone, and also lacks a lot of context about
+ * transforming.
  */
+@Deprecated
 public interface FileTransformerManager
 {
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformException.java
@@ -21,7 +21,11 @@ package org.eclipse.aether.transform;
 
 /**
  * Thrown when transformation failed.
+ *
+ * @deprecated Without any direct replacement for now. This API is OOM-prone, and also lacks a lot of context about
+ * transforming.
  */
+@Deprecated
 public class TransformException
     extends Exception
 {


### PR DESCRIPTION
Deprecate it without replacement for now. Later we can see is replacement needed at all (if Maven API forms, then definitely not).

---

https://issues.apache.org/jira/browse/MRESOLVER-244