### PR TITLE
[MRESOLVER-274] Remote Repository Filter

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -56,6 +56,7 @@ import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
@@ -227,6 +228,7 @@ public final class DefaultServiceLocator
         addService( TrackingFileManager.class, DefaultTrackingFileManager.class );
         addService( ChecksumAlgorithmFactorySelector.class, DefaultChecksumAlgorithmFactorySelector.class );
         addService( LocalPathComposer.class, DefaultLocalPathComposer.class );
+        addService( RemoteRepositoryFilterManager.class, DefaultRemoteRepositoryFilterManager.class );
     }
 
     private <T> Entry<T> getEntry( Class<T> type, boolean create )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryFilterManager.java
@@ -1,0 +1,38 @@
+package org.eclipse.aether.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+
+/**
+ * Remote repository filter manager.
+ *
+ * @since TBD
+ */
+public interface RemoteRepositoryFilterManager
+{
+    /**
+     * Provides the filter instance for given session, or {@code null} if no filtering applied.
+     *
+     * @return The session bound filter or {@code null} if no filtering applied.
+     */
+    RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session );
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
@@ -1,0 +1,163 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default implementation of {@link RemoteRepositoryFilterManager}, it always returns a {@link RemoteRepositoryFilter}
+ * instance, even if no filter sources enabled/registered (then "always allow" instance).
+ * <p>
+ * The created {@link RemoteRepositoryFilter} instance is created once per session and cached.
+ *
+ * @since TBD
+ */
+@Singleton
+@Named
+public final class DefaultRemoteRepositoryFilterManager
+        implements RemoteRepositoryFilterManager
+{
+    private static final String INSTANCE_KEY = DefaultRemoteRepositoryFilterManager.class.getName() + ".instance";
+
+    private final Map<String, RemoteRepositoryFilterSource> sources;
+
+    /**
+     * SL enabled ctor.
+     *
+     * @deprecated for SL and testing purposes only.
+     */
+    @Deprecated
+    public DefaultRemoteRepositoryFilterManager()
+    {
+        this.sources = new HashMap<>();
+    }
+
+    @Inject
+    public DefaultRemoteRepositoryFilterManager( Map<String, RemoteRepositoryFilterSource> sources )
+    {
+        this.sources = requireNonNull( sources );
+    }
+
+    @Override
+    public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+    {
+        return (RemoteRepositoryFilter) session.getData().computeIfAbsent( INSTANCE_KEY, () ->
+                {
+                    HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
+                    for ( Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet() )
+                    {
+                        RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter( session );
+                        if ( filter != null )
+                        {
+                            filters.put( entry.getKey(), filter );
+                        }
+                    }
+                    if ( !filters.isEmpty() )
+                    {
+                        return new Participants( filters );
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+        );
+    }
+
+    /**
+     * {@link RemoteRepositoryFilter} instance when there are participant filters present. It evaluates into result
+     * using {@link Consensus}.
+     */
+    private static class Participants implements RemoteRepositoryFilter
+    {
+        private final Map<String, RemoteRepositoryFilter> participants;
+
+        private Participants( Map<String, RemoteRepositoryFilter> participants )
+        {
+            this.participants = Collections.unmodifiableMap( participants );
+        }
+
+        @Override
+        public RemoteRepositoryFilter.Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+        {
+            return new Consensus( participants.entrySet().stream()
+                    .collect( Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue().acceptArtifact( remoteRepository, artifact ) ) ) );
+        }
+
+        @Override
+        public RemoteRepositoryFilter.Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+        {
+            return new Consensus( participants.entrySet().stream()
+                    .collect( Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.getValue().acceptMetadata( remoteRepository, metadata ) ) ) );
+        }
+    }
+
+    /**
+     * {@link RemoteRepositoryFilter.Result} based on "consensus". All participant have to "accept" to make this
+     * instance "accept".
+     */
+    private static class Consensus implements RemoteRepositoryFilter.Result
+    {
+        private final boolean accepted;
+
+        private final String reasoning;
+
+        Consensus( Map<String, RemoteRepositoryFilter.Result> results )
+        {
+            this.accepted = results.values().stream().allMatch( RemoteRepositoryFilter.Result::isAccepted );
+            this.reasoning = results.values().stream().filter( r -> !r.isAccepted() ).map(
+                    RemoteRepositoryFilter.Result::reasoning ).collect(
+                    Collectors.joining( "; " ) );
+        }
+
+        @Override
+        public boolean isAccepted()
+        {
+            return accepted;
+        }
+
+        @Override
+        public String reasoning()
+        {
+            return reasoning;
+        }
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringRepositoryConnector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringRepositoryConnector.java
@@ -1,0 +1,124 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.ArtifactUpload;
+import org.eclipse.aether.spi.connector.MetadataDownload;
+import org.eclipse.aether.spi.connector.MetadataUpload;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
+import org.eclipse.aether.transfer.MetadataNotFoundException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A filtering connector that filter transfers using remote repository filter and delegates to another connector.
+ *
+ * @since TBD
+ */
+public final class FilteringRepositoryConnector
+        implements RepositoryConnector
+{
+    private final RemoteRepository remoteRepository;
+
+    private final RepositoryConnector delegate;
+
+    private final RemoteRepositoryFilter remoteRepositoryFilter;
+
+    public FilteringRepositoryConnector( RemoteRepository remoteRepository,
+                                         RepositoryConnector delegate,
+                                         RemoteRepositoryFilter remoteRepositoryFilter )
+    {
+        this.remoteRepository = requireNonNull( remoteRepository );
+        this.delegate = requireNonNull( delegate );
+        this.remoteRepositoryFilter = requireNonNull( remoteRepositoryFilter );
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+
+    @Override
+    public void get( Collection<? extends ArtifactDownload> artifactDownloads,
+                     Collection<? extends MetadataDownload> metadataDownloads )
+    {
+        List<ArtifactDownload> filteredArtifactDownloads = null;
+        if ( artifactDownloads != null && !artifactDownloads.isEmpty() )
+        {
+            filteredArtifactDownloads = new ArrayList<>( artifactDownloads.size() );
+            for ( ArtifactDownload artifactDownload : artifactDownloads )
+            {
+                RemoteRepositoryFilter.Result result = remoteRepositoryFilter.acceptArtifact(
+                        remoteRepository, artifactDownload.getArtifact() );
+                if ( result.isAccepted() )
+                {
+                    filteredArtifactDownloads.add( artifactDownload );
+                }
+                else
+                {
+                    artifactDownload.setException( new ArtifactNotFoundException( artifactDownload.getArtifact(),
+                            remoteRepository, result.reasoning() ) );
+                }
+            }
+        }
+        List<MetadataDownload> filteredMetadataDownloads = null;
+        if ( metadataDownloads != null && !metadataDownloads.isEmpty() )
+        {
+            filteredMetadataDownloads = new ArrayList<>( metadataDownloads.size() );
+            for ( MetadataDownload metadataDownload : metadataDownloads )
+            {
+                RemoteRepositoryFilter.Result result = remoteRepositoryFilter.acceptMetadata(
+                        remoteRepository, metadataDownload.getMetadata() );
+                if ( result.isAccepted() )
+                {
+                    filteredMetadataDownloads.add( metadataDownload );
+                }
+                else
+                {
+                    metadataDownload.setException( new MetadataNotFoundException( metadataDownload.getMetadata(),
+                            remoteRepository, result.reasoning() ) );
+                }
+            }
+        }
+        delegate.get( filteredArtifactDownloads, filteredMetadataDownloads );
+    }
+
+    @Override
+    public void put( Collection<? extends ArtifactUpload> artifactUploads,
+                     Collection<? extends MetadataUpload> metadataUploads )
+    {
+        delegate.put( artifactUploads, metadataUploads );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "filtered(" + delegate.toString() + ")";
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
@@ -1,0 +1,319 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.aether.MultiRuntimeException;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.resolution.ArtifactResolverPostProcessor;
+import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Remote repository filter source filtering on G coordinate. It is backed by a file that lists all allowed groupIds
+ * and groupId not present in this file are filtered out.
+ * <p>
+ * The file can be authored manually: format is one groupId per line, comments starting with "#" (hash) amd empty lines
+ * for structuring are supported. The file can also be pre-populated by "record" functionality of this filter.
+ * When "recording", this filter will not filter out anything, but will instead populate the file with all encountered
+ * groupIds.
+ * <p>
+ * The groupId file is expected on path "${basedir}/groupId-${repository.id}.txt".
+ * <p>
+ * The groupId file once loaded are cached in session, so in-flight groupId file change during session are NOT
+ * noticed.
+ *
+ * @since TBD
+ */
+@Singleton
+@Named( GroupIdRemoteRepositoryFilterSource.NAME )
+public final class GroupIdRemoteRepositoryFilterSource
+        extends RemoteRepositoryFilterSourceSupport
+        implements ArtifactResolverPostProcessor
+{
+    public static final String NAME = "groupId";
+
+    private static final String CONF_NAME_RECORD = "record";
+
+    private static final String CONF_NAME_TRUNCATE_ON_SAVE = "truncateOnSave";
+
+    static final String GROUP_ID_FILE_PREFIX = "groupId-";
+
+    static final String GROUP_ID_FILE_SUFFIX = ".txt";
+
+    /**
+     * Key of rules cache in session data as remoteRepository.id -> Set(groupID).
+     */
+    private static final String RULES_KEY = GroupIdRemoteRepositoryFilterSource.class.getName() + ".rules";
+
+    private static final String ON_CLOSE_HANDLER_REG_KEY = GroupIdRemoteRepositoryFilterSource.class.getName()
+            + ".onCloseHandlerReg";
+
+    private static final String NEW_GROUP_ID_RECORDED_KEY = GroupIdRemoteRepositoryFilterSource.class.getName()
+            + ".newGroupIdRecorded";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( GroupIdRemoteRepositoryFilterSource.class );
+
+    @Inject
+    public GroupIdRemoteRepositoryFilterSource()
+    {
+        super( NAME );
+    }
+
+    @Override
+    public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+    {
+        if ( isEnabled( session ) && !isRecord( session ) )
+        {
+            if ( Files.isDirectory( getBasedir( session, false ) ) )
+            {
+                return new GroupIdFilter( session );
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void postProcess( RepositorySystemSession session, List<ArtifactResult> artifactResults )
+    {
+        if ( isEnabled( session ) && isRecord( session ) )
+        {
+            if ( onCloseHandlerRegistered( session ).compareAndSet( false, true ) )
+            {
+                session.addOnCloseHandler( this::saveSessionRecordedLines );
+            }
+            ConcurrentHashMap<String, Set<String>> cache = cache( session );
+            for ( ArtifactResult artifactResult : artifactResults )
+            {
+                if ( artifactResult.isResolved() && artifactResult.getRepository() instanceof RemoteRepository )
+                {
+                    boolean newGroupId = cache.computeIfAbsent( artifactResult.getRepository().getId(),
+                                    f -> Collections.synchronizedSet( new TreeSet<>() ) )
+                            .add( artifactResult.getArtifact().getGroupId() );
+                    if ( newGroupId )
+                    {
+                        newGroupIdRecorded( session ).set( true );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the groupId path. The file and parents may not exist, this method merely calculate the path.
+     */
+    private Path filePath( Path basedir, String remoteRepositoryId )
+    {
+        return basedir.resolve(
+                GROUP_ID_FILE_PREFIX + remoteRepositoryId + GROUP_ID_FILE_SUFFIX );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private ConcurrentHashMap<String, Set<String>> cache( RepositorySystemSession session )
+    {
+        return ( (ConcurrentHashMap<String, Set<String>>) session.getData()
+                .computeIfAbsent( RULES_KEY, ConcurrentHashMap::new ) );
+    }
+
+    private Set<String> cacheRules( RepositorySystemSession session,
+                                    RemoteRepository remoteRepository )
+    {
+        return cache( session ).computeIfAbsent( remoteRepository.getId(), id ->
+                {
+                    Set<String> rules = loadRepositoryRules(
+                            filePath( getBasedir( session, false ), remoteRepository.getId() ) );
+                    if ( rules != NOT_PRESENT )
+                    {
+                        LOGGER.info( "Loaded {} groupId for remote repository {}", rules.size(),
+                                remoteRepository.getId() );
+                    }
+                    return rules;
+                }
+        );
+    }
+
+    private Set<String> loadRepositoryRules( Path filePath )
+    {
+        if ( Files.isReadable( filePath ) )
+        {
+            try ( BufferedReader reader = Files.newBufferedReader( filePath, StandardCharsets.UTF_8 ) )
+            {
+                TreeSet<String> result = new TreeSet<>();
+                String groupId;
+                while ( ( groupId = reader.readLine() ) != null )
+                {
+                    if ( !groupId.startsWith( "#" ) && !groupId.trim().isEmpty() )
+                    {
+                        result.add( groupId );
+                    }
+                }
+                return Collections.unmodifiableSet( result );
+            }
+            catch ( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
+        }
+        return NOT_PRESENT;
+    }
+
+    private static final TreeSet<String> NOT_PRESENT = new TreeSet<>();
+
+    private class GroupIdFilter implements RemoteRepositoryFilter
+    {
+        private final RepositorySystemSession session;
+
+        private GroupIdFilter( RepositorySystemSession session )
+        {
+            this.session = session;
+        }
+
+        @Override
+        public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+        {
+            return acceptGroupId( remoteRepository, artifact.getGroupId() );
+        }
+
+        @Override
+        public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+        {
+            return acceptGroupId( remoteRepository, metadata.getGroupId() );
+        }
+
+        private Result acceptGroupId( RemoteRepository remoteRepository, String groupId )
+        {
+            Set<String> groupIds = cacheRules( session, remoteRepository );
+            if ( NOT_PRESENT == groupIds )
+            {
+                return NOT_PRESENT_RESULT;
+            }
+
+            if ( groupIds.contains( groupId ) )
+            {
+                return new SimpleResult( true,
+                        "G:" + groupId + " allowed from " + remoteRepository );
+            }
+            else
+            {
+                return new SimpleResult( false,
+                        "G:" + groupId + " NOT allowed from " + remoteRepository );
+            }
+        }
+    }
+
+    private static final RemoteRepositoryFilter.Result NOT_PRESENT_RESULT = new SimpleResult(
+            true, "GroupId file not present" );
+
+    /**
+     * Returns {@code true} if given session is recording.
+     */
+    private boolean isRecord( RepositorySystemSession session )
+    {
+        return ConfigUtils.getBoolean( session, false, configPropKey( CONF_NAME_RECORD ) );
+    }
+
+    /**
+     * Flag to preserve on-close handler registration state.
+     */
+    private AtomicBoolean onCloseHandlerRegistered( RepositorySystemSession session )
+    {
+        return (AtomicBoolean) session.getData().computeIfAbsent( ON_CLOSE_HANDLER_REG_KEY,
+                () -> new AtomicBoolean( false ) );
+    }
+
+    /**
+     * Flag to preserve new groupId recorded state.
+     */
+    private AtomicBoolean newGroupIdRecorded( RepositorySystemSession session )
+    {
+        return (AtomicBoolean) session.getData().computeIfAbsent( NEW_GROUP_ID_RECORDED_KEY,
+                () -> new AtomicBoolean( false ) );
+    }
+
+    /**
+     * Returns {@code true} if truncate requested by session.
+     */
+    private boolean isTruncateOnSave( RepositorySystemSession session )
+    {
+        return ConfigUtils.getBoolean( session, false, configPropKey( CONF_NAME_TRUNCATE_ON_SAVE ) );
+    }
+
+    private void saveSessionRecordedLines( RepositorySystemSession session )
+    {
+        Map<String, Set<String>> recorded = cache ( session );
+        if ( !newGroupIdRecorded( session ).get() )
+        {
+            return;
+        }
+
+        Path basedir = getBasedir( session, true );
+        ArrayList<Exception> exceptions = new ArrayList<>();
+        for ( Map.Entry<String, Set<String>> entry : recorded.entrySet() )
+        {
+            Path groupIdPath = filePath( basedir, entry.getKey() );
+            Set<String> recordedLines = entry.getValue();
+            if ( !recordedLines.isEmpty() )
+            {
+                try
+                {
+                    TreeSet<String> result = new TreeSet<>();
+                    if ( !isTruncateOnSave( session ) )
+                    {
+                        result.addAll( loadRepositoryRules( groupIdPath ) );
+                    }
+                    result.addAll( recordedLines );
+
+                    LOGGER.info( "Saving {} groupIds to '{}'", result.size(), groupIdPath );
+                    FileUtils.writeFileWithBackup( groupIdPath, p -> Files.write( p, result ) );
+                }
+                catch ( IOException e )
+                {
+                    exceptions.add( e );
+                }
+            }
+        }
+        MultiRuntimeException.mayThrow( "session save groupIds failure", exceptions );
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -1,0 +1,301 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Remote repository filter source filtering on path prefixes. It is backed by a file that lists all allowed path
+ * prefixes from remote repository. Artifact that layout converted path (using remote repository layout) results in
+ * path with no corresponding prefix present in this file is filtered out.
+ * <p>
+ * The file can be authored manually: format is one prefix per line, comments starting with "#" (hash) and empty lines
+ * for structuring are supported, The "/" (slash) character is used as file separator. Some remote repositories and
+ * MRMs publish these kind of files, they can be downloaded from corresponding URLs.
+ * <p>
+ * The prefix file is expected on path "${basedir}/prefixes-${repository.id}.txt".
+ * <p>
+ * The prefixes file once loaded are cached in session, so in-flight prefixes file change during session are NOT
+ * noticed.
+ * <p>
+ * Examples of published prefix files:
+ * <ul>
+ *     <li>Central: <a href="https://repo.maven.apache.org/maven2/.meta/prefixes.txt">prefixes.txt</a></li>
+ *     <li>Apache Releases:
+ *     <a href="https://repository.apache.org/content/repositories/releases/.meta/prefixes.txt">prefixes.txt</a></li>
+ * </ul>
+ *
+ * @since TBD
+ */
+@Singleton
+@Named( PrefixesRemoteRepositoryFilterSource.NAME )
+public final class PrefixesRemoteRepositoryFilterSource
+        extends RemoteRepositoryFilterSourceSupport
+{
+    public static final String NAME = "prefixes";
+
+    static final String PREFIXES_FILE_PREFIX = "prefixes-";
+
+    static final String PREFIXES_FILE_SUFFIX = ".txt";
+
+    private static final String LAYOUT_CACHE_KEY = PrefixesRemoteRepositoryFilterSource.class.getName() + ".layouts";
+
+    private static final String NODE_CACHE_KEY = PrefixesRemoteRepositoryFilterSource.class.getName() + ".nodes";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( PrefixesRemoteRepositoryFilterSource.class );
+
+    private final RepositoryLayoutProvider repositoryLayoutProvider;
+
+    @Inject
+    public PrefixesRemoteRepositoryFilterSource( RepositoryLayoutProvider repositoryLayoutProvider )
+    {
+        super( NAME );
+        this.repositoryLayoutProvider = requireNonNull( repositoryLayoutProvider );
+    }
+
+    @Override
+    public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+    {
+        if ( isEnabled( session ) )
+        {
+            final Path basedir = getBasedir( session, false );
+            if ( Files.isDirectory( basedir ) )
+            {
+                return new PrefixesFilter( session, basedir );
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Caches layout instances for remote repository within one session.
+     */
+    @SuppressWarnings( "unchecked" )
+    private RepositoryLayout cacheLayout( RepositorySystemSession session,
+                                          RemoteRepository remoteRepository )
+    {
+        return ( (ConcurrentHashMap<String, RepositoryLayout>) session.getData()
+                .computeIfAbsent( LAYOUT_CACHE_KEY, ConcurrentHashMap::new ) )
+                .computeIfAbsent( remoteRepository.getId(), r ->
+                {
+                    try
+                    {
+                        return repositoryLayoutProvider.newRepositoryLayout( session, remoteRepository );
+                    }
+                    catch ( NoRepositoryLayoutException e )
+                    {
+                        throw new RuntimeException( e );
+                    }
+                } );
+    }
+
+    /**
+     * Caches prefixes instances for remote repository within one session.
+     */
+    @SuppressWarnings( "unchecked" )
+    private Node cacheNode( RepositorySystemSession session,
+                            Path basedir,
+                            RemoteRepository remoteRepository )
+    {
+        return ( (ConcurrentHashMap<String, Node>) session.getData()
+                .computeIfAbsent( NODE_CACHE_KEY, ConcurrentHashMap::new ) )
+                .computeIfAbsent( remoteRepository.getId(), r -> loadRepositoryPrefixes( basedir, remoteRepository ) );
+    }
+
+    /**
+     * Loads prefixes file and preprocesses it into {@link Node} instance.
+     */
+    private Node loadRepositoryPrefixes( Path baseDir, RemoteRepository remoteRepository )
+    {
+        Path filePath = baseDir.resolve( PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX );
+        if ( Files.isReadable( filePath ) )
+        {
+            try ( BufferedReader reader = Files.newBufferedReader( filePath, StandardCharsets.UTF_8 ) )
+            {
+                LOGGER.debug( "Loading prefixes for remote repository {} from file '{}'", remoteRepository.getId(),
+                        filePath );
+                Node root = new Node( "" );
+                String prefix;
+                int lines = 0;
+                while ( ( prefix = reader.readLine() ) != null )
+                {
+                    if ( !prefix.startsWith( "#" ) && !prefix.trim().isEmpty() )
+                    {
+                        lines++;
+                        Node currentNode = root;
+                        for ( String element : elementsOf( prefix ) )
+                        {
+                            currentNode = currentNode.addSibling( element );
+                        }
+                    }
+                }
+                LOGGER.info( "Loaded {} prefixes for remote repository {}", lines, remoteRepository.getId() );
+                return root;
+            }
+            catch ( FileNotFoundException e )
+            {
+                // strange: we tested for it above, still, we should not fail
+            }
+            catch ( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
+        }
+        LOGGER.debug( "Prefix file for remote repository {} not found at '{}'", remoteRepository, filePath );
+        return NOT_PRESENT_NODE;
+    }
+
+    private class PrefixesFilter implements RemoteRepositoryFilter
+    {
+        private final RepositorySystemSession session;
+
+        private final Path basedir;
+
+        private PrefixesFilter( RepositorySystemSession session, Path basedir )
+        {
+            this.session = session;
+            this.basedir = basedir;
+        }
+
+        @Override
+        public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+        {
+            return acceptPrefix( remoteRepository,
+                    cacheLayout( session, remoteRepository ).getLocation( artifact, false ).getPath() );
+        }
+
+        @Override
+        public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+        {
+            return acceptPrefix( remoteRepository,
+                    cacheLayout( session, remoteRepository ).getLocation( metadata, false ).getPath() );
+        }
+
+        private Result acceptPrefix( RemoteRepository remoteRepository, String path )
+        {
+            Node root = cacheNode( session, basedir, remoteRepository );
+            if ( NOT_PRESENT_NODE == root )
+            {
+                return NOT_PRESENT_RESULT;
+            }
+            List<String> prefix = new ArrayList<>();
+            final List<String> pathElements = elementsOf( path );
+            Node currentNode = root;
+            for ( String pathElement : pathElements )
+            {
+                prefix.add( pathElement );
+                currentNode = currentNode.getSibling( pathElement );
+                if ( currentNode == null || currentNode.isLeaf() )
+                {
+                    break;
+                }
+            }
+            if ( currentNode != null && currentNode.isLeaf() )
+            {
+                return new SimpleResult( true, "Prefix "
+                        + String.join( "/", prefix ) + " allowed from " + remoteRepository );
+            }
+            else
+            {
+                return new SimpleResult( false, "Prefix "
+                        + String.join( "/", prefix ) + " NOT allowed from " + remoteRepository );
+            }
+        }
+    }
+
+    private static final Node NOT_PRESENT_NODE = new Node(
+            "not-present-node" );
+
+    private static final RemoteRepositoryFilter.Result NOT_PRESENT_RESULT = new SimpleResult(
+            true, "Prefix file not present" );
+
+    private static class Node
+    {
+        private final String name;
+
+        private final HashMap<String, Node> siblings;
+
+        private Node( String name )
+        {
+            this.name = name;
+            this.siblings = new HashMap<>();
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public boolean isLeaf()
+        {
+            return siblings.isEmpty();
+        }
+
+        public Node addSibling( String name )
+        {
+            Node sibling = siblings.get( name );
+            if ( sibling == null )
+            {
+                sibling = new Node( name );
+                siblings.put( name, sibling );
+            }
+            return sibling;
+        }
+
+        public Node getSibling( String name )
+        {
+            return siblings.get( name );
+        }
+    }
+
+    private static List<String> elementsOf( final String path )
+    {
+        return Arrays.stream( path.split( "/" ) ).filter( e -> e != null && !e.isEmpty() ).collect( toList() );
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
@@ -1,0 +1,134 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.DirectoryUtils;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Support class for {@link RemoteRepositoryFilterSource} implementations.
+ * <p>
+ * Support class for implementing {@link RemoteRepositoryFilterSource}. It implements basic support
+ * like optional "basedir" calculation, handling of "enabled" flag.
+ * <p>
+ * The configuration keys supported:
+ * <ul>
+ *     <li><pre>aether.remoteRepositoryFilter.${id}.enabled</pre> (boolean) must be explicitly set to "true"
+ *     to become enabled</li>
+ *     <li><pre>aether.remoteRepositoryFilter.${id}.basedir</pre> (string, path) directory from where implementation
+ *     can use files. If unset, default value is ".remoteRepositoryFilters/${id}" and is resolved from local
+ *     repository basedir.</li>
+ * </ul>
+ *
+ * @since TBD
+ */
+public abstract class RemoteRepositoryFilterSourceSupport
+        implements RemoteRepositoryFilterSource
+{
+    private static final String CONFIG_PROP_PREFIX = "aether.remoteRepositoryFilter.";
+
+    private static final String CONF_NAME_BASEDIR = "basedir";
+
+    static final String LOCAL_REPO_PREFIX_DIR = ".remoteRepositoryFilters";
+
+    private final String name;
+
+    protected RemoteRepositoryFilterSourceSupport( String name )
+    {
+        this.name = requireNonNull( name );
+    }
+
+    /**
+     * Utility method to create scoped configuration property key of given name.
+     */
+    protected String configPropKey( String name )
+    {
+        return CONFIG_PROP_PREFIX + this.name + "." + name;
+    }
+
+    /**
+     * Returns {@code true} if session configuration contains this name set to {@code true}.
+     * <p>
+     * Default is {@code false}.
+     */
+    protected boolean isEnabled( RepositorySystemSession session )
+    {
+        return ConfigUtils.getBoolean( session, false, CONFIG_PROP_PREFIX + this.name );
+    }
+
+    /**
+     * Uses common {@link DirectoryUtils#resolveDirectory(RepositorySystemSession, String, String, boolean)} to
+     * calculate (and maybe create) basedir for this implementation, never returns {@code null}. The returned
+     * {@link Path} may not exists, if invoked with {@code mayCreate} being {@code false}.
+     * <p>
+     * Default value is {@code ${LOCAL_REPOSITORY}/.checksums}.
+     *
+     * @return The {@link Path} of basedir, never {@code null}.
+     */
+    protected Path getBasedir( RepositorySystemSession session, boolean mayCreate )
+    {
+        try
+        {
+            return DirectoryUtils.resolveDirectory(
+                    session, LOCAL_REPO_PREFIX_DIR, configPropKey( CONF_NAME_BASEDIR ), mayCreate );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    /**
+     * Simple {@link RemoteRepositoryFilter.Result} immutable implementation.
+     */
+    protected static class SimpleResult implements RemoteRepositoryFilter.Result
+    {
+        private final boolean accepted;
+
+        private final String reasoning;
+
+        public SimpleResult( boolean accepted, String reasoning )
+        {
+            this.accepted = accepted;
+            this.reasoning = requireNonNull( reasoning );
+        }
+
+        @Override
+        public boolean isAccepted()
+        {
+            return accepted;
+        }
+
+        @Override
+        public String reasoning()
+        {
+            return reasoning;
+        }
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/Filters.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/Filters.java
@@ -1,0 +1,183 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+
+/**
+ * Some filters used in UTs.
+ */
+public final class Filters
+{
+    /**
+     * Returns a filter that always accepts.
+     */
+    public static RemoteRepositoryFilterSource alwaysAccept()
+    {
+        return new RemoteRepositoryFilterSource()
+        {
+            public String getName()
+            {
+                return "always-accept";
+            }
+
+            private final RemoteRepositoryFilter.Result RESULT =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( true, getName() );
+
+            @Override
+            public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+            {
+                return new RemoteRepositoryFilter()
+                {
+                    @Override
+                    public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+                    {
+                        return RESULT;
+                    }
+
+                    @Override
+                    public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+                    {
+                        return RESULT;
+                    }
+                };
+            }
+        };
+    }
+
+    /**
+     * Returns a filter that always accepts from given repo.
+     */
+    public static RemoteRepositoryFilterSource alwaysAcceptFrom( String repoId )
+    {
+        return new RemoteRepositoryFilterSource()
+        {
+            public String getName()
+            {
+                return "always-accept-" + repoId;
+            }
+
+            private final RemoteRepositoryFilter.Result MATCHED =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( true, getName() );
+
+            private final RemoteRepositoryFilter.Result UNMATCHED =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( false, getName() );
+
+            @Override
+            public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+            {
+                return new RemoteRepositoryFilter()
+                {
+                    @Override
+                    public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+                    {
+                        return repoId.equals( remoteRepository.getId() ) ? MATCHED : UNMATCHED;
+                    }
+
+                    @Override
+                    public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+                    {
+                        return repoId.equals( remoteRepository.getId() ) ? MATCHED : UNMATCHED;
+                    }
+                };
+            }
+        };
+    }
+
+    /**
+     * Returns a filter that never accepts.
+     */
+    public static RemoteRepositoryFilterSource neverAccept()
+    {
+        return new RemoteRepositoryFilterSource()
+        {
+            public String getName()
+            {
+                return "never-accept";
+            }
+
+            private final RemoteRepositoryFilter.Result RESULT =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( false, getName() );
+
+            @Override
+            public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+            {
+                return new RemoteRepositoryFilter()
+                {
+                    @Override
+                    public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+                    {
+                        return RESULT;
+                    }
+
+                    @Override
+                    public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+                    {
+                        return RESULT;
+                    }
+                };
+            }
+        };
+    }
+
+    /**
+     * Returns a filter that never accepts from given repo.
+     */
+    public static RemoteRepositoryFilterSource neverAcceptFrom( String repoId )
+    {
+        return new RemoteRepositoryFilterSource()
+        {
+            public String getName()
+            {
+                return "never-accept-" + repoId;
+            }
+
+            private final RemoteRepositoryFilter.Result MATCHED =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( false, getName() );
+
+            private final RemoteRepositoryFilter.Result UNMATCHED =
+                    new RemoteRepositoryFilterSourceSupport.SimpleResult( true, getName() );
+
+            @Override
+            public RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session )
+            {
+                return new RemoteRepositoryFilter()
+                {
+                    @Override
+                    public Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact )
+                    {
+                        return repoId.equals( remoteRepository.getId() ) ? MATCHED : UNMATCHED;
+                    }
+
+                    @Override
+                    public Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata )
+                    {
+                        return repoId.equals( remoteRepository.getId() ) ? MATCHED : UNMATCHED;
+                    }
+                };
+            }
+        };
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
@@ -1,0 +1,76 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+/**
+ * UT for {@link GroupIdRemoteRepositoryFilterSource}.
+ */
+public class GroupIdRemoteRepositoryFilterSourceTest extends RemoteRepositoryFilterSourceTestSupport
+{
+    @Override
+    protected GroupIdRemoteRepositoryFilterSource getRemoteRepositoryFilterSource(
+            DefaultRepositorySystemSession session, RemoteRepository remoteRepository )
+    {
+        return new GroupIdRemoteRepositoryFilterSource();
+    }
+
+    @Override
+    protected void enableSource( DefaultRepositorySystemSession session )
+    {
+        session.setConfigProperty( "aether.remoteRepositoryFilter." + GroupIdRemoteRepositoryFilterSource.NAME,
+                Boolean.TRUE.toString() );
+    }
+
+    protected void allowArtifact( DefaultRepositorySystemSession session, RemoteRepository remoteRepository,
+                                  Artifact artifact )
+    {
+        try ( DefaultRepositorySystemSession newSession = new DefaultRepositorySystemSession( session ) )
+        {
+            Artifact resolvedArtifact = artifact.setFile( Files.createTempFile( "test", "tmp" ).toFile() );
+            ArtifactResult artifactResult = new ArtifactResult( new ArtifactRequest( resolvedArtifact,
+                    Collections.singletonList( remoteRepository ), "context" ) );
+            artifactResult.setArtifact( resolvedArtifact );
+            artifactResult.setRepository( remoteRepository );
+            List<ArtifactResult> artifactResults = Collections.singletonList( artifactResult );
+            enableSource( newSession );
+            newSession.setConfigProperty( "aether.remoteRepositoryFilter." + GroupIdRemoteRepositoryFilterSource.NAME
+                    + ".record", Boolean.TRUE.toString() );
+            getRemoteRepositoryFilterSource( newSession, remoteRepository )
+                    .postProcess( newSession, artifactResults );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
@@ -1,0 +1,75 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
+import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+
+/**
+ * UT for {@link PrefixesRemoteRepositoryFilterSource}.
+ */
+public class PrefixesRemoteRepositoryFilterSourceTest extends RemoteRepositoryFilterSourceTestSupport
+{
+    @Override
+    protected RemoteRepositoryFilterSource getRemoteRepositoryFilterSource(
+            DefaultRepositorySystemSession session, RemoteRepository remoteRepository )
+    {
+        DefaultRepositoryLayoutProvider layoutProvider = new DefaultRepositoryLayoutProvider();
+        layoutProvider.addRepositoryLayoutFactory( new Maven2RepositoryLayoutFactory() );
+        return new PrefixesRemoteRepositoryFilterSource( layoutProvider );
+    }
+
+    @Override
+    protected void enableSource( DefaultRepositorySystemSession session )
+    {
+        session.setConfigProperty( "aether.remoteRepositoryFilter." + PrefixesRemoteRepositoryFilterSource.NAME,
+                Boolean.TRUE.toString() );
+    }
+
+    @Override
+    protected void allowArtifact( DefaultRepositorySystemSession session, RemoteRepository remoteRepository,
+                                  Artifact artifact )
+    {
+        try
+        {
+            Path baseDir = session.getLocalRepository().getBasedir().toPath()
+                    .resolve( PrefixesRemoteRepositoryFilterSource.LOCAL_REPO_PREFIX_DIR );
+            Path groupId = baseDir
+                    .resolve( PrefixesRemoteRepositoryFilterSource.PREFIXES_FILE_PREFIX + remoteRepository.getId()
+                            + PrefixesRemoteRepositoryFilterSource.PREFIXES_FILE_SUFFIX );
+            Files.createDirectories( groupId.getParent() );
+            Files.write( groupId, artifact.getGroupId().replaceAll( "\\.", "/" ).getBytes( StandardCharsets.UTF_8 ) );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceTestSupport.java
@@ -1,0 +1,105 @@
+package org.eclipse.aether.internal.impl.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * UT helper for {@link RemoteRepositoryFilterSource} UTs.
+ */
+public abstract class RemoteRepositoryFilterSourceTestSupport
+{
+    private final Artifact acceptedArtifact = new DefaultArtifact( "org.one:aid:1.0" );
+
+    private final Artifact notAcceptedArtifact = new DefaultArtifact( "org.two:aid:1.0" );
+
+    private DefaultRepositorySystemSession session;
+
+    private RemoteRepository remoteRepository;
+
+    private RemoteRepositoryFilterSource subject;
+
+    @Before
+    public void setup()
+    {
+        remoteRepository = new RemoteRepository.Builder( "test", "default", "https://irrelevant.com" ).build();
+        session = TestUtils.newSession();
+        subject = getRemoteRepositoryFilterSource( session, remoteRepository );
+    }
+
+    protected abstract RemoteRepositoryFilterSource getRemoteRepositoryFilterSource(
+            DefaultRepositorySystemSession session, RemoteRepository remoteRepository );
+
+    protected abstract void enableSource( DefaultRepositorySystemSession session );
+
+    protected abstract void allowArtifact(
+            DefaultRepositorySystemSession session, RemoteRepository remoteRepository, Artifact artifact );
+
+    @Test
+    public void notEnabled()
+    {
+        RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter( session );
+        assertThat( filter, nullValue() );
+    }
+
+    @Test
+    public void acceptedArtifact()
+    {
+        allowArtifact( session, remoteRepository, acceptedArtifact );
+        enableSource( session );
+
+        RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter( session );
+        assertThat( filter, notNullValue() );
+
+        RemoteRepositoryFilter.Result result = filter.acceptArtifact( remoteRepository, acceptedArtifact );
+
+        assertThat( result.isAccepted(), equalTo( true ) );
+        assertThat( result.reasoning(), containsString( "allowed from test" ) );
+    }
+
+    @Test
+    public void notAcceptedArtifact()
+    {
+        allowArtifact( session, remoteRepository, acceptedArtifact );
+        enableSource( session );
+
+        RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter( session );
+        assertThat( filter, notNullValue() );
+
+        RemoteRepositoryFilter.Result result = filter.acceptArtifact( remoteRepository, notAcceptedArtifact );
+
+        assertThat( result.isAccepted(), equalTo( false ) );
+        assertThat( result.reasoning(), containsString( "NOT allowed from test" ) );
+    }
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilter.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilter.java
@@ -1,0 +1,67 @@
+package org.eclipse.aether.spi.connector.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Remote repository filter that decides should the given artifact or metadata be accepted (for further processing)
+ * from remote repository or not.
+ *
+ * @since TBD
+ */
+public interface RemoteRepositoryFilter
+{
+    /**
+     * The check result, is immutable.
+     */
+    interface Result
+    {
+        /**
+         * Returns {@code true} if accepted.
+         */
+        boolean isAccepted();
+
+        /**
+         * Returns string "reasoning" for {@link #isAccepted()} result, meant for human consumption, never {@code null}.
+         */
+        String reasoning();
+    }
+
+    /**
+     * Decides should artifact be accepted from given remote repository.
+     *
+     * @param remoteRepository The remote repository, not {@code null}.
+     * @param artifact         The artifact, not {@code null}.
+     * @return the result, never {@code null}.
+     */
+    Result acceptArtifact( RemoteRepository remoteRepository, Artifact artifact );
+
+    /**
+     * Decides should metadata be accepted from given remote repository.
+     *
+     * @param remoteRepository The remote repository, not {@code null}.
+     * @param metadata         The artifact, not {@code null}.
+     * @return the result, never {@code null}.
+     */
+    Result acceptMetadata( RemoteRepository remoteRepository, Metadata metadata );
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilterSource.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilterSource.java
@@ -1,0 +1,38 @@
+package org.eclipse.aether.spi.connector.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Remote repository filter source component.
+ *
+ * @since TBD
+ */
+public interface RemoteRepositoryFilterSource
+{
+    /**
+     * Provides the filter instance for given session, or {@code null} if this instance wants to abstain from
+     * participating in filtering.
+     *
+     * @return The filter for given session or {@code null}.
+     */
+    RemoteRepositoryFilter getRemoteRepositoryFilter( RepositorySystemSession session );
+}

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -66,7 +66,7 @@ most often a bad idea (filtering, as in "limiting what can come from it"). On ot
 to prevent request leakage to it (see "prefixes" filter).
 
 So, **most often** limiting "what can be fetched" from MC is a bad idea, it **can be done** but in very, very cautious way,
-as otherwise you risk your build. RRF does not distinguish the "context" of an artifact, it merely filters them out
+as otherwise you put your build at risk. RRF does not distinguish the "context" of an artifact, it merely filters them out
 by (artifact, remoteRepository) pair, and by limiting MC you can easily get into state where you break your build (as
 plugin depends on filtered artifact).
 
@@ -100,7 +100,7 @@ prefixes is set by publisher, and is usually value between 2 and 4. It all boils
 paths of deployed artifact from repository root would be 100% coverage, but the cost would be huge
 file size for huge repositories like Maven Central).
 
-As this file is (automatically) published by MC and MRMs, using them is simplest. Manual authoring
+As this file is (automatically) published by MC and MRMs, using them is the simplest. Manual authoring
 of these files, while possible, is not recommended. Best is to keep them up to date by
 downloading published files from remote repositories.
 
@@ -134,19 +134,22 @@ groupIds per remote repository and saves them into properly placed file(s).
 
 To enable GroupId Filter recording, use following setting: `-Daether.remoteRepositoryFilter.groupId.record=true`.
 
-To truncate recorded file(s) instead to merge recorded entries with existing file, use following setting:
-`-Daether.remoteRepositoryFilter.groupId.truncateOnSave=true`.
+To truncate recorded file(s) instead of merging recorded entries with existing file, use following setting:
+`-Daether.remoteRepositoryFilter.groupId.truncateOnSave=true`. If enabled, the saved file will contain ONLY
+the groupIds that were recorded in current session, otherwise the recorded groupIds and already present ones
+in file will be merged, and then saved.
 
 ## Operation
 
 To make RRF filter operate, you have to provide two things: you have to explicitly enable the filter, and you have to
 provide input for the filter. 
 
-Enabling filters does not make them active (participate in filtering): for remote repository not having filter 
-input present, the filter pulls out from "voting" (does not participate in filtering, abstains from voting).
+Enabling filters does not make them active (participate in filtering): if a given remote repository does not have 
+any input available, the filter pulls out from "voting" (does not participate in filtering, abstains 
+from voting).
 
-In short, enabling filters are not enough, to make it active for a remote repository, you
-must provide them "input data" for given remote repository as well.
+In short, enabling filters is not enough, to make it active for a remote repository, you
+must provide them with "input data" for this remote repository as well.
 
 The most common case in case of multiple remote repositories is following setup: enable both filtering, and
 provide Maven Central prefixes file (downloaded) and if any remote repository offers prefixes, download them

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -128,8 +128,8 @@ To enable groupId filtering, use the following setting: `-Daether.remoteReposito
 The groupId filter will "abstain" from filtering for the given remote repository, if there is no input provided for it.
 
 The GroupId filter allows the "recording" of encountered groupIds as well, that can be used as
-starting point: after the "recording" is done, one can edit, remove or add entries as needed. When
-groupId filter set to "record", it does NOT filter, but instead collects all the encountered
+starting point: after the "recording" is done, one can edit, remove or add entries as needed. When the
+groupId filter is set to "record", it does NOT filter, but instead collects all the encountered
 groupIds per remote repository and saves them into properly placed file(s).
 
 To enable GroupId Filter recording, use following setting: `-Daether.remoteRepositoryFilter.groupId.record=true`.

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -77,7 +77,7 @@ implementations for filtering: "prefixes" and "groupId" filters.
 
 Both implementation operate with several files (per remote repository), and they use the term "filter basedir". By
 default, filter basedir is resolved from local repository root and resolves to `${localRepo}/.remoteRepositoryFilters`
-directory.
+directory, and will refer to it in this document with `${filterBasedir}` placeholder.
 
 To explicitly set filter basedir, use following setting: `-Daether.remoteRepositoryFilter.${filterName}.basedir=somePath`, 
 where "somePath" can be relative (then is resolved from local repository root) or absolute (then is used as is).

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -62,12 +62,12 @@ faster and more private, optimized, without loosing build information (remote re
 
 Maven Central (MC) repository is special in this respect, as Maven will always try to get things from here, as your build,
 plugins, plugin dependencies, extension, etc. will most often come from here. While you CAN filter MC, filtering MC is
-most often a bad idea (filtering, as in "limiting what can come from it"). On other hand, MC itself offers helps
-to prevent request leakage to it (publishes available prefixes).
+most often a bad idea (filtering, as in "limiting what can come from it"). On other hand, MC itself offers help
+to prevent request leakage to it (see "prefixes" filter).
 
 So, **most often** limiting "what can be fetched" from MC is a bad idea, it **can be done** but in very, very cautious way,
 as otherwise you risk your build. RRF does not distinguish the "context" of an artifact, it merely filters them out
-by {artifact, remoteRepository) pair, and by limiting MC you can easily get into state where you break your build (as
+by (artifact, remoteRepository) pair, and by limiting MC you can easily get into state where you break your build (as
 plugin depends on filtered artifact).
 
 ## RRF
@@ -80,7 +80,7 @@ default, filter basedir is resolved from local repository root and resolves to `
 directory, and will refer to it in this document with `${filterBasedir}` placeholder.
 
 To explicitly set filter basedir, use following setting: `-Daether.remoteRepositoryFilter.${filterName}.basedir=somePath`, 
-where "somePath" can be relative (then is resolved from local repository root) or absolute (then is used as is).
+where "somePath" can be relative path, then is resolved from local repository root, or absolute path, then is used as is.
 
 ### The Prefixes Filter
 

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -23,11 +23,11 @@ criteria.
 
 ### Why?
 
-Remote Repository Filtering (RRF) is a long asked feature of Maven, and plays huge role when your build uses
+Remote Repository Filtering (RRF) is a long asked feature of Maven, and plays a huge role when your build uses
 several remote repositories. In such cases Maven "searches" the ordered list (effective POM) of remote repositories,
-and artifact gets resolved using loop and "first found wins" strategy. This have several implications:
+and artifacts get resolved using a loop and a "first found wins" strategy. This has several implications:
 
-* your build gets slower, as if your artifact is in Nth repository, Maven must make N-1 requests that will result in
+* your build gets slower, as if your artifact is in the Nth repository, Maven must make N-1 requests that will result in
   404 Not Found only to get to Nth repository to finally get the artifact.
 * you build "leaks" artifact requests, as those repositories are asked for artifacts, that does not (or worse,
   cannot) have them. Still, those remote repository operators do get your requests in access logs.
@@ -72,12 +72,12 @@ plugin depends on filtered artifact).
 
 ## RRF
 
-The RRF feature offer filter source SPI for 3rd party implementors, but it also provides 2 out of the box 
+The RRF feature offers a filter source SPI for 3rd party implementors, but it also provides 2 out of the box 
 implementations for filtering: "prefixes" and "groupId" filters.
 
 Both implementation operate with several files (per remote repository), and they use the term "filter basedir". By
 default, filter basedir is resolved from local repository root and resolves to `${localRepo}/.remoteRepositoryFilters`
-directory, and will refer to it in this document with `${filterBasedir}` placeholder.
+directory. It will be referred to in this document with `${filterBasedir}` placeholder.
 
 To explicitly set filter basedir, use following setting: `-Daether.remoteRepositoryFilter.${filterName}.basedir=somePath`, 
 where "somePath" can be relative path, then is resolved from local repository root, or absolute path, then is used as is.

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -1,0 +1,163 @@
+# Remote Repository Filtering
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+A new Maven Resolver feature that allows filtering of Artifact by RemoteRepository based on various (extensible) 
+criteria.
+
+### Why?
+
+Remote Repository Filtering (RRF) is a long asked feature of Maven, and plays huge role when your build uses
+several remote repositories. In such cases Maven "searches" the ordered list (effective POM) of remote repositories,
+and artifact gets resolved using loop and "first found wins" strategy. This have several implications:
+
+* your build gets slower, as if your artifact is in Nth repository, Maven must make N-1 requests that will result in
+  404 Not Found only to get to Nth repository to finally get the artifact.
+* you build "leaks" artifact requests, as those repositories are asked for artifacts, that does not (or worse,
+  cannot) have them. Still, those remote repository operators do get your requests in access logs.
+* to "simplify" things, users tend to use MRM "group" (or "virtual") repositories, that causes  data loss on
+  Maven Project side (project loses artifact origin information) and ends up in disasters, as at the end these
+  "super-uber groups" grow uncontrollably, their member count become huge (as new members are being
+  added as time passes), or created groups count grows uncontrollably, and project start losing the knowledge
+  about their required remote repositories, needed to (re)build a project, hence these projects become
+  un-buildable without the MRM, projects become bound to MRM and/or environment that is usually out of project
+  control.
+
+Maven by default gets slower as remote repositories are added, leaks your own build information to remote
+repository operators, and current solutions offered to solve this problem just end up in disasters (most often).
+
+### What It Is?
+
+Imagine you can instruct Maven which repository can contain what artifact? Instead of "ordered loop" searching
+for artifacts in remote repositories, Maven could be instructed in controlled way to directly reach only the
+needed remote repository.
+
+With RRF, Maven build does NOT have to slow down with new remote repositories added, and will not leak either
+build information anywhere, as it will get things from where they should be get from.
+
+### What It Is Not?
+
+When it solely comes to dependencies, don't forget
+[maven-enforcer-plugin](https://maven.apache.org/enforcer/enforcer-rules/bannedDependencies.html) rules that are 
+handling exactly them. RRF is NOT an alternative means to these enforcer rules, it is a tool to make your build
+faster and more private, optimized, without loosing build information (remote repositories should be in POM).
+
+### Maven Central Is Special
+
+Maven Central (MC) repository is special in this respect, as Maven will always try to get things from here, as your build,
+plugins, plugin dependencies, extension, etc. will most often come from here. While you CAN filter MC, filtering MC is
+most often a bad idea (filtering, as in "limiting what can come from it"). On other hand, MC itself offers helps
+to prevent request leakage to it (publishes available prefixes).
+
+So, **most often** limiting "what can be fetched" from MC is a bad idea, it **can be done** but in very, very cautious way,
+as otherwise you risk your build. RRF does not distinguish the "context" of an artifact, it merely filters them out
+by {artifact, remoteRepository) pair, and by limiting MC you can easily get into state where you break your build (as
+plugin depends on filtered artifact).
+
+## RRF
+
+The RRF feature offer filter source SPI for 3rd party implementors, but it also provides 2 out of the box 
+implementations for filtering: "prefixes" and "groupId" filters.
+
+Both implementation operate with several files (per remote repository), and they use the term "filter basedir". By
+default, filter basedir is resolved from local repository root and resolves to `${localRepo}/.remoteRepositoryFilters`
+directory.
+
+To explicitly set filter basedir, use following setting: `-Daether.remoteRepositoryFilter.${filterName}.basedir=somePath`, 
+where "somePath" can be relative (then is resolved from local repository root) or absolute (then is used as is).
+
+### The Prefixes Filter
+
+The "prefixes" named filter relies on file containing list of "repository prefixes" available from given repository.
+The prefix is essentially "starts with" of Artifact path as translated by Repository Layout. Its effect is that
+only those artifacts will be attempted to be downloaded from given remote repository, if there is a
+"starts with" match between artifact path translated by layout, and prefixes file published by remote repository.
+
+Prefixes are usually published by remote repositories, hence, are kinda filtering other way around:
+is rather remote repository advising us "do not even bother by coming to me with a path that has no
+appropriate prefix enlisted in this file". On the other hand, having a prefix enlisted does not
+provide 100% guarantee that matched artifact is really present! For example presence of `/com/foo`
+prefix does NOT imply that `com.foo:baz:1.0` artifact is present, it merely tells "I do have
+something that starts with `/com/foo`" (for example `com.foo.baz:lib:1.0`). The depth of published
+prefixes is set by publisher, and is usually value between 2 and 4. It all boils down to equilibrium of
+"best coverage" and "acceptable file size" (ultimately, prefixes file containing all the relative
+paths of deployed artifact from repository root would be 100% coverage, but the cost would be huge
+file size for huge repositories like Maven Central).
+
+As this file is (automatically) published by MC and MRMs, using them is simplest. Manual authoring
+of these files, while possible, is not recommended. Best is to keep them up to date by
+downloading published files from remote repositories.
+
+Many MRMs and Maven Central itself publishes this file. Some prefixes file examples:
+* Maven Central [prefixes.txt](https://repo.maven.apache.org/maven2/.meta/prefixes.txt)
+* ASF Releases hosted repository [prefixes.txt](https://repository.apache.org/content/repositories/releases/.meta/prefixes.txt)
+
+The prefixes files are expected in following location by default: 
+`${filterBasedir}/prefixes-${remoteRepository.id}.txt`.
+
+To enable prefixes filter, use following setting: `-Daether.remoteRepositoryFilter.prefixes=true`.
+
+The prefixes filter "abstains" from filtering for given remote repository, if there is no input for it provided.
+
+### The GroupId Filter
+
+The "groupId" named implementation is filtering based on allowed `groupId` of Artifact. In essence, is a list
+of "allowed groupId coordinates from given remote repository". The file contains Artifact groupId per one line.
+
+The groupId files are expected in following location by default: 
+`${filterBasedir}/groupId-${remoteRepository.id}.txt`.
+
+To enable groupId filter, use following setting: `-Daether.remoteRepositoryFilter.groupId=true`.
+
+The groupId filter "abstains" from filtering for given remote repository, if there is no input for it provided.
+
+The GroupId filter allows "recording" of encountered groupIds as well, that can be used as
+starting point: after "recording" done, one can edit it, remove or add entries as needed. When
+groupId filter set to "record", it does NOT filter, but instead collects all the encountered
+groupIds per remote repository and saves them into properly placed file(s).
+
+To enable GroupId Filter recording, use following setting: `-Daether.remoteRepositoryFilter.groupId.record=true`.
+
+To truncate recorded file(s) instead to merge recorded entries with existing file, use following setting:
+`-Daether.remoteRepositoryFilter.groupId.truncateOnSave=true`.
+
+## Operation
+
+To make RRF filter operate, you have to provide two things: you have to explicitly enable the filter, and you have to
+provide input for the filter. 
+
+Enabling filters does not make them active (participate in filtering): for remote repository not having filter 
+input present, the filter pulls out from "voting" (does not participate in filtering, abstains from voting).
+
+In short, enabling filters are not enough, to make it active for a remote repository, you
+must provide them "input data" for given remote repository as well.
+
+The most common case in case of multiple remote repositories is following setup: enable both filtering, and
+provide Maven Central prefixes file (downloaded) and if any remote repository offers prefixes, download them
+as well. Optionally provide groupId files for other remote repositories, if needed. It results in following filter 
+activity:
+
+| Remote Repository | Prefixes Filter | GroupId Filter |
+|-------------------|-----------------|----------------|
+| Maven Central     | active          | inactive       |
+| Some Remote       | inactive        | active         |
+
+It results in following "constraints":
+* "Maven Central" is asked only for those artifacts it claims it may have (prefixes)
+* "Some Remote" is asked only for allowed groupIds. If it publishes prefixes, it can be safely added as well.

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -84,51 +84,51 @@ where "somePath" can be relative path, then is resolved from local repository ro
 
 ### The Prefixes Filter
 
-The "prefixes" named filter relies on file containing list of "repository prefixes" available from given repository.
-The prefix is essentially "starts with" of Artifact path as translated by Repository Layout. Its effect is that
+The "prefixes" named filter relies on a file containing a list of "repository prefixes" available from a given repository.
+The prefix is essentially the "starts with" of Artifact path as translated by the repository layout. Its effect is that
 only those artifacts will be attempted to be downloaded from given remote repository, if there is a
-"starts with" match between artifact path translated by layout, and prefixes file published by remote repository.
+"starts with" match between the artifact path translated by the layout, and the prefixes file published by remote repository.
 
-Prefixes are usually published by remote repositories, hence, are kinda filtering other way around:
-is rather remote repository advising us "do not even bother by coming to me with a path that has no
+Prefixes are usually published by remote repositories, hence, are kinda filtering the other way around:
+it is rather the remote repository advising us "do not even bother to come to me with a path that has no
 appropriate prefix enlisted in this file". On the other hand, having a prefix enlisted does not
-provide 100% guarantee that matched artifact is really present! For example presence of `/com/foo`
+provide 100% guarantee that a matching artifact is really present! For example the presence of `/com/foo`
 prefix does NOT imply that `com.foo:baz:1.0` artifact is present, it merely tells "I do have
 something that starts with `/com/foo`" (for example `com.foo.baz:lib:1.0`). The depth of published
-prefixes is set by publisher, and is usually value between 2 and 4. It all boils down to equilibrium of
-"best coverage" and "acceptable file size" (ultimately, prefixes file containing all the relative
-paths of deployed artifact from repository root would be 100% coverage, but the cost would be huge
+prefixes is set by the publisher, and is usually a value between 2 and 4. It all boils down to the balance between
+"best coverage" and "acceptable file size" (ultimately, the prefixes file containing all the relative
+paths of deployed artifacts from the repository root would be 100% coverage, but the cost would be a huge
 file size for huge repositories like Maven Central).
 
 As this file is (automatically) published by MC and MRMs, using them is the simplest. Manual authoring
-of these files, while possible, is not recommended. Best is to keep them up to date by
-downloading published files from remote repositories.
+of these files, while possible, is not recommended. The best is to keep them up to date by
+downloading the published files from the remote repositories.
 
-Many MRMs and Maven Central itself publishes this file. Some prefixes file examples:
+Many MRMs and Maven Central itself publish these files. Some prefixes file examples:
 * Maven Central [prefixes.txt](https://repo.maven.apache.org/maven2/.meta/prefixes.txt)
 * ASF Releases hosted repository [prefixes.txt](https://repository.apache.org/content/repositories/releases/.meta/prefixes.txt)
 
-The prefixes files are expected in following location by default: 
+The prefixes files are expected in the following location by default: 
 `${filterBasedir}/prefixes-${remoteRepository.id}.txt`.
 
-To enable prefixes filter, use following setting: `-Daether.remoteRepositoryFilter.prefixes=true`.
+To enable prefixes filter, use the following setting: `-Daether.remoteRepositoryFilter.prefixes=true`.
 
-The prefixes filter "abstains" from filtering for given remote repository, if there is no input for it provided.
+The prefixes filter will "abstain" from filtering for the given remote repository, if there is no input provided for it.
 
 ### The GroupId Filter
 
-The "groupId" named implementation is filtering based on allowed `groupId` of Artifact. In essence, is a list
-of "allowed groupId coordinates from given remote repository". The file contains Artifact groupId per one line.
+The "groupId" named implementation is filtering based on allowed `groupId` of Artifact. In essence, it is a list
+of "allowed groupId coordinates from given remote repository". The file contains one Artifact groupId per line.
 
-The groupId files are expected in following location by default: 
+The groupId files are expected in the following location by default: 
 `${filterBasedir}/groupId-${remoteRepository.id}.txt`.
 
-To enable groupId filter, use following setting: `-Daether.remoteRepositoryFilter.groupId=true`.
+To enable groupId filtering, use the following setting: `-Daether.remoteRepositoryFilter.groupId=true`.
 
-The groupId filter "abstains" from filtering for given remote repository, if there is no input for it provided.
+The groupId filter will "abstain" from filtering for the given remote repository, if there is no input provided for it.
 
-The GroupId filter allows "recording" of encountered groupIds as well, that can be used as
-starting point: after "recording" done, one can edit it, remove or add entries as needed. When
+The GroupId filter allows the "recording" of encountered groupIds as well, that can be used as
+starting point: after the "recording" is done, one can edit, remove or add entries as needed. When
 groupId filter set to "record", it does NOT filter, but instead collects all the encountered
 groupIds per remote repository and saves them into properly placed file(s).
 
@@ -145,14 +145,14 @@ To make RRF filter operate, you have to provide two things: you have to explicit
 provide input for the filter. 
 
 Enabling filters does not make them active (participate in filtering): if a given remote repository does not have 
-any input available, the filter pulls out from "voting" (does not participate in filtering, abstains 
+any input available, the filter pulls out from "voting" (does not participate in filtering, will abstain 
 from voting).
 
 In short, enabling filters is not enough, to make it active for a remote repository, you
 must provide them with "input data" for this remote repository as well.
 
-The most common case in case of multiple remote repositories is following setup: enable both filtering, and
-provide Maven Central prefixes file (downloaded) and if any remote repository offers prefixes, download them
+The most common configuration in case of multiple remote repositories is the following setup: enable both filters, 
+provide the Maven Central prefixes file (downloaded) and if any remote repository offers prefixes, download them
 as well. Optionally provide groupId files for other remote repositories, if needed. It results in following filter 
 activity:
 
@@ -161,6 +161,6 @@ activity:
 | Maven Central     | active          | inactive       |
 | Some Remote       | inactive        | active         |
 
-It results in following "constraints":
+This leads to the following "constraints":
 * "Maven Central" is asked only for those artifacts it claims it may have (prefixes)
 * "Some Remote" is asked only for allowed groupIds. If it publishes prefixes, it can be safely added as well.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -30,6 +30,7 @@ under the License.
       <item name="About Checksums" href="about-checksums.html"/>
       <item name="About Local Repository" href="local-repository.html"/>
       <item name="Included Checksum Strategies" href="included-checksum-strategies.html"/>
+      <item name="Remote Repository Filtering" href="remote-repository-filtering.html"/>
       <item name="Maven 3.8.x" href="maven-3.8.x.html"/>
       <item name="JavaDocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>


### PR DESCRIPTION
RemoteRepository filter feature and some filter implementations:
* groupId filter: is able to fiter artifacts from remote repository by groupId (manually authored or "recorded").
* prefix filter: uses prefixes file published by remote repositories (or manually authored).

Like any new feature, they are by default disabled/dormant, and need to be explicitly enabled.

About feature: the "remote repository filter" feature is able to filter (allow or disallow) artifact to be resolved (so even if locally present) from given remote repository. This is "all or nothing" filter, so it neglects usage context of artifact. In other words, if you filter out "maven-plugin-api", you probably rendered your build broken (same for any plugin dependencies). Simply put, if you have some "unwanted" artifact that is needed by build, better use enforcer to ban it from build. This filter is to prevent "leaks" of requests toward possible remote repositories instead, but may also serve as "hard" gate for really unwanted artifacts (those that should not enter project but also build).

---

https://issues.apache.org/jira/browse/MRESOLVER-274