### PR TITLE
Add some TLP doco about shared local repo access

### DIFF
--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -25,17 +25,27 @@ then you can use named locks to make sure they are being protected from concurre
 
 Named locks provide support classes for implementations, and provide out of the box seven named lock implementations and three name mappers.
 
-Out of the box, "local" (local to JVM) named lock implementations are the following:
+Following implementations are "local" (local to JVM) named lock implementations:
 
 - `rwlock-local` implemented in `org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory` that uses
   JVM `java.util.concurrent.locks.ReentrantReadWriteLock`.
 - `semaphore-local` implemented in `org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory` that uses
   JVM `java.util.concurrent.Semaphore`.
-- `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
-  JVM `java.nio.channels.FileLock`.
 - `noop` implemented in `org.eclipse.aether.named.providers.NoopNamedLockFactory` that uses no locking.
 
-Out of the box, "distributed" named lock implementations are the following (separate modules which require additional dependencies):
+Following named lock implementations use underlying OS advisory file locking:
+
+- `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
+  JVM `java.nio.channels.FileLock`.
+
+Note about `file-lock` implementation: it uses OS advisory file locking, hence, concurrently running Maven processes
+all set up to use `file-loxk` implementation can safely share one local repository. This is almost certain on
+local file systems across all operating systems. In case of NFS mounts, file advisory locking MAY work if NFSv4+
+used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement advisory
+file locking, check your NFS and/or OS manuals for details). In short: if your (local or remote) FS correctly support
+and implements advisory locking, it should work. Local FS usually does, while with NFS your mileage may vary.
+
+Finally, "distributed" named lock implementations are the following (separate modules which require additional dependencies and remote services):
 
 - `rwlock-redisson` implemented in `org.eclipse.aether.named.redisson.RedissonReadWriteLockNamedLockFactory`.
 - `semaphore-redisson` implemented in `org.eclipse.aether.named.redisson.RedissonSemaphoreNamedLockFactory`.
@@ -44,7 +54,6 @@ Out of the box, "distributed" named lock implementations are the following (sepa
 
 Local named locks are only suited within one JVM with a multithreaded build.
 Sharing a local repository between multiple Maven processes (i.e., on a busy CI server) requires a distributed named lock!
-
 
 The aforementioned (opaque) IDs need to be mapped from artifacts and metadata.
 

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -23,7 +23,7 @@ Named locks are essentially locks that are assigned to some given (opaque) ID. I
 resources that each can have unique ID assigned (i.e., file with an absolute path, some entities with unique ID),
 then you can use named locks to make sure they are being protected from concurrent read and write actions.
 
-Named locks provide support classes for implementations, and provide out of the box seven named lock implementations and three name mappers.
+Named locks provide support classes for implementations, and provide out of the box several lock and name mapper implementations.
 
 Following implementations are "local" (local to JVM) named lock implementations:
 
@@ -35,17 +35,17 @@ Following implementations are "local" (local to JVM) named lock implementations:
 
 Note about "local" locks: they are in-JVM, in a way, they properly coordinate in case of multithreaded access from
 same JVM, but does not cover accesses across multiple processes and multiple hosts access.
-In other words, local named locks are only suited within one JVM with a multithreaded build.
+In other words, local named locks are only suited within one JVM with a multithreaded access.
 
 Following named lock implementations use underlying OS advisory file locking:
 
 - `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
   JVM `java.nio.channels.FileLock`.
 
-Note about `file-lock` implementation: it uses OS advisory file locking, hence, concurrently running Maven processes
-all set up to use `file-loxk` implementation can safely share one local repository. This is almost certain on
+The `file-lock` implementation uses OS advisory file locking, hence, concurrently running Maven processes
+set up to use `file-loxk` implementation can safely share one local repository. This is almost certain on
 local file systems across all operating systems. In case of NFS mounts, file advisory locking MAY work if NFSv4+
-used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement advisory
+used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement NFS advisory
 file locking, check your NFS and/or OS manuals for details). In short: if your (local or remote) FS correctly support
 and implements advisory locking, it should work. Local FS usually does, while with NFS your mileage may vary.
 
@@ -66,3 +66,5 @@ Out of the box, name mapper implementations are the following:
 - `gav` implemented in `org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper`.
 - `discriminating` implemented in `org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper`.
 - `file-gav` implemented in `org.eclipse.aether.internal.impl.synccontext.named.FileGAVNameMapper`.
+
+Note: the `file-gav` name mapper MUST be used with `file-lock` named locking, no other mapper will work with it.

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -56,7 +56,8 @@ Finally, "distributed" named lock implementations are the following (separate mo
 - `semaphore-hazelcast-client` implemented in `org.eclipse.aether.named.hazelcast.HazelcastClientCPSemaphoreNamedLockFactory`.
 - `semaphore-hazelcast` implemented in `org.eclipse.aether.named.hazelcast.HazelcastCPSemaphoreNamedLockFactory`.
 
-Sharing a local repository between multiple hosts (i.e., on a busy CI server) requires a distributed named lock!
+Sharing a local repository between multiple hosts (i.e., on a busy CI server) may be best done with one of distributed named lock,
+if NFS locking is not working for you.
 
 The aforementioned (opaque) IDs need to be mapped from artifacts and metadata.
 

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -33,6 +33,10 @@ Following implementations are "local" (local to JVM) named lock implementations:
   JVM `java.util.concurrent.Semaphore`.
 - `noop` implemented in `org.eclipse.aether.named.providers.NoopNamedLockFactory` that uses no locking.
 
+Note about "local" locks: they are in-JVM, in a way, they properly coordinate in case of multithreaded access from
+same JVM, but does not cover accesses across multiple processes and multiple hosts access.
+In other words, local named locks are only suited within one JVM with a multithreaded build.
+
 Following named lock implementations use underlying OS advisory file locking:
 
 - `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
@@ -52,8 +56,7 @@ Finally, "distributed" named lock implementations are the following (separate mo
 - `semaphore-hazelcast-client` implemented in `org.eclipse.aether.named.hazelcast.HazelcastClientCPSemaphoreNamedLockFactory`.
 - `semaphore-hazelcast` implemented in `org.eclipse.aether.named.hazelcast.HazelcastCPSemaphoreNamedLockFactory`.
 
-Local named locks are only suited within one JVM with a multithreaded build.
-Sharing a local repository between multiple Maven processes (i.e., on a busy CI server) requires a distributed named lock!
+Sharing a local repository between multiple hosts (i.e., on a busy CI server) requires a distributed named lock!
 
 The aforementioned (opaque) IDs need to be mapped from artifacts and metadata.
 

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -43,7 +43,7 @@ Following named lock implementations use underlying OS advisory file locking:
   JVM `java.nio.channels.FileLock`.
 
 The `file-lock` implementation uses OS advisory file locking, hence, concurrently running Maven processes
-set up to use `file-loxk` implementation can safely share one local repository. This is almost certain on
+set up to use `file-lock` implementation can safely share one local repository. This is almost certain on
 local file systems across all operating systems. In case of NFS mounts, file advisory locking MAY work if NFSv4+
 used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement NFS advisory
 file locking, check your NFS and/or OS manuals for details). In short: if your (local or remote) FS correctly support

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -34,15 +34,15 @@ Following implementations are "local" (local to JVM) named lock implementations:
 - `noop` implemented in `org.eclipse.aether.named.providers.NoopNamedLockFactory` that uses no locking.
 
 Note about "local" locks: they are in-JVM, in a way, they properly coordinate in case of multithreaded access from
-same JVM, but does not cover accesses across multiple processes and multiple hosts access.
+same JVM, but do not cover accesses across multiple processes and/or multiple hosts access.
 In other words, local named locks are only suited within one JVM with a multithreaded access.
 
-Following named lock implementations use underlying OS advisory file locking:
+Following named lock implementations use underlying file system advisory file locking:
 
 - `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
   JVM `java.nio.channels.FileLock`.
 
-The `file-lock` implementation uses OS advisory file locking, hence, concurrently running Maven processes
+The `file-lock` implementation uses file system advisory file locking, hence, concurrently running Maven processes
 set up to use `file-lock` implementation can safely share one local repository. This is almost certain on
 local file systems across all operating systems. In case of NFS mounts, file advisory locking MAY work if NFSv4+
 used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement NFS advisory

--- a/src/site/markdown/local-repository.md
+++ b/src/site/markdown/local-repository.md
@@ -34,7 +34,7 @@ scenarios (is not meant for production use).
 
 ### Enhanced LRM
 
-Enhanced LRM on the other hand is enhanced with several extra 
+Enhanced LRM is enhanced with several extra 
 features, one most notable is scoping cached content by its origin and context: 
 if you downloaded an artifact A1 from repository R1 
 and later initiate build that requires same artifact A1, but repository R1 

--- a/src/site/markdown/local-repository.md
+++ b/src/site/markdown/local-repository.md
@@ -164,7 +164,7 @@ recommended way to use it, as it should be rather injected whenever possible.
 This example above is merely a showcase how to obtain LRM implementation
 in unit tests.
 
-## Shared access to Local Repository
+## Shared Access to Local Repository
 
 In case of shared (multi-threaded, multi-process or even multi host) access
 to local repository, coordination is a must, as local repository is hosted
@@ -179,3 +179,4 @@ available, providing out of the box lock implementations for cases like:
 * multi-host locking using Hazelcast or Redisson (needs Hazelcast or Redisson cluster)
 
 For details see [Named Locks module](maven-resolver-named-locks/).
+

--- a/src/site/markdown/local-repository.md
+++ b/src/site/markdown/local-repository.md
@@ -169,7 +169,7 @@ in unit tests.
 In case of shared (multi-threaded, multi-process or even multi host) access
 to local repository, coordination is a must, as local repository is hosted
 on file system, and each thread may read and write concurrently into it,
-causing other threads to get incomplete or partially written data.
+causing other threads or processes to get incomplete or partially written data.
 
 Hence, since Resolver 1.7.x version, there is a pluggable API called "Named Locks" 
 available, providing out of the box lock implementations for cases like:

--- a/src/site/markdown/local-repository.md
+++ b/src/site/markdown/local-repository.md
@@ -167,15 +167,15 @@ in unit tests.
 ## Shared access to Local Repository
 
 In case of shared (multi-threaded, multi-process or even multi host) access
-to local repository coordination is required, as local repository is hosted
+to local repository, coordination is a must, as local repository is hosted
 on file system, and each thread may read and write concurrently into it,
-causing other threads get incomplete or partially written data.
+causing other threads to get incomplete or partially written data.
 
-Hence, since Resolver 1.7.x line, there is a pluggable API called "Named Locks" 
-available, providing out of the box lock implementations for cases:
+Hence, since Resolver 1.7.x version, there is a pluggable API called "Named Locks" 
+available, providing out of the box lock implementations for cases like:
 
 * multi-threaded, in JVM locking (the default)
 * multi-process locking using file system advisory locking
-* multi-host locking using Hazelcast or Redisson (needs Redisson or Hazelcast cluster)
+* multi-host locking using Hazelcast or Redisson (needs Hazelcast or Redisson cluster)
 
 For details see [Named Locks module](maven-resolver-named-locks/).


### PR DESCRIPTION
Rework local repo page available from TLP, move "uninteresting" simple LRM to bottom, add intro about locking, to not have it buried in some module...

Inspired by https://github.com/apache/maven-resolver/pull/184