### PR TITLE
[MRESOLVER-249] Update Hazelcast to 5.1.1

### DIFF
--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>5.0.2</version>
+      <version>5.1.1</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks-hazelcast/src/site/markdown/index.md.vm
@@ -72,7 +72,7 @@ ${esc.hash}${esc.hash} Installation/Testing
 - Copy the following JARs from Maven Central to `${maven.home}/lib/ext/`:
       <pre class="source">
       ├── <a href="https://repo.maven.apache.org/maven2/org/apache/maven/resolver/${project.artifactId}/${project.version}/${project.artifactId}-${project.version}.jar">${project.artifactId}-${project.version}.jar</a>
-      └── <a href="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/5.0.2/hazelcast-5.0.2.jar">hazelcast-5.0.2.jar</a></pre>
+      └── <a href="https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/5.1.1/hazelcast-5.1.1.jar">hazelcast-5.1.1.jar</a></pre>
 - Configure Hazelcast instance with `${maven.conf}/hazelcast.xml` or `${maven.conf}/hazelcast-client.xml` (if client used).
   See Hazelcast documentation, default Hazelcast configuration discovery is being used.
 - Now start a multithreaded Maven build on your project and make sure `NamedSyncContextFactory` is being used.

--- a/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast-client.xml
+++ b/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast-client.xml
@@ -22,7 +22,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  https://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd">
+                  https://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.1.xsd">
 
     <cluster-name>maven-resolver-named</cluster-name>
     <instance-name>client</instance-name>

--- a/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
+++ b/maven-resolver-named-locks-hazelcast/src/test/resources/hazelcast.xml
@@ -22,7 +22,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           https://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+           https://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>maven-resolver-named</cluster-name>
     <instance-name>server</instance-name>


### PR DESCRIPTION
Update Hazelcast from 5.0.2 to latest 5.1.1. This is really
not a game changer, as Hazelcast 5.x is API compatible, so
end users may choose which version to use for real at runtime.

---

https://issues.apache.org/jira/browse/MRESOLVER-249