### PR TITLE
Prepare 1.8.1 release

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Default implementation of {@link LocalPathComposer}.
  *
- * @since TBD
+ * @since 1.8.1
  */
 @Singleton
 @Named

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
@@ -28,7 +28,7 @@ import org.eclipse.aether.RepositorySystemSession;
  * Default local path prefix composer factory: it fully reuses {@link LocalPathPrefixComposerFactorySupport} class
  * without changing anything from it.
  *
- * @since TBD
+ * @since 1.8.1
  */
 @Singleton
 @Named

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathComposer.java
@@ -26,7 +26,7 @@ import org.eclipse.aether.metadata.Metadata;
  * Composes {@link Artifact} and {@link Metadata} relative paths to be used in
  * {@link org.eclipse.aether.repository.LocalRepositoryManager}.
  *
- * @since TBD
+ * @since 1.8.1
  */
 public interface LocalPathComposer
 {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposer.java
@@ -26,7 +26,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 /**
  * Composes path prefixes for {@link EnhancedLocalRepositoryManager}.
  *
- * @since TBD
+ * @since 1.8.1
  */
 public interface LocalPathPrefixComposer
 {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactory.java
@@ -24,7 +24,7 @@ import org.eclipse.aether.RepositorySystemSession;
 /**
  * Creates instances of {@link LocalPathPrefixComposer}.
  *
- * @since TBD
+ * @since 1.8.1
  */
 public interface LocalPathPrefixComposerFactory
 {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
@@ -34,7 +34,7 @@ import org.eclipse.aether.util.ConfigUtils;
  * configuration, they should override any configuration getter from this class.
  *
  * @see DefaultLocalPathPrefixComposerFactory
- * @since TBD
+ * @since 1.8.1
  */
 public abstract class LocalPathPrefixComposerFactorySupport implements LocalPathPrefixComposerFactory
 {


### PR DESCRIPTION
This PR is just here as a reminder for upcoming
1.8.1 and also cleans up "TBD" versions.

To be merged just before release AFTER ensured all
`@since TBD`s are covered.