### PR TITLE
[MRESOLVER-269] Allow storage of provided checksums in file format

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SummaryProvidedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SummaryProvidedChecksumsSource.java
@@ -1,0 +1,172 @@
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ProvidedChecksumsSource;
+import org.eclipse.aether.util.ConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Local filesystem backed {@link ProvidedChecksumsSource} implementation that use specified directory as base
+ * directory, where it expects summary files per checksum type in the format 'artifact checksum' per line.
+ * Each file is expected to be named after its represented algorithm, e.g. 'summary.sha256' for SHA-256
+ * checksums.
+ *
+ * @since 1.8.3
+ */
+@Singleton
+@Named( SummaryProvidedChecksumsSource.NAME )
+public final class SummaryProvidedChecksumsSource
+    implements ProvidedChecksumsSource
+{
+    public static final String NAME = "summary";
+
+    static final String CONFIG_PROP_FILE = "aether.artifactResolver.providedChecksumsSource.summary.baseDir";
+
+    static final String LOCAL_REPO_PREFIX = ".checksums";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( SummaryProvidedChecksumsSource.class );
+
+    private final ConcurrentMap<Path, ConcurrentMap<String, Map<String, String>>> cached = new ConcurrentHashMap<>();
+
+    private final Set<Path> read = new HashSet<>();
+
+    @Inject
+    public SummaryProvidedChecksumsSource()
+    {
+    }
+
+    @Override
+    public Map<String, String> getProvidedArtifactChecksums( RepositorySystemSession session,
+                                                             ArtifactDownload transfer,
+                                                             List<ChecksumAlgorithmFactory> checksumAlgorithmFactories )
+    {
+        Path baseDir = getBaseDir( session );
+        if ( baseDir == null )
+        {
+            return null;
+        }
+        ConcurrentMap<String, Map<String, String>> cache = cached.computeIfAbsent(
+                baseDir,
+                path -> new ConcurrentHashMap<>() );
+        readChecksums( baseDir, checksumAlgorithmFactories, cache );
+        Map<String, String> values = cache.get( transfer.getArtifact().toString() );
+        return values == null ? null : Collections.unmodifiableMap( values );
+    }
+
+    /**
+     * Populates the cache of previously read files.
+     */
+    private void readChecksums( Path baseDir,
+                                List<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
+                                ConcurrentMap<String, Map<String, String>> cache )
+    {
+        for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithmFactories )
+        {
+            Path file = baseDir.resolve( "summary." + checksumAlgorithmFactory.getFileExtension() );
+            if ( Files.isRegularFile( file )
+                    && Files.isReadable( file )
+                    && read.add( file ) )
+            {
+                try ( BufferedReader reader = Files.newBufferedReader( file ) )
+                {
+                    String line;
+                    while ( ( line = reader.readLine() ) != null )
+                    {
+                        String[] segments = line.split( " ", 2 );
+                        if ( segments.length != 2 )
+                        {
+                            LOGGER.debug(
+                                    "Ignored line '{}' in '{}' which does not follow the expected checksum format",
+                                    line, file );
+                        }
+                        else
+                        {
+                            cache.merge( segments[0],
+                                    Collections.singletonMap( checksumAlgorithmFactory.getName(), segments[1] ),
+                                    ( left, right ) ->
+                                    {
+                                        Map<String, String> merged = new HashMap<>();
+                                        merged.putAll( left );
+                                        merged.putAll( right );
+                                        right.forEach( ( key, value ) ->
+                                        {
+                                            String previous = left.get( key );
+                                            if ( previous != null  && !previous.equals( value ) )
+                                            {
+                                                LOGGER.warn(
+                                                        "Found both checksums '{}' and '{}' for '{}', using latter",
+                                                        previous, value, checksumAlgorithmFactory.getName() );
+                                            }
+                                        } );
+                                        return merged;
+                                    } );
+                        }
+                    }
+                }
+                catch ( IOException e )
+                {
+                    LOGGER.warn( "Could not read provided checksum for '{}' at path '{}'",
+                            checksumAlgorithmFactory.getName(), file, e );
+                }
+            }
+        }
+    }
+
+    private Path getBaseDir( RepositorySystemSession session )
+    {
+        String baseDirPath = ConfigUtils.getString( session, null, CONFIG_PROP_FILE );
+        Path baseDir;
+        if ( baseDirPath != null )
+        {
+            baseDir = Paths.get( baseDirPath );
+        }
+        else
+        {
+            baseDir = session.getLocalRepository().getBasedir().toPath().resolve( LOCAL_REPO_PREFIX );
+        }
+        if ( !Files.isDirectory( baseDir ) )
+        {
+            return null;
+        }
+        return baseDir;
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SummaryProvidedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SummaryProvidedChecksumsSourceTest.java
@@ -1,0 +1,105 @@
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class SummaryProvidedChecksumsSourceTest {
+
+    private DefaultRepositorySystemSession session;
+
+    private RepositoryLayout repositoryLayout;
+
+    private SummaryProvidedChecksumsSource subject;
+
+    @Before
+    public void setup() throws NoRepositoryLayoutException, IOException
+    {
+        RemoteRepository repository = new RemoteRepository.Builder("test", "default", "https://irrelevant.com").build();
+        session = TestUtils.newSession();
+        repositoryLayout = new Maven2RepositoryLayoutFactory().newInstance(session, repository);
+        subject = new SummaryProvidedChecksumsSource();
+
+        // populate local repository
+        Path baseDir = session.getLocalRepository().getBasedir().toPath().resolve( SummaryProvidedChecksumsSource.LOCAL_REPO_PREFIX );
+
+        // artifact: test:test:2.0 => "foobar"
+        {
+            Path test = baseDir.resolve("summary.sha1");
+            Files.createDirectories(test.getParent());
+            Files.write(test, "test:test:jar:2.0 foobar".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void noProvidedArtifactChecksum()
+    {
+        ArtifactDownload transfer = new ArtifactDownload(
+                new DefaultArtifact("test:test:1.0"),
+                "irrelevant",
+                new File("irrelevant"),
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL
+        );
+        Map<String, String> providedChecksums = subject.getProvidedArtifactChecksums(
+                session,
+                transfer,
+                repositoryLayout.getChecksumAlgorithmFactories()
+        );
+        assertNull(providedChecksums);
+    }
+
+    @Test
+    public void haveProvidedArtifactChecksum()
+    {
+        ArtifactDownload transfer = new ArtifactDownload(
+                new DefaultArtifact("test:test:2.0"),
+                "irrelevant",
+                new File("irrelevant"),
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL
+        );
+        Map<String, String> providedChecksums = subject.getProvidedArtifactChecksums(
+                session,
+                transfer,
+                repositoryLayout.getChecksumAlgorithmFactories()
+        );
+        assertNotNull(providedChecksums);
+        assertEquals(providedChecksums.get(Sha1ChecksumAlgorithmFactory.NAME), "foobar");
+    }
+
+}


### PR DESCRIPTION
  Allow Maven to read provided checksums from files per
  checksum algorithm. Files are more version control system
  friendly what improves their existence within projects.
  Single files are also easier to download when offering large
  checksum collections.