### PR TITLE
[MRESOLVER-278] Session close and onClose hooks fix

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -816,9 +816,9 @@ public final class DefaultRepositorySystemSession
         {
             throw new IllegalStateException( "repository system session is read-only" );
         }
-        if ( isClosed() )
+        if ( closed.get() )
         {
-            throw new IllegalStateException( "repository system session is closed" );
+            throw new IllegalStateException( "repository system session is already closed" );
         }
     }
 
@@ -897,7 +897,7 @@ public final class DefaultRepositorySystemSession
         requireNonNull( handler, "handler cannot be null" );
         if ( closed.get() )
         {
-            throw new IllegalStateException( "repository system session is closed" );
+            throw new IllegalStateException( "repository system session is already closed" );
         }
         onCloseHandlers.add( 0, handler );
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -894,8 +894,11 @@ public final class DefaultRepositorySystemSession
     @Override
     public void addOnCloseHandler( Consumer<RepositorySystemSession> handler )
     {
-        verifyStateForMutation();
         requireNonNull( handler, "handler cannot be null" );
+        if ( closed.get() )
+        {
+            throw new IllegalStateException( "repository system session is closed" );
+        }
         onCloseHandlers.add( 0, handler );
     }
 


### PR DESCRIPTION
Maven ITs running against https://github.com/apache/maven/pull/831 fails. Reason is "too late" registration of onClose handler to session, when it is already readOnoy.

There are valid cases in Maven when interaction with resolver (that would "lazily" init SyncContext) happens way late, when session is already made readOnly.

Fix: adding onCloseHandler should NOT be affected by readOnly state of session, as it merely means it's members like LRM, etc are "fixed", but session data etc are all still mutable.

Similarly, due lazy init, some components may -- as in above valid cases -- register some handler when session is already read only.

This change makes all Maven ITs pass with this resolver.