### PR TITLE
[MRESOLVER-268] Allow for checksum validation upon artifact resolution.

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/ChecksumFailureException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/ChecksumFailureException.java
@@ -61,13 +61,28 @@ public class ChecksumFailureException
      */
     public ChecksumFailureException( String expected, String expectedKind, String actual )
     {
+        this( expected, expectedKind, actual, true );
+    }
+
+    /**
+     * Creates a new exception with the specified expected, expected kind and actual checksum.
+     *
+     * @param expected The expected checksum as declared by the hosting repository, may be {@code null}.
+     * @param expectedKind The expected checksum kind, may be {@code null}.
+     * @param actual The actual checksum as computed from the local bytes, may be {@code null}.
+     * @param retryWorthy if retrying the download might solve the checksum failure, {@code false} if the checksum
+     *                    failure is non-recoverable.
+     * @since 1.8.4
+     */
+    public ChecksumFailureException( String expected, String expectedKind, String actual, boolean retryWorthy )
+    {
         super( "Checksum validation failed, expected '"
             + expected + "'" + ( expectedKind == null ? "" : " (" + expectedKind + ")" )
             + " but is actually '" + actual + "'" );
         this.expected = expected;
         this.expectedKind = expectedKind;
         this.actual = actual;
-        this.retryWorthy = true;
+        this.retryWorthy = retryWorthy;
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
@@ -25,6 +25,9 @@ import org.eclipse.aether.transfer.TransferResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.util.function.Supplier;
+
 import static java.util.Objects.requireNonNull;
 
 abstract class AbstractChecksumPolicy
@@ -33,11 +36,16 @@ abstract class AbstractChecksumPolicy
 
     protected final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    protected final TransferResource resource;
+    private final Supplier<String> name;
 
-    protected AbstractChecksumPolicy( TransferResource resource )
+    AbstractChecksumPolicy( TransferResource resource )
     {
-        this.resource = resource;
+        name = resource::getResourceName;
+    }
+
+    AbstractChecksumPolicy( File file )
+    {
+        name = file::getAbsolutePath;
     }
 
     @Override
@@ -62,7 +70,7 @@ abstract class AbstractChecksumPolicy
     {
         requireNonNull( algorithm, "algorithm cannot be null" );
         requireNonNull( exception, "exception cannot be null" );
-        logger.debug( "Could not validate {} checksum for {}", algorithm, resource.getResourceName(), exception );
+        logger.debug( "Could not validate {} checksum for {}", algorithm, name.get(), exception );
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultChecksumPolicyProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultChecksumPolicyProvider.java
@@ -22,6 +22,7 @@ package org.eclipse.aether.internal.impl;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.io.File;
 import java.util.Objects;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -48,6 +49,26 @@ public final class DefaultChecksumPolicyProvider
     public DefaultChecksumPolicyProvider()
     {
         // enables default constructor
+    }
+
+    public ChecksumPolicy newChecksumPolicy( RepositorySystemSession session, File resource, String policy )
+    {
+        Objects.requireNonNull( session, "session cannot be null" );
+        Objects.requireNonNull( resource, "resource cannot be null" );
+        validatePolicy( "policy", policy );
+
+        switch ( policy )
+        {
+            case RepositoryPolicy.CHECKSUM_POLICY_IGNORE:
+                return null;
+            case RepositoryPolicy.CHECKSUM_POLICY_FAIL:
+                return new FailChecksumPolicy( resource );
+            case RepositoryPolicy.CHECKSUM_POLICY_WARN:
+                return new WarnChecksumPolicy( resource );
+            default:
+                throw new IllegalArgumentException( "Unsupported policy: " + policy );
+        }
+
     }
 
     public ChecksumPolicy newChecksumPolicy( RepositorySystemSession session, RemoteRepository repository,
@@ -110,7 +131,7 @@ public final class DefaultChecksumPolicyProvider
 
     private static void validatePolicy( String paramName, String policy )
     {
-        Objects.requireNonNull( policy, paramName + "cannot be null" );
+        Objects.requireNonNull( policy, paramName + " cannot be null" );
 
         switch ( policy )
         {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FailChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FailChecksumPolicy.java
@@ -19,6 +19,8 @@ package org.eclipse.aether.internal.impl;
  * under the License.
  */
 
+import java.io.File;
+
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
 
@@ -28,6 +30,11 @@ import org.eclipse.aether.transfer.TransferResource;
 final class FailChecksumPolicy
     extends AbstractChecksumPolicy
 {
+
+    FailChecksumPolicy( File file )
+    {
+        super( file );
+    }
 
     FailChecksumPolicy( TransferResource resource )
     {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/FileProvidedChecksumsSource.java
@@ -20,7 +20,7 @@ package org.eclipse.aether.internal.impl;
  */
 
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ProvidedChecksumsSource;
 import org.eclipse.aether.spi.io.FileProcessor;
@@ -78,7 +78,7 @@ public final class FileProvidedChecksumsSource
 
     @Override
     public Map<String, String> getProvidedArtifactChecksums( RepositorySystemSession session,
-                                                             ArtifactDownload transfer,
+                                                             Artifact artifact,
                                                              List<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
     {
         Path baseDir = getBaseDir( session );
@@ -90,10 +90,10 @@ public final class FileProvidedChecksumsSource
         for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithmFactories )
         {
             checksumFilePaths.add( new ChecksumFilePath(
-                    localPathComposer.getPathForArtifact( transfer.getArtifact(), false ) + '.'
+                    localPathComposer.getPathForArtifact( artifact, false ) + '.'
                     + checksumAlgorithmFactory.getFileExtension(), checksumAlgorithmFactory ) );
         }
-        return getProvidedChecksums( baseDir, checksumFilePaths, ArtifactIdUtils.toId( transfer.getArtifact() ) );
+        return getProvidedChecksums( baseDir, checksumFilePaths, ArtifactIdUtils.toId( artifact ) );
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
@@ -22,6 +22,9 @@ package org.eclipse.aether.internal.impl;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
 
+import java.io.File;
+import java.util.function.Consumer;
+
 /**
  * Implements {@link org.eclipse.aether.repository.RepositoryPolicy#CHECKSUM_POLICY_WARN}.
  */
@@ -29,17 +32,31 @@ final class WarnChecksumPolicy
     extends AbstractChecksumPolicy
 {
 
+    private final Consumer<ChecksumFailureException> onTransferChecksumFailure;
+
+    WarnChecksumPolicy( File file )
+    {
+        super( file );
+        onTransferChecksumFailure = exception -> logger.warn(
+                "Could not validate integrity of available file {}",
+                file.getAbsoluteFile(),
+                exception );
+    }
+
     WarnChecksumPolicy( TransferResource resource )
     {
         super( resource );
+        onTransferChecksumFailure = exception -> logger.warn(
+                "Could not validate integrity of download from {}{}",
+                resource.getRepositoryUrl(),
+                resource.getResourceName(),
+                exception );
     }
 
     @Override
     public boolean onTransferChecksumFailure( ChecksumFailureException exception )
     {
-        logger.warn( "Could not validate integrity of download from {}{}", resource.getRepositoryUrl(),
-                resource.getResourceName(), exception );
+        onTransferChecksumFailure.accept( exception );
         return true;
     }
-
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumPolicy.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumPolicy.java
@@ -22,9 +22,9 @@ package org.eclipse.aether.spi.connector.checksum;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 
 /**
- * A checksum policy gets employed by repository connectors to validate the integrity of a downloaded file. For each
- * downloaded file, a checksum policy instance is obtained and presented with the available checksums to conclude
- * whether the download is valid or not. The following pseudo-code illustrates the usage of a checksum policy by a
+ * A checksum policy gets employed by repository connectors to validate the integrity of a file. For each
+ * file, a checksum policy instance is obtained and presented with the available checksums to conclude
+ * whether the file is valid or not. The following pseudo-code illustrates the usage of a checksum policy by a
  * repository connector in some more detail (the retry logic has been omitted for the sake of brevity):
  *
  * <pre>
@@ -95,19 +95,18 @@ public interface ChecksumPolicy
     }
 
     /**
-     * Signals a match between the locally computed checksum value and the checksum value declared by the remote
-     * repository.
+     * Signals a match between the locally computed checksum value and the expected checksum.
      *
      * @param algorithm The name of the checksum algorithm being used, must not be {@code null}.
      * @param kind      A field providing further details about the checksum.
-     * @return {@code true} to accept the download as valid and stop further validation, {@code false} to continue
+     * @return {@code true} to accept the artifact as valid and stop further validation, {@code false} to continue
      * validation with the next checksum.
      */
     boolean onChecksumMatch( String algorithm, ChecksumKind kind );
 
     /**
-     * Signals a mismatch between the locally computed checksum value and the checksum value declared by the remote
-     * repository. A simple policy would just rethrow the provided exception. More sophisticated policies could update
+     * Signals a mismatch between the locally computed checksum value and the expected checksum. A simple
+     * policy would just rethrow the provided exception. More sophisticated policies could update
      * their internal state and defer a conclusion until all available checksums have been processed.
      *
      * @param algorithm The name of the checksum algorithm being used, must not be {@code null}.
@@ -136,7 +135,7 @@ public interface ChecksumPolicy
      * Signals that all available checksums have been processed.
      *
      * @throws ChecksumFailureException If the checksum validation is to be failed. If the method returns normally, the
-     *                                  download is assumed to be valid.
+     *                                  resource is assumed to be valid.
      */
     void onNoMoreChecksums()
             throws ChecksumFailureException;
@@ -156,8 +155,8 @@ public interface ChecksumPolicy
      *                  {@link #onChecksumMismatch(String, ChecksumKind, ChecksumFailureException)},
      *                  {@link #onChecksumError(String, ChecksumKind, ChecksumFailureException)} or {@link
      *                  #onNoMoreChecksums()}.
-     * @return {@code true} to accept the download nevertheless and let artifact resolution succeed, {@code false} to
-     * reject the transferred file as unusable.
+     * @return {@code true} to accept the file nevertheless and let artifact resolution succeed, {@code false} to
+     * reject the file as unusable.
      */
     boolean onTransferChecksumFailure( ChecksumFailureException exception );
 

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumPolicyProvider.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumPolicyProvider.java
@@ -19,6 +19,8 @@ package org.eclipse.aether.spi.connector.checksum;
  * under the License.
  */
 
+import java.io.File;
+
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.transfer.TransferResource;
@@ -31,6 +33,16 @@ import org.eclipse.aether.transfer.TransferResource;
  */
 public interface ChecksumPolicyProvider
 {
+
+    /**
+     * Retrieves the checksum policy with the specified identifier for use on the given local resource.
+     *
+     * @param session The repository system session during which the request is made, must not be {@code null}.
+     * @param resource The resource on which the policy will be applied, must not be {@code null}.
+     * @param policy The identifier of the policy to apply, must not be {@code null}.
+     * @return The policy to apply or {@code null} if checksums should be ignored.
+     */
+    ChecksumPolicy newChecksumPolicy( RepositorySystemSession session, File resource, String policy );
 
     /**
      * Retrieves the checksum policy with the specified identifier for use on the given remote resource.

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ProvidedChecksumsSource.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ProvidedChecksumsSource.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.ArtifactDownload;
 
 /**
@@ -37,11 +38,26 @@ public interface ProvidedChecksumsSource
      * May return the provided checksums (for given artifact transfer) from trusted source other than remote
      * repository, or {@code null}.
      *
-     * @param transfer The transfer that is about to be executed.
+     * @param artifact The resolved artifact.
      * @param checksumAlgorithmFactories The checksum algorithms that are expected.
      * @return Map of expected checksums, or {@code null}.
      */
     Map<String, String> getProvidedArtifactChecksums( RepositorySystemSession session,
-                                                      ArtifactDownload transfer,
+                                                      Artifact artifact,
                                                       List<ChecksumAlgorithmFactory> checksumAlgorithmFactories );
+    /**
+     * May return the provided checksums (for given artifact transfer) from trusted source other than remote
+     * repository, or {@code null}.
+     *
+     * @param transfer The transfer that is about to be executed.
+     * @param checksumAlgorithmFactories The checksum algorithms that are expected.
+     * @return Map of expected checksums, or {@code null}.
+     */
+    default Map<String, String> getProvidedArtifactChecksums(
+            RepositorySystemSession session,
+            ArtifactDownload transfer,
+            List<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
+    {
+        return getProvidedArtifactChecksums( session, transfer.getArtifact(), checksumAlgorithmFactories );
+    }
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/locator/ServiceLocator.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/locator/ServiceLocator.java
@@ -53,7 +53,8 @@ public interface ServiceLocator
      * 
      * @param <T> The service type.
      * @param type The interface describing the service, must not be {@code null}.
-     * @return The (read-only) list of available service instances, never {@code null}.
+     * @return The (read-only) list of available service instances or {@code null} if no services
+     * could be located/initialized.
      */
     <T> List<T> getServices( Class<T> type );
 


### PR DESCRIPTION
  Artifacts are currently only checksum validated via a ProvidedChecksumsSource if they are
  downloaded from a remote repository. This disables any checksum validation if another
  project already downloaded a corrupted artifact without validating a checksum.