### PR TITLE
[MRESOLVER-266] Simplify named lock adapter creation and align config source

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-api</artifactId>

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-connector-basic</artifactId>

--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver-demos</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>resolver-demo-maven-plugin</artifactId>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver-demos</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-demo-snippets</artifactId>

--- a/maven-resolver-demos/pom.xml
+++ b/maven-resolver-demos/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-demos</artifactId>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-impl</artifactId>

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -142,6 +142,7 @@ public final class Maven2RepositoryLayoutFactory
         }
 
         return new Maven2RepositoryLayout(
+                new ArrayList<>( checksumAlgorithmFactorySelector.getChecksumAlgorithmFactories() ),
                 checksumsAlgorithms,
                 omitChecksumsForExtensions
         );
@@ -150,15 +151,18 @@ public final class Maven2RepositoryLayoutFactory
     private static class Maven2RepositoryLayout
             implements RepositoryLayout
     {
+        private final List<ChecksumAlgorithmFactory> allChecksumAlgorithms;
 
-        private final List<ChecksumAlgorithmFactory> checksumAlgorithms;
+        private final List<ChecksumAlgorithmFactory> configuredChecksumAlgorithms;
 
         private final Set<String> extensionsWithoutChecksums;
 
-        private Maven2RepositoryLayout( List<ChecksumAlgorithmFactory> checksumAlgorithms,
+        private Maven2RepositoryLayout( List<ChecksumAlgorithmFactory> allChecksumAlgorithms,
+                                        List<ChecksumAlgorithmFactory> configuredChecksumAlgorithms,
                                         Set<String> extensionsWithoutChecksums )
         {
-            this.checksumAlgorithms = Collections.unmodifiableList( checksumAlgorithms );
+            this.allChecksumAlgorithms = Collections.unmodifiableList( allChecksumAlgorithms );
+            this.configuredChecksumAlgorithms = Collections.unmodifiableList( configuredChecksumAlgorithms );
             this.extensionsWithoutChecksums = requireNonNull( extensionsWithoutChecksums );
         }
 
@@ -177,7 +181,7 @@ public final class Maven2RepositoryLayoutFactory
         @Override
         public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
         {
-            return checksumAlgorithms;
+            return configuredChecksumAlgorithms;
         }
 
         @Override
@@ -263,8 +267,8 @@ public final class Maven2RepositoryLayoutFactory
 
         private List<ChecksumLocation> getChecksumLocations( URI location )
         {
-            List<ChecksumLocation> checksumLocations = new ArrayList<>( checksumAlgorithms.size() );
-            for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithms )
+            List<ChecksumLocation> checksumLocations = new ArrayList<>( configuredChecksumAlgorithms.size() );
+            for ( ChecksumAlgorithmFactory checksumAlgorithmFactory : configuredChecksumAlgorithms )
             {
                 checksumLocations.add( ChecksumLocation.forLocation( location, checksumAlgorithmFactory ) );
             }
@@ -273,7 +277,7 @@ public final class Maven2RepositoryLayoutFactory
 
         private boolean isChecksum( String extension )
         {
-            return checksumAlgorithms.stream().anyMatch( a -> extension.endsWith( "." + a.getFileExtension() ) );
+            return allChecksumAlgorithms.stream().anyMatch( a -> extension.endsWith( "." + a.getFileExtension() ) );
         }
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
@@ -332,6 +332,17 @@ public class Maven2RepositoryLayoutFactoryTest
     }
 
     @Test
+    public void testNotConfiguredButSupportedChecksumsHandledAsChecksums()
+            throws Exception
+    {
+        layout = factory.newInstance( session, newRepo( "default" ) );
+        DefaultArtifact artifact = new DefaultArtifact( "g.i.d", "a-i.d", "cls", "jar.sha512", "1.0" );
+        URI uri = layout.getLocation( artifact, true );
+        List<ChecksumLocation> checksums = layout.getChecksumLocations( artifact, true, uri );
+        assertEquals( 0, checksums.size() );
+    }
+
+    @Test
     public void testCustomChecksumsIgnored_IllegalInout()
             throws Exception
     {

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks-hazelcast</artifactId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks-redisson</artifactId>
@@ -38,6 +38,8 @@
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.named.redisson</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
+    <!-- Used in site also -->
+    <redissonVersion>3.17.5</redissonVersion>
   </properties>
 
   <dependencies>
@@ -52,7 +54,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>3.15.6</version>
+      <version>${redissonVersion}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.cache</groupId>
@@ -73,6 +75,14 @@
         <exclusion>
           <groupId>io.reactivex.rxjava3</groupId>
           <artifactId>rxjava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/maven-resolver-named-locks-redisson/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks-redisson/src/site/markdown/index.md.vm
@@ -46,27 +46,32 @@ To use this implementation within your project, depending on how you integrate, 
 
 ${esc.hash}${esc.hash} Installation/Testing
 
+#set( $jacksonVersion = "2.13.3" )
+#set( $jbossMarshallingVersion = "2.0.11.Final" )
+#set( $nettyVersion = "4.1.79.Final" )
+#set( $snakeyamlVersion = "1.30" )
+
 - Create the directory `${maven.home}/lib/ext/redisson/`.
 - Modify `${maven.home}/bin/m2.conf` by adding `load ${maven.home}/lib/ext/redisson/*.jar`
   right after the `${maven.conf}/logging` line.
 - Copy the following dependencies from Maven Central to `${maven.home}/lib/ext/redisson/`:
   <pre class="source">
   ├── <a href="https://repo1.maven.org/maven2/org/apache/maven/resolver/${project.artifactId}/${project.version}/${project.artifactId}-${project.version}.jar">${project.artifactId}-${project.version}.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar">jackson-annotations-2.12.1.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.jar">jackson-core-2.12.1.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.1/jackson-databind-2.12.1.jar">jackson-databind-2.12.1.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.12.1/jackson-dataformat-yaml-2.12.1.jar">jackson-dataformat-yaml-2.12.1.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling/2.0.11.Final/jboss-marshalling-2.0.11.Final.jar">jboss-marshalling-2.0.11.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling-river/2.0.11.Final/jboss-marshalling-river-2.0.11.Final.jar">jboss-marshalling-river-2.0.11.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.65.Final/netty-buffer-4.1.65.Final.jar">netty-buffer-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.65.Final/netty-codec-4.1.65.Final.jar">netty-codec-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.65.Final/netty-codec-dns-4.1.65.Final.jar">netty-codec-dns-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-common/4.1.65.Final/netty-common-4.1.65.Final.jar">netty-common-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.65.Final/netty-handler-4.1.65.Final.jar">netty-handler-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.65.Final/netty-resolver-4.1.65.Final.jar">netty-resolver-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.65.Final/netty-resolver-dns-4.1.65.Final.jar">netty-resolver-dns-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.65.Final/netty-transport-4.1.65.Final.jar">netty-transport-4.1.65.Final.jar</a>
-  ├── <a href="https://repo1.maven.org/maven2/org/redisson/redisson/3.15.6/redisson-3.15.6.jar">redisson-3.15.6.jar</a>
-  └── <a href="https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.27/snakeyaml-1.27.jar">snakeyaml-1.27.jar</a></pre>
+  ├── <a href="https://repo1.maven.org/maven2/org/redisson/redisson/${redissonVersion}/redisson-${redissonVersion}.jar">redisson-${redissonVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/${jacksonVersion}/jackson-annotations-${jacksonVersion}.jar">jackson-annotations-${jacksonVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/${jacksonVersion}/jackson-core-${jacksonVersion}.jar">jackson-core-${jacksonVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/${jacksonVersion}/jackson-databind-${jacksonVersion}.jar">jackson-databind-${jacksonVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/${jacksonVersion}/jackson-dataformat-yaml-${jacksonVersion}.jar">jackson-dataformat-yaml-${jacksonVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling/${jbossMarshallingVersion}/jboss-marshalling-${jbossMarshallingVersion}.jar">jboss-marshalling-${jbossMarshallingVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling-river/${jbossMarshallingVersion}/jboss-marshalling-river-${jbossMarshallingVersion}.jar">jboss-marshalling-river-${jbossMarshallingVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-buffer/${nettyVersion}/netty-buffer-${nettyVersion}.jar">netty-buffer-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-codec/${nettyVersion}/netty-codec-${nettyVersion}.jar">netty-codec-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-codec-dns/${nettyVersion}/netty-codec-dns-${nettyVersion}.jar">netty-codec-dns-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-common/${nettyVersion}/netty-common-${nettyVersion}.jar">netty-common-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-handler/${nettyVersion}/netty-handler-${nettyVersion}.jar">netty-handler-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-resolver/${nettyVersion}/netty-resolver-${nettyVersion}.jar">netty-resolver-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/${nettyVersion}/netty-resolver-dns-${nettyVersion}.jar">netty-resolver-dns-${nettyVersion}.jar</a>
+  ├── <a href="https://repo1.maven.org/maven2/io/netty/netty-transport/${nettyVersion}/netty-transport-${nettyVersion}.jar">netty-transport-${nettyVersion}.jar</a>
+  └── <a href="https://repo1.maven.org/maven2/org/yaml/snakeyaml/${snakeyamlVersion}/snakeyaml-${snakeyamlVersion}.jar">snakeyaml-${snakeyamlVersion}.jar</a></pre>
 - Start your Redis instance on `localhost` or configure a remote instance with `${maven.conf}/maven-resolver-redisson.yaml`.
 - Now start a multithreaded Maven build on your project.

--- a/maven-resolver-named-locks/pom.xml
+++ b/maven-resolver-named-locks/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks</artifactId>

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -23,28 +23,41 @@ Named locks are essentially locks that are assigned to some given (opaque) ID. I
 resources that each can have unique ID assigned (i.e., file with an absolute path, some entities with unique ID),
 then you can use named locks to make sure they are being protected from concurrent read and write actions.
 
-Named locks provide support classes for implementations, and provide out of the box seven named lock implementations and three name mappers.
+Named locks provide support classes for implementations, and provide out of the box several lock and name mapper implementations.
 
-Out of the box, "local" (local to JVM) named lock implementations are the following:
+Following implementations are "local" (local to JVM) named lock implementations:
 
 - `rwlock-local` implemented in `org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory` that uses
   JVM `java.util.concurrent.locks.ReentrantReadWriteLock`.
 - `semaphore-local` implemented in `org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory` that uses
   JVM `java.util.concurrent.Semaphore`.
-- `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
-  JVM `java.nio.channels.FileLock`.
 - `noop` implemented in `org.eclipse.aether.named.providers.NoopNamedLockFactory` that uses no locking.
 
-Out of the box, "distributed" named lock implementations are the following (separate modules which require additional dependencies):
+Note about "local" locks: they are in-JVM, in a way, they properly coordinate in case of multithreaded access from
+same JVM, but do not cover accesses across multiple processes and/or multiple hosts access.
+In other words, local named locks are only suited within one JVM with a multithreaded access.
+
+Following named lock implementations use underlying file system advisory file locking:
+
+- `file-lock` implemented in `org.eclipse.aether.named.providers.FileLockNamedLockFactory` that uses
+  JVM `java.nio.channels.FileLock`.
+
+The `file-lock` implementation uses file system advisory file locking, hence, concurrently running Maven processes
+set up to use `file-lock` implementation can safely share one local repository. This is almost certain on
+local file systems across all operating systems. In case of NFS mounts, file advisory locking MAY work if NFSv4+
+used with complete setup (with all the necessary services like `RPC` and `portmapper` needed to implement NFS advisory
+file locking, check your NFS and/or OS manuals for details). In short: if your (local or remote) FS correctly support
+and implements advisory locking, it should work. Local FS usually does, while with NFS your mileage may vary.
+
+Finally, "distributed" named lock implementations are the following (separate modules which require additional dependencies and remote services):
 
 - `rwlock-redisson` implemented in `org.eclipse.aether.named.redisson.RedissonReadWriteLockNamedLockFactory`.
 - `semaphore-redisson` implemented in `org.eclipse.aether.named.redisson.RedissonSemaphoreNamedLockFactory`.
 - `semaphore-hazelcast-client` implemented in `org.eclipse.aether.named.hazelcast.HazelcastClientCPSemaphoreNamedLockFactory`.
 - `semaphore-hazelcast` implemented in `org.eclipse.aether.named.hazelcast.HazelcastCPSemaphoreNamedLockFactory`.
 
-Local named locks are only suited within one JVM with a multithreaded build.
-Sharing a local repository between multiple Maven processes (i.e., on a busy CI server) requires a distributed named lock!
-
+Sharing a local repository between multiple hosts (i.e., on a busy CI server) may be best done with one of distributed named lock,
+if NFS locking is not working for you.
 
 The aforementioned (opaque) IDs need to be mapped from artifacts and metadata.
 
@@ -54,3 +67,5 @@ Out of the box, name mapper implementations are the following:
 - `gav` implemented in `org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper`.
 - `discriminating` implemented in `org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper`.
 - `file-gav` implemented in `org.eclipse.aether.internal.impl.synccontext.named.FileGAVNameMapper`.
+
+Note: the `file-gav` name mapper MUST be used with `file-lock` named locking, no other mapper will work with it.

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-spi</artifactId>

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-test-util</artifactId>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-classpath</artifactId>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-file</artifactId>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-http</artifactId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-wagon</artifactId>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.8.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>36</version>
+    <version>37</version>
     <relativePath />
   </parent>
 
   <groupId>org.apache.maven.resolver</groupId>
   <artifactId>maven-resolver</artifactId>
-  <version>1.8.2-SNAPSHOT</version>
+  <version>1.8.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Maven Artifact Resolver</name>
@@ -59,7 +59,7 @@
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>
-    <url>https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-resolver/</url>
+    <url>https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-resolver/</url>
   </ciManagement>
   <distributionManagement>
     <site>
@@ -79,7 +79,7 @@
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <project.build.outputTimestamp>2022-06-10T15:27:07Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2022-07-25T16:26:16Z</project.build.outputTimestamp>
   </properties>
 
   <modules>
@@ -381,7 +381,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M6</version>
           <configuration>
             <argLine>-Xmx128m</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
@@ -393,7 +392,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M6</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
             <argLine>-Xmx128m</argLine>
@@ -433,14 +431,14 @@
               <exclude>src/test/resources/**/*.ini</exclude>
               <exclude>src/test/resources/**/*.txt</exclude>
               <exclude>src/test/resources/ssl/*-store</exclude>
-              <exclude>.travis.yml</exclude>
+              <exclude>.gitattributes</exclude>
             </excludes>
           </configuration>
         </plugin>
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
-          <version>6.2.0</version>
+          <version>6.3.1</version>
           <executions>
             <execution>
               <id>bnd-process</id>

--- a/src/site/markdown/local-repository.md
+++ b/src/site/markdown/local-repository.md
@@ -25,30 +25,16 @@ remote, but also to store the artifacts locally installed (locally built and
 installed, to be more precise). Both of these artifacts were stored in bulk 
 in the local repository.
 
+## Implementations
+
 Local repository implementations implement the `LocalRepositoryManager` (LRM) 
 interface, and Resolver out of the box provides two implementations for it: 
-"simple" and "enhanced". 
+"enhanced" used at runtime and "simple" meant to be used in tests and alike
+scenarios (is not meant for production use). 
 
-## Simple LRM
+### Enhanced LRM
 
-Simple is a fully functional LRM implementation, but is used 
-mainly in tests, it is not recommended in production environments. 
-
-To manually instantiate a simple LRM, one needs to invoke following code:
-
-```java
-LocalRepositoryManager simple = new SimpleLocalRepositoryManagerFactory()
-        .newInstance( session, new LocalRepository( baseDir ) );
-```
-
-Note: This code snippet above instantiates a component, that is not 
-recommended way to use it, as it should be rather injected whenever possible. 
-This example above is merely a showcase how to obtain LRM implementation 
-in unit tests.
-
-## Enhanced LRM
-
-Enhanced LRM on the other hand is enhanced with several extra 
+Enhanced LRM is enhanced with several extra 
 features, one most notable is scoping cached content by its origin and context: 
 if you downloaded an artifact A1 from repository R1 
 and later initiate build that requires same artifact A1, but repository R1 
@@ -58,7 +44,7 @@ Those two, originating from two different repositories may not be the same thing
 This is meant to protect users from "bad practice" (artifact coordinates are 
 unique in ideal world).
 
-### Split Local Repository
+#### Split Local Repository
 
 Latest addition to the enhanced LRM is *split* feature. By default, split 
 feature is **not enabled**, enhanced LRM behaves as it behaved in all 
@@ -75,7 +61,7 @@ The split feature is implemented by the `LocalPathPrefixComposer` interface,
 that adds different "prefixes" for the locally stored artifacts, based on 
 their context.
 
-#### Note About Release And Snapshot Differentiation
+##### Note About Release And Snapshot Differentiation
 
 The prefix composer is able to differentiate between release and snapshot 
 versioned artifacts, and this is clear-cut: Maven Artifacts are either 
@@ -99,7 +85,7 @@ The GAV level metadata gets differentiated based on version it carries, so
 they may end up in releases or snapshots, depending on their value of 
 `metadata/version` field.
 
-#### Use Cases
+##### Use Cases
 
 Most direct use case is simpler local repository eviction. One can delete all 
 locally built artifacts without deleting the cached ones, hence, no 
@@ -139,7 +125,7 @@ $ mvn ... -Daether.enhancedLocalRepository.split \
 For complete reference of enhanced LRM configuration possibilities, refer to 
 [configuration page](configuration.html).
 
-#### Split Repository Considerations
+##### Split Repository Considerations
 
 **Word of warning**: on every change of "split" parameters, user must be aware
 of the consequences. For example, if one change all aspects of split
@@ -149,7 +135,7 @@ is unchanged! Simply put, as all prefixes will be "new", the composed paths will
 point to potentially non-existing locations, hence, resolver will consider
 it as a "new" local repository in every aspect.
 
-#### Implementing Custom Split Strategy
+##### Implementing Custom Split Strategy
 
 To implement custom split strategy, one needs to create a component of
 type `LocalPathPrefixComposerFactory` and override the default component
@@ -160,3 +146,37 @@ class that provides all the defaults.
 The factory should create a stateless instance of a composer
 configured from passed in session, that will be used with the enhanced LRM
 throughout the session.
+
+### Simple LRM
+
+Simple is a fully functional LRM implementation, but is used
+mainly in tests, it is not recommended in production environments.
+
+To manually instantiate a simple LRM, one needs to invoke following code:
+
+```java
+LocalRepositoryManager simple = new SimpleLocalRepositoryManagerFactory()
+        .newInstance( session, new LocalRepository( baseDir ) );
+```
+
+Note: This code snippet above instantiates a component, that is not
+recommended way to use it, as it should be rather injected whenever possible.
+This example above is merely a showcase how to obtain LRM implementation
+in unit tests.
+
+## Shared Access to Local Repository
+
+In case of shared (multi-threaded, multi-process or even multi host) access
+to local repository, coordination is a must, as local repository is hosted
+on file system, and each thread may read and write concurrently into it,
+causing other threads or processes to get incomplete or partially written data.
+
+Hence, since Resolver 1.7.x version, there is a pluggable API called "Named Locks" 
+available, providing out of the box lock implementations for cases like:
+
+* multi-threaded, in JVM locking (the default)
+* multi-process locking using file system advisory locking
+* multi-host locking using Hazelcast or Redisson (needs Hazelcast or Redisson cluster)
+
+For details see [Named Locks module](maven-resolver-named-locks/).
+

--- a/src/site/markdown/maven-3.8.x.md
+++ b/src/site/markdown/maven-3.8.x.md
@@ -23,5 +23,7 @@ factory has been implemented. Both are not compatible with Maven 3.8.x anymore w
 Java 7 to run. Maven 3.8.x will continue to use version 1.6.x which you will find
 [here](/resolver-archives/resolver-1.6.3/).
 This also means that you cannot make use of the features provided by version 1.7.0 and later.
-If you require the changes in this version, but must use Maven 3.8.x, you can build an adapted version
-of Maven from the branch [`maven-3.8.x-maven-resolver-1.7.x`](https://github.com/apache/maven/tree/maven-3.8.x-resolver-1.7.x) and use as if you would use Maven 4.
+If you require the changes from this version, but must use Maven 3.8.x, you can build yourself an adapted version
+of Maven from the branch [`maven-3.8.x-resolver-1.8.x`](https://github.com/apache/maven/tree/maven-3.8.x-resolver-1.8.x)
+with Java 8 requirement or use signed binaries and source from the [dev dist area](https://dist.apache.org/repos/dist/dev/maven/maven-3/3.8.x-resolver-1.8.x/)
+and use it as if you would use Maven 3.9.x.


### PR DESCRIPTION
Simplified adapter creation and now as everything else in resolver, session
config properties are used as configuration source, not Java system
properties.

---

https://issues.apache.org/jira/browse/MRESOLVER-266

---

Supersede https://github.com/apache/maven-resolver/pull/188