### PR TITLE
[MRESOLVER-245] Isolate and update tests

### DIFF
--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -121,17 +121,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <argLine combine.self="append">
-                --add-modules java.se
-                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                --add-opens java.base/java.lang=ALL-UNNAMED
-                --add-opens java.base/java.nio=ALL-UNNAMED
-                --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-                --add-opens java.management/sun.management=ALL-UNNAMED
-                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-              </argLine>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>5.0.1</version>
+      <version>5.0.2</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -121,6 +121,17 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <argLine combine.self="append">
+                --add-modules java.se
+                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                --add-opens java.base/java.lang=ALL-UNNAMED
+                --add-opens java.base/java.nio=ALL-UNNAMED
+                --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                --add-opens java.management/sun.management=ALL-UNNAMED
+                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+              </argLine>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/DirectHazelcastSemaphoreProvider.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/DirectHazelcastSemaphoreProvider.java
@@ -19,17 +19,25 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import org.junit.BeforeClass;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.ISemaphore;
 
-public class HazelcastCPSemaphoreAdapterIT
-        extends NamedLockFactoryAdapterTestSupport
+/**
+ * Direct provider of {@link ISemaphore} instances: it simply uses the passed in lock name to create semaphore name out
+ * of it. This implies, that as many lock names are requested from it, this class will create as many semaphores in
+ * Hazelcast.
+ */
+public class DirectHazelcastSemaphoreProvider extends HazelcastSemaphoreProvider
 {
-
-    @BeforeClass
-    public static void createNamedLockFactory()
+    @Override
+    public ISemaphore acquireSemaphore( HazelcastInstance hazelcastInstance, String name )
     {
-        String clusterName = utils.clusterName( HazelcastCPSemaphoreAdapterIT.class );
-        setNamedLockFactory(
-                new HazelcastCPSemaphoreNamedLockFactory( utils.createMember( clusterName ), true ) );
+        return hazelcastInstance.getCPSubsystem().getSemaphore( NAME_PREFIX + name );
+    }
+
+    @Override
+    public void releaseSemaphore( HazelcastInstance hazelcastInstance, String name, ISemaphore semaphore )
+    {
+        // nothing
     }
 }

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactory.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactory.java
@@ -19,32 +19,37 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import com.hazelcast.core.Hazelcast;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
 /**
- * {@link HazelcastSemaphoreNamedLockFactory} using Hazelcast and {@link
- * com.hazelcast.core.HazelcastInstance#getCPSubsystem()} method to get CP semaphore. For this to work, the Hazelcast
- * cluster the client is connecting to must be CP enabled cluster.
+ * {@link HazelcastSemaphoreNamedLockFactory} using {@link DirectHazelcastSemaphoreProvider} full Hazelcast member.
  */
 @Singleton
 @Named( HazelcastCPSemaphoreNamedLockFactory.NAME )
-public class HazelcastCPSemaphoreNamedLockFactory
-    extends HazelcastSemaphoreNamedLockFactory
+public class HazelcastCPSemaphoreNamedLockFactory extends HazelcastSemaphoreNamedLockFactory
 {
-  public static final String NAME = "semaphore-hazelcast";
+    public static final String NAME = "semaphore-hazelcast";
 
-  @Inject
-  public HazelcastCPSemaphoreNamedLockFactory()
-  {
-    super(
-        Hazelcast.newHazelcastInstance(),
-        ( hazelcastInstance, name ) -> hazelcastInstance.getCPSubsystem().getSemaphore( NAME_PREFIX + name ),
-        false,
-        true
-    );
-  }
+    /**
+     * The default constructor: creates own instance of Hazelcast using standard Hazelcast configuration discovery.
+     */
+    @Inject
+    public HazelcastCPSemaphoreNamedLockFactory()
+    {
+        this( Hazelcast.newHazelcastInstance(), true );
+    }
+
+    /**
+     * Constructor for customization.
+     */
+    public HazelcastCPSemaphoreNamedLockFactory( HazelcastInstance hazelcastInstance,
+                                                 boolean manageHazelcast )
+    {
+        super( hazelcastInstance, manageHazelcast, new DirectHazelcastSemaphoreProvider() );
+    }
 }

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactory.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactory.java
@@ -19,32 +19,38 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import com.hazelcast.client.HazelcastClient;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.core.HazelcastInstance;
+
 /**
- * Provider of {@link HazelcastSemaphoreNamedLockFactory} using Hazelcast Client and {@link
- * com.hazelcast.core.HazelcastInstance#getCPSubsystem()} method to get CP semaphore. For this to work, the Hazelcast
- * cluster the client is connecting to must be CP enabled cluster.
+ * {@link HazelcastSemaphoreNamedLockFactory} using {@link DirectHazelcastSemaphoreProvider} and Hazelcast client. The
+ * client must be configured to connect to some existing cluster (w/ proper configuration applied).
  */
 @Singleton
 @Named( HazelcastClientCPSemaphoreNamedLockFactory.NAME )
-public class HazelcastClientCPSemaphoreNamedLockFactory
-    extends HazelcastSemaphoreNamedLockFactory
+public class HazelcastClientCPSemaphoreNamedLockFactory extends HazelcastSemaphoreNamedLockFactory
 {
-  public static final String NAME = "semaphore-hazelcast-client";
+    public static final String NAME = "semaphore-hazelcast-client";
 
-  @Inject
-  public HazelcastClientCPSemaphoreNamedLockFactory()
-  {
-    super(
-        HazelcastClient.newHazelcastClient(),
-        ( hazelcastInstance, name ) -> hazelcastInstance.getCPSubsystem().getSemaphore( NAME_PREFIX + name ),
-        false,
-        true
-    );
-  }
+    /**
+     * The default constructor: creates own instance of Hazelcast using standard Hazelcast configuration discovery.
+     */
+    @Inject
+    public HazelcastClientCPSemaphoreNamedLockFactory()
+    {
+        this( HazelcastClient.newHazelcastClient(), true );
+    }
+
+    /**
+     * Constructor for customization.
+     */
+    public HazelcastClientCPSemaphoreNamedLockFactory( HazelcastInstance hazelcastInstance,
+                                                       boolean manageHazelcast )
+    {
+        super( hazelcastInstance, manageHazelcast, new DirectHazelcastSemaphoreProvider() );
+    }
 }

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreProvider.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreProvider.java
@@ -19,17 +19,26 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import org.junit.BeforeClass;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.ISemaphore;
 
-public class HazelcastCPSemaphoreAdapterIT
-        extends NamedLockFactoryAdapterTestSupport
+/**
+ * Support class for providers of {@link ISemaphore} instances.
+ */
+public abstract class HazelcastSemaphoreProvider
 {
+    /**
+     * Name prefix recommended using for simpler configuration of Hazelcast.
+     */
+    protected static final String NAME_PREFIX = "mvn:resolver:";
 
-    @BeforeClass
-    public static void createNamedLockFactory()
-    {
-        String clusterName = utils.clusterName( HazelcastCPSemaphoreAdapterIT.class );
-        setNamedLockFactory(
-                new HazelcastCPSemaphoreNamedLockFactory( utils.createMember( clusterName ), true ) );
-    }
+    /**
+     * Invoked when new instance of semaphore needed for given name. must not return {@code null}.
+     */
+    public abstract ISemaphore acquireSemaphore( HazelcastInstance hazelcastInstance, String name );
+
+    /**
+     * Invoked when passed in semaphore associated with passed in name is not to be used anymore.
+     */
+    public abstract void releaseSemaphore( HazelcastInstance hazelcastInstance, String name, ISemaphore semaphore );
 }

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreProvider.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreProvider.java
@@ -30,7 +30,7 @@ public abstract class HazelcastSemaphoreProvider
     /**
      * Name prefix recommended using for simpler configuration of Hazelcast.
      */
-    protected static final String NAME_PREFIX = "mvn:resolver:";
+    protected static final String NAME_PREFIX = "maven:resolver:";
 
     /**
      * Invoked when new instance of semaphore needed for given name. must not return {@code null}.

--- a/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
@@ -29,10 +29,10 @@ Out of the box "hazelcast" (distributed) named lock implementations are the foll
 - `semaphore-hazelcast-client` implemented in `org.eclipse.aether.named.hazelcast.HazelcastClientCPSemaphoreNamedLockFactory`
   This implementation uses Hazelcast Client, so existing Hazelcast cluster to connect to is a requirement.
 
-The semaphore name prefix is `mvn:resolver:` and pre-configuring semaphores in Hazelcast is a must. The Hazelcast
+The semaphore name prefix is `maven:resolver:` and pre-configuring semaphores in Hazelcast is a must. The Hazelcast
 configuration must have the following entry:
 
-- Name prefix: `mvn:resolver:` (use pattern matching configuration)
+- Name prefix: `maven:resolver:` (use pattern matching configuration)
 - JDK compatible: true
 - Permit count: `Integer.MAX_VALUE` (value `2147483647`)
 
@@ -42,7 +42,7 @@ Example Hazelcast XML relevant snippet:
     <cp-subsystem>
         <semaphores>
             <semaphore>
-                <name>mvn:resolver:*</name>
+                <name>maven:resolver:*</name>
                 <jdk-compatible>true</jdk-compatible>
                 <initial-permits>2147483647</initial-permits>
             </semaphore>

--- a/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
@@ -19,40 +19,60 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This module implement named locks using Hazelcast. It provides two implementations, that are distributed and rely on
-Hazelcast 4.x ISemaphores.
+This module implement named locks using Hazelcast. It provides two implementations, using members or clients and
+rely on Hazelcast ISemaphore instances.
 
 Out of the box "hazelcast" (distributed) named lock implementations are the following:
 
-- `semaphore-hazelcast` implemented in `org.eclipse.aether.named.hazelcast.HazelcastCPSemaphoreNamedLockFactory` that uses
-  Hazelcast backed `com.hazelcast.cp.ISemaphore`. Full Hazelcast member is used here.
+- `semaphore-hazelcast` implemented in `org.eclipse.aether.named.hazelcast.HazelcastCPSemaphoreNamedLockFactory`.
+  Full Hazelcast member is used here.
 - `semaphore-hazelcast-client` implemented in `org.eclipse.aether.named.hazelcast.HazelcastClientCPSemaphoreNamedLockFactory`
-  that uses Hazelcast Client backed `com.hazelcast.cp.ISemaphore`. This implementation uses Hazelcast Client, so
-  connection to some existing Hazelcast cluster, and its existence is a requirement.
+  This implementation uses Hazelcast Client, so existing Hazelcast cluster to connect to is a requirement.
+
+The semaphore name prefix is `mvn:resolver:` and pre-configuring semaphores in Hazelcast is a must. The Hazelcast
+configuration must have the following entry:
+
+- Name prefix: `mvn:resolver:` (use pattern matching configuration)
+- JDK compatible: true
+- Permit count: `Integer.MAX_VALUE` (value `2147483647`)
+
+Example Hazelcast XML relevant snippet:
+
+```xml
+    <cp-subsystem>
+        <semaphores>
+            <semaphore>
+                <name>mvn:resolver:*</name>
+                <jdk-compatible>true</jdk-compatible>
+                <initial-permits>2147483647</initial-permits>
+            </semaphore>
+        </semaphores>
+    </cp-subsystem>
+```
+
+Without this configuration present, this library will not work.
 
 ${esc.hash}${esc.hash} Open Issues/Notes
 
-- Usage from plugins has not been tested yet.
 - The `furnace-maven-plugin` does not work this implementation because it uses `ServiceLocator` instead
   of dependency injection.
 
 ${esc.hash}${esc.hash} Open Issues/Notes for Maven Resolver integrators
 
-To use this implementation within your project, depending on how you integrate, you have following options:
-- If you use Sisu DI, then all you need is to provide this module (and its dependencies) on classpath and you are done.
-- If you use Guice, you need to add this module (and its dependencies) upfront, and bind them explicitly.
+To use this implementation within your project, depending on how you integrate, you have the following options:
+
+- If you use Sisu DI, then all you need is to provide this module (and Hazelcast JAR) on classpath, and you are done.
+- If you use Guice, you need to add this module (and its dependencies) upfront to classpath, and bind them explicitly.
 - If you use ServiceLocator, be aware it is deprecated, and you should move away from it. In this case, simplest is
   to roll your own "bootstrap" class that does pretty much same thing as ServiceLocator was, and extend it to
   instantiate these components as well.
 
 ${esc.hash}${esc.hash} Installation/Testing
 
-- Create the directory `${maven.home}/lib/ext/hazelcast/`.
-- Modify `${maven.home}/bin/m2.conf` by adding `load ${maven.home}/lib/ext/hazelcast/*.jar`
-  right after the `${maven.conf}/logging` line.
-- Copy the following dependency from Maven Central to `${maven.home}/lib/ext/hazelcast/`:
+- Copy the following JARs from Maven Central to `${maven.home}/lib/ext/`:
       <pre class="source">
-      └── <a href="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/4.1.1/hazelcast-4.1.1.jar">hazelcast-4.1.1.jar</a></pre>
-- Optionally configure Hazelcast instance with `${maven.conf}/hazelcast.xml` or `${maven.conf}/hazelcast-client.xml`
-  (see Hazelcast documentation for possibilities, or, see test resources of this project as starter).
+      ├── <a href="https://repo.maven.apache.org/maven2/org/apache/maven/resolver/${project.artifactId}/${project.version}/${project.artifactId}-${project.version}.jar">${project.artifactId}-${project.version}.jar</a>
+      └── <a href="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/5.0.2/hazelcast-5.0.2.jar">hazelcast-5.0.2.jar</a></pre>
+- Configure Hazelcast instance with `${maven.conf}/hazelcast.xml` or `${maven.conf}/hazelcast-client.xml` (if client used).
+  See Hazelcast documentation, default Hazelcast configuration discovery is being used.
 - Now start a multithreaded Maven build on your project and make sure `NamedSyncContextFactory` is being used.

--- a/maven-resolver-named-locks-hazelcast/src/site/site.xml
+++ b/maven-resolver-named-locks-hazelcast/src/site/site.xml
@@ -21,7 +21,7 @@ under the License.
 
 <project xmlns="http://maven.apache.org/DECORATION/1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 https://maven.apache.org/xsd/decoration-1.0.0.xsd"
   name="Named Locks using Hazelcast">
   <body>
     <menu name="Overview">

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactoryIT.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactoryIT.java
@@ -19,21 +19,16 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public class HazelcastCPSemaphoreNamedLockFactoryIT
-    extends NamedLockFactoryTestSupport {
+        extends NamedLockFactoryTestSupport
+{
 
     @BeforeClass
-    public static void createNamedLockFactory() {
-        namedLockFactory = new HazelcastCPSemaphoreNamedLockFactory();
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        if (namedLockFactory != null) {
-            namedLockFactory.shutdown();
-        }
+    public static void createNamedLockFactory()
+    {
+        String clusterName = utils.clusterName( HazelcastCPSemaphoreNamedLockFactoryIT.class );
+        namedLockFactory = new HazelcastCPSemaphoreNamedLockFactory( utils.createMember( clusterName ), true );
     }
 }

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreAdapterIT.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreAdapterIT.java
@@ -19,24 +19,17 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public class HazelcastClientCPSemaphoreAdapterIT
-    extends NamedLockFactoryAdapterTestSupport {
-
-    private static HazelcastClientUtils utils;
-
+        extends NamedLockFactoryAdapterTestSupport
+{
     @BeforeClass
-    public static void createNamedLockFactory() {
-        utils = new HazelcastClientUtils().createCpCluster();
-        setNamedLockFactory(new HazelcastClientCPSemaphoreNamedLockFactory());
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        if (utils != null) {
-            utils.cleanup();
-        }
+    public static void createNamedLockFactory()
+    {
+        String clusterName = utils.clusterName( HazelcastClientCPSemaphoreAdapterIT.class );
+        utils.createMember( clusterName );
+        setNamedLockFactory(
+                new HazelcastClientCPSemaphoreNamedLockFactory( utils.createClient( clusterName ), true ) );
     }
 }

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactoryIT.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactoryIT.java
@@ -19,27 +19,17 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public class HazelcastClientCPSemaphoreNamedLockFactoryIT
-    extends NamedLockFactoryTestSupport {
-
-    private static HazelcastClientUtils utils;
-
+        extends NamedLockFactoryTestSupport
+{
     @BeforeClass
-    public static void createNamedLockFactory() {
-        utils = new HazelcastClientUtils().createCpCluster();
-        namedLockFactory = new HazelcastClientCPSemaphoreNamedLockFactory();
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        if (namedLockFactory != null) {
-            namedLockFactory.shutdown();
-        }
-        if (utils != null) {
-            utils.cleanup();
-        }
+    public static void createNamedLockFactory()
+    {
+        String clusterName = utils.clusterName( HazelcastClientCPSemaphoreNamedLockFactoryIT.class );
+        utils.createMember( clusterName );
+        namedLockFactory =
+                new HazelcastClientCPSemaphoreNamedLockFactory( utils.createClient( clusterName ), true );
     }
 }

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/NamedLockFactoryAdapterTestSupport.java
@@ -19,6 +19,14 @@ package org.eclipse.aether.named.hazelcast;
  * under the License.
  */
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -33,14 +41,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,203 +49,232 @@ import static org.mockito.Mockito.when;
  */
 public abstract class NamedLockFactoryAdapterTestSupport
 {
-  private static final long ADAPTER_TIME = 100L;
+    protected static final HazelcastClientUtils utils = new HazelcastClientUtils();
 
-  private static final TimeUnit ADAPTER_TIME_UNIT = TimeUnit.MILLISECONDS;
+    private static final long ADAPTER_TIME = 100L;
 
-  /**
-   * Subclass should populate this field, using {@link #setNamedLockFactory(NamedLockFactory)}, but subclass
-   * must take care of proper cleanup as well, if needed!
-   */
-  private static NamedLockFactoryAdapter adapter;
+    private static final TimeUnit ADAPTER_TIME_UNIT = TimeUnit.MILLISECONDS;
 
-  private RepositorySystemSession session;
+    /**
+     * Subclass should populate this field, using {@link #setNamedLockFactory(NamedLockFactory)}, but subclass
+     * must take care of proper cleanup as well, if needed!
+     */
+    private static NamedLockFactoryAdapter adapter;
 
-  protected static void setNamedLockFactory(final NamedLockFactory namedLockFactory) {
-    adapter = new NamedLockFactoryAdapter(
-            new DiscriminatingNameMapper(new GAVNameMapper()), namedLockFactory
-    );
-  }
+    private RepositorySystemSession session;
 
-  @AfterClass
-  public static void cleanupAdapter() {
-    if (adapter != null) {
-      adapter.shutdown();
-    }
-  }
-
-  @Before
-  public void before() throws IOException {
-    Files.createDirectories(Paths.get(System.getProperty("java.io.tmpdir"))); // hack for Surefire
-    LocalRepository localRepository = new LocalRepository(Files.createTempDirectory("test").toFile());
-    session = mock(RepositorySystemSession.class);
-    when(session.getLocalRepository()).thenReturn(localRepository);
-    HashMap<String, Object> config = new HashMap<>();
-    config.put(NamedLockFactoryAdapter.TIME_KEY, String.valueOf(ADAPTER_TIME));
-    config.put(NamedLockFactoryAdapter.TIME_UNIT_KEY, ADAPTER_TIME_UNIT.name());
-    when(session.getConfigProperties()).thenReturn(config);
-  }
-
-  @Test
-  public void justCreateAndClose() {
-    adapter.newInstance(session, false).close();
-  }
-
-  @Test
-  public void justAcquire() {
-    try (SyncContext syncContext = adapter.newInstance(session, false)) {
-      syncContext.acquire(
-          Arrays.asList(new DefaultArtifact("groupId:artifactId:1.0"), new DefaultArtifact("groupId:artifactId:1.1")),
-          null
-      );
-    }
-  }
-
-  @Test(timeout = 5000)
-  public void sharedAccess() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(2); // we expect 2 winners
-    CountDownLatch losers = new CountDownLatch(0); // we expect 0 losers
-    Thread t1 = new Thread(new Access(true, winners, losers, adapter, session, null));
-    Thread t2 = new Thread(new Access(true, winners, losers, adapter, session, null));
-    t1.start();
-    t2.start();
-    t1.join();
-    t2.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void exclusiveAccess() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner
-    CountDownLatch losers = new CountDownLatch(1); // we expect 1 loser
-    Thread t1 = new Thread(new Access(false, winners, losers, adapter, session, null));
-    Thread t2 = new Thread(new Access(false, winners, losers, adapter, session, null));
-    t1.start();
-    t2.start();
-    t1.join();
-    t2.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void mixedAccess() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner
-    CountDownLatch losers = new CountDownLatch(1); // we expect 1 loser
-    Thread t1 = new Thread(new Access(true, winners, losers, adapter, session, null));
-    Thread t2 = new Thread(new Access(false, winners, losers, adapter, session, null));
-    t1.start();
-    t2.start();
-    t1.join();
-    t2.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void nestedSharedShared() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(2); // we expect 2 winners
-    CountDownLatch losers = new CountDownLatch(0); // we expect 0 losers
-    Thread t1 = new Thread(
-            new Access(true, winners, losers, adapter, session,
-                    new Access(true, winners, losers, adapter, session, null)
-            )
-    );
-    t1.start();
-    t1.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void nestedExclusiveShared() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(2); // we expect 2 winners
-    CountDownLatch losers = new CountDownLatch(0); // we expect 0 losers
-    Thread t1 = new Thread(
-            new Access(false, winners, losers, adapter, session,
-                    new Access(true, winners, losers, adapter, session, null)
-            )
-    );
-    t1.start();
-    t1.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void nestedExclusiveExclusive() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(2); // we expect 2 winners
-    CountDownLatch losers = new CountDownLatch(0); // we expect 0 losers
-    Thread t1 = new Thread(
-            new Access(false, winners, losers, adapter, session,
-                    new Access(false, winners, losers, adapter, session, null)
-            )
-    );
-    t1.start();
-    t1.join();
-    winners.await();
-    losers.await();
-  }
-
-  @Test(timeout = 5000)
-  public void nestedSharedExclusive() throws InterruptedException {
-    CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner (outer)
-    CountDownLatch losers = new CountDownLatch(1); // we expect 1 loser (inner)
-    Thread t1 = new Thread(
-            new Access(true, winners, losers, adapter, session,
-                    new Access(false, winners, losers, adapter, session, null)
-            )
-    );
-    t1.start();
-    t1.join();
-    winners.await();
-    losers.await();
-  }
-
-  private static class Access implements Runnable {
-    final boolean shared;
-    final CountDownLatch winner;
-    final CountDownLatch loser;
-    final NamedLockFactoryAdapter adapter;
-    final RepositorySystemSession session;
-    final Access chained;
-
-    public Access(boolean shared,
-                  CountDownLatch winner,
-                  CountDownLatch loser,
-                  NamedLockFactoryAdapter adapter,
-                  RepositorySystemSession session,
-                  Access chained) {
-      this.shared = shared;
-      this.winner = winner;
-      this.loser = loser;
-      this.adapter = adapter;
-      this.session = session;
-      this.chained = chained;
+    protected static void setNamedLockFactory( final NamedLockFactory namedLockFactory )
+    {
+        adapter = new NamedLockFactoryAdapter(
+                new DiscriminatingNameMapper( new GAVNameMapper() ), namedLockFactory
+        );
     }
 
-    @Override
-    public void run() {
-      try {
-        try (SyncContext syncContext = adapter.newInstance(session, shared)) {
-          syncContext.acquire(
-                  Arrays.asList(new DefaultArtifact("groupId:artifactId:1.0"), new DefaultArtifact("groupId:artifactId:1.1")),
-                  null
-          );
-          winner.countDown();
-          if (chained != null) {
-            chained.run();
-          }
-          loser.await();
-        } catch (IllegalStateException e) {
-          loser.countDown();
-          winner.await();
+    @AfterClass
+    public static void cleanup()
+    {
+        if ( adapter != null )
+        {
+            adapter.shutdown();
         }
-      }
-      catch (InterruptedException e) {
-        Assert.fail("interrupted");
-      }
+
+        utils.cleanup();
     }
-  }
+
+    @Before
+    public void before() throws IOException
+    {
+        Files.createDirectories( Paths.get( System.getProperty( "java.io.tmpdir" ) ) ); // hack for Surefire
+        LocalRepository localRepository = new LocalRepository( Files.createTempDirectory( "test" ).toFile() );
+        session = mock( RepositorySystemSession.class );
+        when( session.getLocalRepository() ).thenReturn( localRepository );
+        HashMap<String, Object> config = new HashMap<>();
+        config.put( NamedLockFactoryAdapter.TIME_KEY, String.valueOf( ADAPTER_TIME ) );
+        config.put( NamedLockFactoryAdapter.TIME_UNIT_KEY, ADAPTER_TIME_UNIT.name() );
+        when( session.getConfigProperties() ).thenReturn( config );
+    }
+
+    @Test
+    public void justCreateAndClose()
+    {
+        adapter.newInstance( session, false ).close();
+    }
+
+    @Test
+    public void justAcquire()
+    {
+        try ( SyncContext syncContext = adapter.newInstance( session, false ) )
+        {
+            syncContext.acquire(
+                    Arrays.asList( new DefaultArtifact( "groupId:artifactId:1.0" ),
+                            new DefaultArtifact( "groupId:artifactId:1.1" ) ),
+                    null
+            );
+        }
+    }
+
+    @Test( timeout = 5000 )
+    public void sharedAccess() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 2 ); // we expect 2 winners
+        CountDownLatch losers = new CountDownLatch( 0 ); // we expect 0 losers
+        Thread t1 = new Thread( new Access( true, winners, losers, adapter, session, null ) );
+        Thread t2 = new Thread( new Access( true, winners, losers, adapter, session, null ) );
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void exclusiveAccess() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 1 ); // we expect 1 winner
+        CountDownLatch losers = new CountDownLatch( 1 ); // we expect 1 loser
+        Thread t1 = new Thread( new Access( false, winners, losers, adapter, session, null ) );
+        Thread t2 = new Thread( new Access( false, winners, losers, adapter, session, null ) );
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void mixedAccess() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 1 ); // we expect 1 winner
+        CountDownLatch losers = new CountDownLatch( 1 ); // we expect 1 loser
+        Thread t1 = new Thread( new Access( true, winners, losers, adapter, session, null ) );
+        Thread t2 = new Thread( new Access( false, winners, losers, adapter, session, null ) );
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void nestedSharedShared() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 2 ); // we expect 2 winners
+        CountDownLatch losers = new CountDownLatch( 0 ); // we expect 0 losers
+        Thread t1 = new Thread(
+                new Access( true, winners, losers, adapter, session,
+                        new Access( true, winners, losers, adapter, session, null )
+                )
+        );
+        t1.start();
+        t1.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void nestedExclusiveShared() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 2 ); // we expect 2 winners
+        CountDownLatch losers = new CountDownLatch( 0 ); // we expect 0 losers
+        Thread t1 = new Thread(
+                new Access( false, winners, losers, adapter, session,
+                        new Access( true, winners, losers, adapter, session, null )
+                )
+        );
+        t1.start();
+        t1.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void nestedExclusiveExclusive() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 2 ); // we expect 2 winners
+        CountDownLatch losers = new CountDownLatch( 0 ); // we expect 0 losers
+        Thread t1 = new Thread(
+                new Access( false, winners, losers, adapter, session,
+                        new Access( false, winners, losers, adapter, session, null )
+                )
+        );
+        t1.start();
+        t1.join();
+        winners.await();
+        losers.await();
+    }
+
+    @Test( timeout = 5000 )
+    public void nestedSharedExclusive() throws InterruptedException
+    {
+        CountDownLatch winners = new CountDownLatch( 1 ); // we expect 1 winner (outer)
+        CountDownLatch losers = new CountDownLatch( 1 ); // we expect 1 loser (inner)
+        Thread t1 = new Thread(
+                new Access( true, winners, losers, adapter, session,
+                        new Access( false, winners, losers, adapter, session, null )
+                )
+        );
+        t1.start();
+        t1.join();
+        winners.await();
+        losers.await();
+    }
+
+    private static class Access implements Runnable
+    {
+        final boolean shared;
+        final CountDownLatch winner;
+        final CountDownLatch loser;
+        final NamedLockFactoryAdapter adapter;
+        final RepositorySystemSession session;
+        final Access chained;
+
+        public Access( boolean shared,
+                       CountDownLatch winner,
+                       CountDownLatch loser,
+                       NamedLockFactoryAdapter adapter,
+                       RepositorySystemSession session,
+                       Access chained )
+        {
+            this.shared = shared;
+            this.winner = winner;
+            this.loser = loser;
+            this.adapter = adapter;
+            this.session = session;
+            this.chained = chained;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                try ( SyncContext syncContext = adapter.newInstance( session, shared ) )
+                {
+                    syncContext.acquire(
+                            Arrays.asList( new DefaultArtifact( "groupId:artifactId:1.0" ),
+                                    new DefaultArtifact( "groupId:artifactId:1.1" ) ),
+                            null
+                    );
+                    winner.countDown();
+                    if ( chained != null )
+                    {
+                        chained.run();
+                    }
+                    loser.await();
+                }
+                catch ( IllegalStateException e )
+                {
+                    loser.countDown();
+                    winner.await();
+                }
+            }
+            catch ( InterruptedException e )
+            {
+                Assert.fail( "interrupted" );
+            }
+        }
+    }
 }

--- a/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast-client.xml
+++ b/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast-client.xml
@@ -22,7 +22,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.1.xsd">
+                  https://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd">
 
     <cluster-name>maven-resolver-named</cluster-name>
     <instance-name>client</instance-name>

--- a/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
+++ b/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
@@ -42,7 +42,7 @@
         <semaphores>
             <!-- Config for resolver semaphores -->
             <semaphore>
-                <name>mvn:resolver:*</name>
+                <name>maven:resolver:*</name>
                 <jdk-compatible>true</jdk-compatible>
                 <!-- Integer.MAX_VALUE -->
                 <initial-permits>2147483647</initial-permits>

--- a/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
+++ b/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
@@ -22,7 +22,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           https://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
 
     <cluster-name>maven-resolver-named</cluster-name>
     <instance-name>server</instance-name>
@@ -31,10 +31,22 @@
     </properties>
     <network>
         <join>
+            <auto-detection enabled="false"/>
             <multicast enabled="false"/>
             <tcp-ip>
                 <interface>localhost</interface>
             </tcp-ip>
         </join>
     </network>
+    <cp-subsystem>
+        <semaphores>
+            <!-- Config for resolver semaphores -->
+            <semaphore>
+                <name>mvn:resolver:*</name>
+                <jdk-compatible>true</jdk-compatible>
+                <!-- Integer.MAX_VALUE -->
+                <initial-permits>2147483647</initial-permits>
+            </semaphore>
+        </semaphores>
+    </cp-subsystem>
 </hazelcast>


### PR DESCRIPTION
Main intent is to properly isolate ITs, but did other cleanup as well
like patch update of Hazelcast and documentation updated as well.

High level changes:
* POM update with new patch release of HZ
* removed obsolete `destroySemaphore` parameter (always false), factored out semaphore provision
* updated all 4 ITs to form random named clusters (hence to prevent outer HZ instance joining)
* provided hazelcast and hazelcast-client XML fixed (used wrong schema)
* Tests reformatted to maven codestyle (changes best viewed with `?w=1`)

---

https://issues.apache.org/jira/browse/MRESOLVER-245