### PR TITLE
Reword warning on site

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -29,7 +29,7 @@
   <body>
 
     <section name="Apache Maven Artifact Resolver">
-      <p style="font-size: 14pt; font-style: bold">Since version 1.7.0 Maven Resolver requires Maven 4.0.0-alpha-1 or newer to run. For a Maven 3.8.x compatible version read <a href="./maven-3.8.x.html">here</a>.</p>
+      <p style="font-size: 14pt; font-style: bold">Since version 1.7.0 Maven Resolver requires Java 8 to run. For a Maven 3.8.x (Java 7) compatible version read <a href="./maven-3.8.x.html">here</a>.</p>
       <p>Apache Maven Artifact Resolver is a library for working with artifact repositories and dependency resolution.</p>
       <p>Maven Artifact Resolver deals with the specification of local repository, remote repository, developer workspaces, artifact transports, and artifact resolution. It is expected to be extended by a concrete repository implementation, such as
         <a href="/ref/current/maven-resolver-provider/">Maven Artifact Resolver Provider</a> for Maven repositories

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -29,7 +29,7 @@
   <body>
 
     <section name="Apache Maven Artifact Resolver">
-      <p style="font-size: 14pt; font-style: bold">Since version 1.7.0 Maven Resolver requires Java 8 to run. For a Maven 3.8.x (Java 7) compatible version read <a href="./maven-3.8.x.html">here</a>.</p>
+      <p style="font-size: 14pt; font-style: bold">Since version 1.7.0 Maven Resolver requires Java 8 to run. For a Maven 3.8.x compatible version read <a href="./maven-3.8.x.html">here</a>.</p>
       <p>Apache Maven Artifact Resolver is a library for working with artifact repositories and dependency resolution.</p>
       <p>Maven Artifact Resolver deals with the specification of local repository, remote repository, developer workspaces, artifact transports, and artifact resolution. It is expected to be extended by a concrete repository implementation, such as
         <a href="/ref/current/maven-resolver-provider/">Maven Artifact Resolver Provider</a> for Maven repositories


### PR DESCRIPTION
Instead to refer to version that "works with" (and forget about 3.9.x),
better state Java level, and mention how to run on Java 7 bound
maven 3.8.x. Do not mention any later maven version, and we are not
fortune tellers (as 3.9.x can show).