### PR TITLE
Fix the problem that the dependency tree is different when DF and BF …

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -453,7 +453,7 @@ public class BfDependencyCollector
                     {
                         doRecurse( args, parentContext, descriptorResult, child );
                     }
-                    else if(!args.skipper.skipResolution( child, parentContext.parents ))
+                    else if ( !args.skipper.skipResolution( child, parentContext.parents ) )
                     {
                         List<DependencyNode> parents = new ArrayList<>( parentContext.parents.size() + 1 );
                         parents.addAll( parentContext.parents );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -453,7 +453,7 @@ public class BfDependencyCollector
                     {
                         doRecurse( args, parentContext, descriptorResult, child );
                     }
-                    else
+                    else if(!args.skipper.skipResolution( child, parentContext.parents ))
                     {
                         List<DependencyNode> parents = new ArrayList<>( parentContext.parents.size() + 1 );
                         parents.addAll( parentContext.parents );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -448,9 +448,17 @@ public class BfDependencyCollector
                     context.getParent().getChildren().add( child );
 
                     boolean recurse = traverse && !descriptorResult.getDependencies().isEmpty();
+                    DependencyProcessingContext parentContext = context.withDependency( d );
                     if ( recurse )
                     {
-                        doRecurse( args, context.withDependency( d ), descriptorResult, child );
+                        doRecurse( args, parentContext, descriptorResult, child );
+                    }
+                    else
+                    {
+                        List<DependencyNode> parents = new ArrayList<>( parentContext.parents.size() + 1 );
+                        parents.addAll( parentContext.parents );
+                        parents.add( child );
+                        args.skipper.cache( child, parents );
                     }
                 }
             }

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_a_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_a_ver.ini
@@ -1,0 +1,4 @@
+[dependencies]
+gid:b:jar:ver
+gid:c:jar:ver
+gid:e:jar:ver

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_b_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_b_ver.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:d:jar:1

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_c_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_c_ver.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:d:jar:2

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_d_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_d_1.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_d_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_d_2.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:g:jar:1

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_e_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_e_ver.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:f:jar:ver

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_f_ver.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_f_ver.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:g:jar:2

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_g_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_g_1.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:h:jar:1

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_g_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_g_2.ini
@@ -1,0 +1,2 @@
+[dependencies]
+gid:h:jar:2

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_h_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_h_1.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_h_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/dependencies-empty/gid_h_2.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/expectedSubtreeOnDescriptorDependenciesEmpty.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/expectedSubtreeOnDescriptorDependenciesEmpty.txt
@@ -1,0 +1,8 @@
+gid:a:jar:ver
++- gid:b:jar:ver compile
+|  \- gid:d:jar:1 compile
++- gid:c:jar:ver compile
+\- gid:e:jar:ver compile
+|  +- gid:f:jar:ver compile
+|  |  +- gid:g:jar:2 compile
+|  |  |  \- gid:h:jar:2 compile


### PR DESCRIPTION
Fix the problem that the dependency tree is different when DF and BF strategies are adopted when a dependency package has no children dependency.
When BF is adopted, when a dependent package has no children dependency, it will not continue to call the doRecurse() method, that is, it will not call the CacheManager.cachewinner() to put this dependency package into the winnerGAs object, which affects the analysis results of dependency packages of the same GA. The current fix is to call the CacheManager.cachewinner() method when a dependent package has no children dependency and it is not skip resolution, so that the dependent package can be found in winnerGAs.



We take the dependency in the following figure as an example to illustrate the generation process of the problem.
<img width="359" alt="image" src="https://user-images.githubusercontent.com/104960983/166911972-6d721f62-ea17-46fc-af60-181aa5fdb041.png">


At org eclipse. aether. internal. impl. Bfdependencycollector #collectdependencies() mainly has two stages: processdependency() and transformer.transformGraph( node, context )。
In the first stage of process dependency:
1. When parsing to D1, descriptorResult.getDependencies().isEmpty(), so doRecurse() will not be executed. Therefore, args.skipper.cache() will not be executed. The D1 will not exist in winnerGAs in the end.
![image](https://user-images.githubusercontent.com/104960983/166884243-317a53ec-f26d-4bc2-96d0-1c6bf4053d76.png)

2. When parsing D2 of the same layer, because there is no same GA in winnerGAs, D2 and its children dependencies （ G1 and H1） will be parsed.
3. When resolving to G2 on the same layer as G1, because winnerGAs already has G1, the resolution of the children dependencies of G2 will be skipped, that is, H2 will not be resolved.
Then, to the second stage, transformgraph:
4. Because D1 has the same depth as D2, D1 wins, that is, D2 and its children are eliminated, including G1
5. Because G1 was eliminated, G2 won.

Finally, the final dependency tree obtained by BF strategy is as follows:
<img width="272" alt="image" src="https://user-images.githubusercontent.com/104960983/166912027-21d7fcd4-79bd-43cc-80c8-0088091a91ef.png">

But the dependency tree obtained by DF is as follows:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/104960983/166912045-2cff5bd6-f54d-4faa-a955-6c985923058a.png">

That is, in the final generated dependency tree, BF has less children dependency of G2 than DF.


thanks.

Signed-off-by: hongbo.weihb <hongbo.weihb@alibaba-inc.com>