### PR TITLE
[MRESOLVER-255] Update Jetty to 9.4.46.v20220331

### DIFF
--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-    <jettyVersion>9.4.36.v20210114</jettyVersion>
+    <jettyVersion>9.4.46.v20220331</jettyVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Jetty is used in tests for Transport HTTP only.