### PR TITLE
[MRESOLVER-279] Simplify and improve trusted checksum sources

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/ArtifactResolverPostProcessorSupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/ArtifactResolverPostProcessorSupport.java
@@ -45,20 +45,36 @@ public abstract class ArtifactResolverPostProcessorSupport
         this.name = requireNonNull( name );
     }
 
-    protected String configPropKey( String name )
-    {
-        return CONFIG_PROP_PREFIX + this.name + "." + name;
-    }
-
+    /**
+     * This implementation will call into underlying code only if enabled.
+     */
     @Override
     public void postProcess( RepositorySystemSession session, List<ArtifactResult> artifactResults )
     {
-        boolean enabled = ConfigUtils.getBoolean( session, false, CONFIG_PROP_PREFIX + this.name );
-        if ( enabled )
+        if ( isEnabled( session ) )
         {
-            doProcess( session, artifactResults );
+            doPostProcess( session, artifactResults );
         }
     }
 
-    protected abstract void doProcess( RepositorySystemSession session, List<ArtifactResult> artifactResults );
+    protected abstract void doPostProcess( RepositorySystemSession session, List<ArtifactResult> artifactResults );
+
+    /**
+     * To be used by underlying implementations to form configuration property keys properly scoped.
+     */
+    protected String configPropKey( String name )
+    {
+        requireNonNull( name );
+        return CONFIG_PROP_PREFIX + this.name + "." + name;
+    }
+
+    /**
+     * Returns {@code true} if session configuration marks this instance as enabled.
+     * <p>
+     * Default value is {@code false}.
+     */
+    protected boolean isEnabled( RepositorySystemSession session )
+    {
+        return ConfigUtils.getBoolean( session, false, CONFIG_PROP_PREFIX + this.name );
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/FileTrustedChecksumsSourceTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/FileTrustedChecksumsSourceTestSupport.java
@@ -44,15 +44,15 @@ import static org.junit.Assume.assumeThat;
 
 public abstract class FileTrustedChecksumsSourceTestSupport
 {
-    protected static final Artifact ARTIFACT_WITHOUT_CHECKSUM = new DefaultArtifact( "test:test:1.0" );
+    private static final Artifact ARTIFACT_WITHOUT_CHECKSUM = new DefaultArtifact( "test:test:1.0" );
 
-    protected static final Artifact ARTIFACT_WITH_CHECKSUM = new DefaultArtifact( "test:test:2.0" );
+    private static final Artifact ARTIFACT_WITH_CHECKSUM = new DefaultArtifact( "test:test:2.0" );
 
-    protected static final String ARTIFACT_TRUSTED_CHECKSUM = "trustedChecksum";
+    private static final String ARTIFACT_TRUSTED_CHECKSUM = "trustedChecksum";
 
-    protected DefaultRepositorySystemSession session;
+    private DefaultRepositorySystemSession session;
 
-    protected ChecksumAlgorithmFactory checksumAlgorithmFactory;
+    private ChecksumAlgorithmFactory checksumAlgorithmFactory;
 
     private FileTrustedChecksumsSourceSupport subject;
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
@@ -19,35 +19,21 @@ package org.eclipse.aether.internal.impl.checksum;
  * under the License.
  */
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.internal.impl.DefaultFileProcessor;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
-import org.eclipse.aether.internal.impl.LocalPathComposer;
 
 public class SparseDirectoryTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport
 {
     @Override
-    protected FileTrustedChecksumsSourceSupport prepareSubject( Path basedir ) throws IOException
+    protected FileTrustedChecksumsSourceSupport prepareSubject()
     {
-        LocalPathComposer localPathComposer = new DefaultLocalPathComposer();
-        // artifact: test:test:2.0 => "foobar"
-        {
-            Path test = basedir.resolve( localPathComposer
-                    .getPathForArtifact( ARTIFACT_WITH_CHECKSUM, false )
-                    + "." + checksumAlgorithmFactory.getFileExtension() );
-            Files.createDirectories( test.getParent() );
-            Files.write( test, ARTIFACT_TRUSTED_CHECKSUM.getBytes( StandardCharsets.UTF_8 ) );
-        }
-
-        return new SparseDirectoryTrustedChecksumsSource( new DefaultFileProcessor(), localPathComposer );
+        return new SparseDirectoryTrustedChecksumsSource( new DefaultFileProcessor(), new DefaultLocalPathComposer() );
     }
 
     @Override
-    protected void enableSource()
+    protected void enableSource( DefaultRepositorySystemSession session )
     {
         session.setConfigProperty( "aether.trustedChecksumsSource.sparse-directory", Boolean.TRUE.toString() );
     }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
@@ -19,32 +19,19 @@ package org.eclipse.aether.internal.impl.checksum;
  * under the License.
  */
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 
 public class SummaryFileTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport
 {
     @Override
-    protected FileTrustedChecksumsSourceSupport prepareSubject( Path basedir ) throws IOException
+    protected FileTrustedChecksumsSourceSupport prepareSubject()
     {
-        // artifact: test:test:2.0 => "foobar"
-        {
-            Path test = basedir.resolve( "checksums." + checksumAlgorithmFactory.getFileExtension() );
-            Files.createDirectories( test.getParent() );
-            Files.write( test,
-                    ( ArtifactIdUtils.toId( ARTIFACT_WITH_CHECKSUM ) + " " + ARTIFACT_TRUSTED_CHECKSUM ).getBytes(
-                            StandardCharsets.UTF_8 ) );
-        }
-
-        return new SummaryFileTrustedChecksumsSource();
+        return new SummaryFileTrustedChecksumsSource( new DefaultLocalPathComposer() );
     }
 
     @Override
-    protected void enableSource()
+    protected void enableSource( DefaultRepositorySystemSession session )
     {
         session.setConfigProperty( "aether.trustedChecksumsSource.summary-file", Boolean.TRUE.toString() );
     }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/DirectoryUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/DirectoryUtils.java
@@ -45,14 +45,16 @@ public final class DirectoryUtils
 
     /**
      * Creates {@link Path} instance out of passed in {@code name} parameter. May create a directory on resulting path,
-     * if not exists. Following outcomes may happen:
+     * if not exist, when invoked with {@code mayCreate} being {@code true}. Never returns {@code null}.
+     * <p>
+     * Following outcomes may happen:
      * <ul>
      *     <li>{@code name} is absolute path - results in {@link Path} instance created directly from name.</li>
-     *     <li>{@code name} is relative path - results in {@link Path} instance resolved with {@code base} parameter.
+     *     <li>{@code name} is relative path - results in {@link Path} instance resolved against {@code base} parameter.
      *     </li>
      * </ul>
-     * Resulting path is being checked is a directory, and if not, it will be created. If resulting path exists but
-     * is not a directory, this method will fail.
+     * Resulting path is being checked is a directory, and if not, it will be created if {@code mayCreate} is
+     * {@code true}. If resulting path exist but is not a directory, this method will throw.
      *
      * @param name      The name to create directory with, cannot be {@code null}.
      * @param base      The base {@link Path} to resolve name, if it is relative path, cannot be {@code null}.
@@ -91,8 +93,7 @@ public final class DirectoryUtils
 
     /**
      * Creates {@link Path} instance out of session configuration, and (if relative) resolve it against local
-     * repository
-     * basedir. Pre-populates values and invokes {@link #resolveDirectory(String, Path, boolean)}.
+     * repository basedir. Pre-populates values and invokes {@link #resolveDirectory(String, Path, boolean)}.
      * <p>
      * For this method to work, {@link org.eclipse.aether.repository.LocalRepository#getBasedir()} must return
      * non-{@code null} value, otherwise {@link NullPointerException} is thrown.
@@ -103,6 +104,7 @@ public final class DirectoryUtils
      * @param mayCreate   If resulting path does not exist, should it create?
      * @return The {@link Path} instance that is resolved and backed by existing directory.
      * @throws IOException If some IO related errors happens.
+     * @see #resolveDirectory(String, Path, boolean)
      */
     public static Path resolveDirectory( RepositorySystemSession session,
                                          String defaultName,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -1,0 +1,112 @@
+package org.eclipse.aether.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A utility class to write files.
+ *
+ * @since TBD
+ */
+public final class FileUtils
+{
+    private FileUtils()
+    {
+        // hide constructor
+    }
+
+    /**
+     * A file writer, that accepts a {@link Path} to write some content to.
+     */
+    @FunctionalInterface
+    public interface FileWriter
+    {
+        void write( Path path ) throws IOException;
+    }
+
+    /**
+     * Writes file without backup.
+     *
+     * @param target   that is the target file (must be file, the path must have parent).
+     * @param writer   the writer that will accept a {@link Path} to write content to.
+     * @throws IOException if at any step IO problem occurs.
+     */
+    public static void writeFile( Path target, FileWriter writer ) throws IOException
+    {
+        writeFile( target, writer, false );
+    }
+
+    /**
+     * Writes file with backup copy (appends ".bak" extension).
+     *
+     * @param target   that is the target file (must be file, the path must have parent).
+     * @param writer   the writer that will accept a {@link Path} to write content to.
+     * @throws IOException if at any step IO problem occurs.
+     */
+    public static void writeFileWithBackup( Path target, FileWriter writer ) throws IOException
+    {
+        writeFile( target, writer, true );
+    }
+
+    /**
+     * Utility method to write out file to disk in "atomic" manner, with optional backups (".bak") if needed. This
+     * ensures that no other thread or process will be able to read not fully written files. Finally, this methos
+     * may create the needed parent directories, if the passed in target parents does not exist.
+     *
+     * @param target   that is the target file (must be an existing or non-existing file, the path must have parent).
+     * @param writer   the writer that will accept a {@link Path} to write content to.
+     * @param doBackup if {@code true}, and target file is about to be overwritten, a ".bak" file with old contents will
+     *                 be created/overwritten.
+     * @throws IOException if at any step IO problem occurs.
+     */
+    private static void writeFile( Path target, FileWriter writer, boolean doBackup ) throws IOException
+    {
+        requireNonNull( target, "target is null" );
+        requireNonNull( writer, "writer is null" );
+        Path parent = requireNonNull( target.getParent(), "target must have parent" );
+        Path temp = null;
+
+        Files.createDirectories( parent );
+        try
+        {
+            temp = Files.createTempFile( parent, "writer", "tmp" );
+            writer.write( temp );
+            if ( doBackup && Files.isRegularFile( target ) )
+            {
+                Files.copy( target, parent.resolve( target.getFileName() + ".bak" ),
+                        StandardCopyOption.REPLACE_EXISTING );
+            }
+            Files.move( temp, target, StandardCopyOption.ATOMIC_MOVE );
+        }
+        finally
+        {
+            if ( temp != null )
+            {
+                Files.deleteIfExists( temp );
+            }
+        }
+    }
+}


### PR DESCRIPTION
High level changes:
* support class should meddle way less, it is here to provide some utils and protect from future API changes
* sparse source: use `FileProcessor` for both, checksum read and write (instead to mix in `Files.write`)
* summary source: heavily enhanced, on save it truncate or merges with existing summary file, added change detection (prevents save when no change to save), summary file is written out atomically, and finally file format is made GNU Coreutils formatted, hence is usable with GNU sha1sum and alike OS tools
* TrustedChecksumsArtifactResolverPostProcessor got new config "snapshots" to validate/record snapshots as well (by default, they should be "in-house", hence trusted).
* introduce FileUtils, Java NIO2 based file writing utility

For both checksum sources the semantics of concurrent lookup/write is cleared up and documented (and fixed in summary). For both purposes (lookup or write), the source must be explicitly enabled.

Tests redone as well, and should work with any writable trusted checksum source.

---

https://issues.apache.org/jira/browse/MRESOLVER-279