### PR TITLE
[MRESOLVER-7] download poms in parallel

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -481,10 +481,9 @@ public class BfDependencyCollector
             this.executorService = getExecutorService( session );
         }
 
-        Future<DescriptorResolutionResult> resolveDescriptors( Artifact artifact,
-                                                               Callable<DescriptorResolutionResult> callable )
+        void resolveDescriptors( Artifact artifact, Callable<DescriptorResolutionResult> callable )
         {
-            return results.computeIfAbsent( ArtifactIdUtils.toId( artifact ),
+            results.computeIfAbsent( ArtifactIdUtils.toId( artifact ),
                     key -> this.executorService.submit( callable ) );
         }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -66,7 +66,6 @@ import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
-import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.util.ConfigUtils;
@@ -380,14 +379,9 @@ public class BfDependencyCollector
         return false;
     }
 
+
     private void resolveArtifactDescriptorAsync( Args args, DependencyProcessingContext context,
                                                  Results results )
-    {
-        args.resolver.resolveDescriptors( context.dependency, () -> resolveDescriptor( args, context, results ) );
-    }
-
-    private DescriptorResolutionResult resolveDescriptor( Args args, DependencyProcessingContext context,
-                                                          Results results )
     {
         Dependency dependency = context.dependency;
 
@@ -410,7 +404,7 @@ public class BfDependencyCollector
                     newContext.withDependency( newDependency ), results );
         };
 
-        try
+        args.resolver.resolveDescriptors( dependency, () ->
         {
             VersionRangeRequest rangeRequest =
                     createVersionRangeRequest( args.request.getRequestContext(), context.trace, context.repositories,
@@ -449,12 +443,7 @@ public class BfDependencyCollector
             }
 
             return resolutionResult;
-        }
-        catch ( VersionRangeResolutionException e )
-        {
-            results.addException( context.dependency, e, context.parents );
-            return null;
-        }
+        } );
     }
 
     private ArtifactDescriptorResult resolveCachedArtifactDescriptor( DataPool pool,

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl.collect.bf;
 
 import java.util.List;
 
+import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.DependencyTraverser;
@@ -48,14 +49,16 @@ final class DependencyProcessingContext
      * All parents of the dependency in the top > down order.
      */
     final List<DependencyNode> parents;
+    final PremanagedDependency premanagedDependency;
+    final RequestTrace trace;
     Dependency dependency;
-    PremanagedDependency premanagedDependency;
 
     @SuppressWarnings( "checkstyle:parameternumber" )
     DependencyProcessingContext( DependencySelector depSelector,
                                  DependencyManager depManager,
                                  DependencyTraverser depTraverser,
                                  VersionFilter verFilter,
+                                 RequestTrace trace,
                                  List<RemoteRepository> repositories,
                                  List<Dependency> managedDependencies,
                                  List<DependencyNode> parents,
@@ -66,6 +69,7 @@ final class DependencyProcessingContext
         this.depManager = depManager;
         this.depTraverser = depTraverser;
         this.verFilter = verFilter;
+        this.trace = trace;
         this.repositories = repositories;
         this.dependency = dependency;
         this.premanagedDependency = premanagedDependency;
@@ -82,7 +86,7 @@ final class DependencyProcessingContext
     DependencyProcessingContext copy()
     {
         return new DependencyProcessingContext( depSelector, depManager, depTraverser,
-                verFilter, repositories, managedDependencies, parents, dependency,
+                verFilter, trace, repositories, managedDependencies, parents, dependency,
                 premanagedDependency );
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
@@ -27,6 +27,7 @@ import org.eclipse.aether.collection.DependencyTraverser;
 import org.eclipse.aether.collection.VersionFilter;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.internal.impl.collect.PremanagedDependency;
 import org.eclipse.aether.repository.RemoteRepository;
 
 /**
@@ -48,6 +49,7 @@ final class DependencyProcessingContext
      */
     final List<DependencyNode> parents;
     Dependency dependency;
+    PremanagedDependency premanagedDependency;
 
     @SuppressWarnings( "checkstyle:parameternumber" )
     DependencyProcessingContext( DependencySelector depSelector,
@@ -57,7 +59,8 @@ final class DependencyProcessingContext
                                  List<RemoteRepository> repositories,
                                  List<Dependency> managedDependencies,
                                  List<DependencyNode> parents,
-                                 Dependency dependency )
+                                 Dependency dependency,
+                                 PremanagedDependency premanagedDependency )
     {
         this.depSelector = depSelector;
         this.depManager = depManager;
@@ -65,6 +68,7 @@ final class DependencyProcessingContext
         this.verFilter = verFilter;
         this.repositories = repositories;
         this.dependency = dependency;
+        this.premanagedDependency = premanagedDependency;
         this.managedDependencies = managedDependencies;
         this.parents = parents;
     }
@@ -73,6 +77,13 @@ final class DependencyProcessingContext
     {
         this.dependency = dependency;
         return this;
+    }
+
+    DependencyProcessingContext copy()
+    {
+        return new DependencyProcessingContext( depSelector, depManager, depTraverser,
+                verFilter, repositories, managedDependencies, parents, dependency,
+                premanagedDependency );
     }
 
     DependencyNode getParent()


### PR DESCRIPTION
This PR is for parallel POM downloading, the idea is a bit different than https://github.com/ibabiankou/maven-resolver/pull/2/files:

- only parallelize the VersionRange and ArtifactDesciptor resolution part (poms.xml & maven-metadata.xml downloading in parallel) as the poms downloading or maven-metadata.xml is the most slow part.
- Pure dependency resolution logic and the [skip logic](https://github.com/apache/maven-resolver/pull/158) are still run in sequence.
