### PR TITLE
[MRESOLVER-278] On repository system shutdown

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
@@ -8,9 +8,9 @@ package org.eclipse.aether;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,7 +20,6 @@ package org.eclipse.aether;
  */
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
@@ -41,10 +40,10 @@ import org.eclipse.aether.transform.FileTransformerManager;
 
 /**
  * A special repository system session to enable decorating or proxying another session. To do so, clients have to
- * create a subclass and implement {@link #getSession()}.
+ * create a subclass and implement {@link #getSession()}, and optionally override other methods.
  */
 public abstract class AbstractForwardingRepositorySystemSession
-    implements RepositorySystemSession
+        implements RepositorySystemSession
 {
 
     /**
@@ -58,7 +57,7 @@ public abstract class AbstractForwardingRepositorySystemSession
      * Gets the repository system session to which this instance forwards calls. It's worth noting that this class does
      * not save/cache the returned reference but queries this method before each forwarding. Hence, the session
      * forwarded to may change over time or depending on the context (e.g. calling thread).
-     * 
+     *
      * @return The repository system session to forward calls to, never {@code null}.
      */
     protected abstract RepositorySystemSession getSession();
@@ -212,34 +211,10 @@ public abstract class AbstractForwardingRepositorySystemSession
     {
         return getSession().getCache();
     }
-    
+
     @Override
     public FileTransformerManager getFileTransformerManager()
     {
         return getSession().getFileTransformerManager();
-    }
-
-    @Override
-    public final void addOnCloseHandler( Consumer<RepositorySystemSession> handler )
-    {
-        getSession().addOnCloseHandler( handler );
-    }
-
-    @Override
-    public final boolean isClosed()
-    {
-        return getSession().isClosed();
-    }
-
-    /**
-     * This method is special: by default it throws (nested session should never be closed), the "top level" session
-     * should be closed instead. Still, this method is NOT {@code final}, to allow implementations overriding it,
-     * and in case when needed, handle forwarded session as "top level" session.
-     */
-    @Override
-    public void close()
-    {
-        throw new IllegalStateException( "Forwarding session should not be closed, "
-                + "close the top-level (forwarded) session instead." );
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -8,9 +8,9 @@ package org.eclipse.aether;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,16 +19,10 @@ package org.eclipse.aether;
  * under the License.
  */
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import static java.util.Objects.requireNonNull;
-
-import java.util.Collection;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactType;
@@ -54,6 +48,8 @@ import org.eclipse.aether.transfer.TransferListener;
 import org.eclipse.aether.transform.FileTransformer;
 import org.eclipse.aether.transform.FileTransformerManager;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A simple repository system session.
  * <p>
@@ -63,10 +59,8 @@ import org.eclipse.aether.transform.FileTransformerManager;
  * accidental manipulation of it afterwards.
  */
 public final class DefaultRepositorySystemSession
-    implements RepositorySystemSession
+        implements RepositorySystemSession
 {
-
-    private final AtomicBoolean closed;
 
     private boolean readOnly;
 
@@ -133,7 +127,6 @@ public final class DefaultRepositorySystemSession
      */
     public DefaultRepositorySystemSession()
     {
-        closed = new AtomicBoolean( false );
         systemProperties = new HashMap<>();
         systemPropertiesView = Collections.unmodifiableMap( systemProperties );
         userProperties = new HashMap<>();
@@ -160,7 +153,6 @@ public final class DefaultRepositorySystemSession
     {
         requireNonNull( session, "repository system session cannot be null" );
 
-        closed = new AtomicBoolean( false );
         setOffline( session.isOffline() );
         setIgnoreArtifactDescriptorRepositories( session.isIgnoreArtifactDescriptorRepositories() );
         setResolutionErrorPolicy( session.getResolutionErrorPolicy() );
@@ -188,6 +180,7 @@ public final class DefaultRepositorySystemSession
         setCache( session.getCache() );
     }
 
+    @Override
     public boolean isOffline()
     {
         return offline;
@@ -196,7 +189,7 @@ public final class DefaultRepositorySystemSession
     /**
      * Controls whether the repository system operates in offline mode and avoids/refuses any access to remote
      * repositories.
-     * 
+     *
      * @param offline {@code true} if the repository system is in offline mode, {@code false} otherwise.
      * @return This session for chaining, never {@code null}.
      */
@@ -207,6 +200,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public boolean isIgnoreArtifactDescriptorRepositories()
     {
         return ignoreArtifactDescriptorRepositories;
@@ -215,9 +209,10 @@ public final class DefaultRepositorySystemSession
     /**
      * Controls whether repositories declared in artifact descriptors should be ignored during transitive dependency
      * collection. If enabled, only the repositories originally provided with the collect request will be considered.
-     * 
+     *
      * @param ignoreArtifactDescriptorRepositories {@code true} to ignore additional repositories from artifact
-     *            descriptors, {@code false} to merge those with the originally specified repositories.
+     *                                             descriptors, {@code false} to merge those with the originally
+     *                                             specified repositories.
      * @return This session for chaining, never {@code null}.
      */
     public DefaultRepositorySystemSession setIgnoreArtifactDescriptorRepositories(
@@ -228,6 +223,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public ResolutionErrorPolicy getResolutionErrorPolicy()
     {
         return resolutionErrorPolicy;
@@ -235,9 +231,9 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the policy which controls whether resolutions errors from remote repositories should be cached.
-     * 
+     *
      * @param resolutionErrorPolicy The resolution error policy for this session, may be {@code null} if resolution
-     *            errors should generally not be cached.
+     *                              errors should generally not be cached.
      * @return This session for chaining, never {@code null}.
      */
     public DefaultRepositorySystemSession setResolutionErrorPolicy( ResolutionErrorPolicy resolutionErrorPolicy )
@@ -247,6 +243,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public ArtifactDescriptorPolicy getArtifactDescriptorPolicy()
     {
         return artifactDescriptorPolicy;
@@ -254,9 +251,9 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the policy which controls how errors related to reading artifact descriptors should be handled.
-     * 
+     *
      * @param artifactDescriptorPolicy The descriptor error policy for this session, may be {@code null} if descriptor
-     *            errors should generally not be tolerated.
+     *                                 errors should generally not be tolerated.
      * @return This session for chaining, never {@code null}.
      */
     public DefaultRepositorySystemSession setArtifactDescriptorPolicy(
@@ -267,6 +264,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public String getChecksumPolicy()
     {
         return checksumPolicy;
@@ -275,7 +273,7 @@ public final class DefaultRepositorySystemSession
     /**
      * Sets the global checksum policy. If set, the global checksum policy overrides the checksum policies of the remote
      * repositories being used for resolution.
-     * 
+     *
      * @param checksumPolicy The global checksum policy, may be {@code null}/empty to apply the per-repository policies.
      * @return This session for chaining, never {@code null}.
      * @see RepositoryPolicy#CHECKSUM_POLICY_FAIL
@@ -289,6 +287,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public String getUpdatePolicy()
     {
         return updatePolicy;
@@ -297,7 +296,7 @@ public final class DefaultRepositorySystemSession
     /**
      * Sets the global update policy. If set, the global update policy overrides the update policies of the remote
      * repositories being used for resolution.
-     * 
+     *
      * @param updatePolicy The global update policy, may be {@code null}/empty to apply the per-repository policies.
      * @return This session for chaining, never {@code null}.
      * @see RepositoryPolicy#UPDATE_POLICY_ALWAYS
@@ -311,6 +310,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public LocalRepository getLocalRepository()
     {
         LocalRepositoryManager lrm = getLocalRepositoryManager();
@@ -325,7 +325,7 @@ public final class DefaultRepositorySystemSession
     /**
      * Sets the local repository manager used during this session. <em>Note:</em> Eventually, a valid session must have
      * a local repository manager set.
-     * 
+     *
      * @param localRepositoryManager The local repository manager used during this session, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -353,6 +353,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public WorkspaceReader getWorkspaceReader()
     {
         return workspaceReader;
@@ -361,7 +362,7 @@ public final class DefaultRepositorySystemSession
     /**
      * Sets the workspace reader used during this session. If set, the workspace reader will usually be consulted first
      * to resolve artifacts.
-     * 
+     *
      * @param workspaceReader The workspace reader for this session, may be {@code null} if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -372,6 +373,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public RepositoryListener getRepositoryListener()
     {
         return repositoryListener;
@@ -379,7 +381,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the listener being notified of actions in the repository system.
-     * 
+     *
      * @param repositoryListener The repository listener, may be {@code null} if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -390,6 +392,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public TransferListener getTransferListener()
     {
         return transferListener;
@@ -397,7 +400,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the listener being notified of uploads/downloads by the repository system.
-     * 
+     *
      * @param transferListener The transfer listener, may be {@code null} if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -435,6 +438,7 @@ public final class DefaultRepositorySystemSession
         return map;
     }
 
+    @Override
     public Map<String, String> getSystemProperties()
     {
         return systemPropertiesView;
@@ -446,7 +450,7 @@ public final class DefaultRepositorySystemSession
      * <p>
      * <em>Note:</em> System properties are of type {@code Map<String, String>} and any key-value pair in the input map
      * that doesn't match this type will be silently ignored.
-     * 
+     *
      * @param systemProperties The system properties, may be {@code null} or empty if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -460,8 +464,8 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the specified system property.
-     * 
-     * @param key The property key, must not be {@code null}.
+     *
+     * @param key   The property key, must not be {@code null}.
      * @param value The property value, may be {@code null} to remove/unset the property.
      * @return This session for chaining, never {@code null}.
      */
@@ -479,6 +483,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public Map<String, String> getUserProperties()
     {
         return userPropertiesView;
@@ -491,7 +496,7 @@ public final class DefaultRepositorySystemSession
      * <p>
      * <em>Note:</em> User properties are of type {@code Map<String, String>} and any key-value pair in the input map
      * that doesn't match this type will be silently ignored.
-     * 
+     *
      * @param userProperties The user properties, may be {@code null} or empty if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -505,8 +510,8 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the specified user property.
-     * 
-     * @param key The property key, must not be {@code null}.
+     *
+     * @param key   The property key, must not be {@code null}.
      * @param value The property value, may be {@code null} to remove/unset the property.
      * @return This session for chaining, never {@code null}.
      */
@@ -524,6 +529,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public Map<String, Object> getConfigProperties()
     {
         return configPropertiesView;
@@ -535,7 +541,7 @@ public final class DefaultRepositorySystemSession
      * <p>
      * <em>Note:</em> Configuration properties are of type {@code Map<String, Object>} and any key-value pair in the
      * input map that doesn't match this type will be silently ignored.
-     * 
+     *
      * @param configProperties The configuration properties, may be {@code null} or empty if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -549,8 +555,8 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the specified configuration property.
-     * 
-     * @param key The property key, must not be {@code null}.
+     *
+     * @param key   The property key, must not be {@code null}.
      * @param value The property value, may be {@code null} to remove/unset the property.
      * @return This session for chaining, never {@code null}.
      */
@@ -568,6 +574,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public MirrorSelector getMirrorSelector()
     {
         return mirrorSelector;
@@ -577,7 +584,7 @@ public final class DefaultRepositorySystemSession
      * Sets the mirror selector to use for repositories discovered in artifact descriptors. Note that this selector is
      * not used for remote repositories which are passed as request parameters to the repository system, those
      * repositories are supposed to denote the effective repositories.
-     * 
+     *
      * @param mirrorSelector The mirror selector to use, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -592,6 +599,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public ProxySelector getProxySelector()
     {
         return proxySelector;
@@ -601,7 +609,7 @@ public final class DefaultRepositorySystemSession
      * Sets the proxy selector to use for repositories discovered in artifact descriptors. Note that this selector is
      * not used for remote repositories which are passed as request parameters to the repository system, those
      * repositories are supposed to have their proxy (if any) already set.
-     * 
+     *
      * @param proxySelector The proxy selector to use, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      * @see org.eclipse.aether.repository.RemoteRepository#getProxy()
@@ -617,6 +625,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public AuthenticationSelector getAuthenticationSelector()
     {
         return authenticationSelector;
@@ -626,7 +635,7 @@ public final class DefaultRepositorySystemSession
      * Sets the authentication selector to use for repositories discovered in artifact descriptors. Note that this
      * selector is not used for remote repositories which are passed as request parameters to the repository system,
      * those repositories are supposed to have their authentication (if any) already set.
-     * 
+     *
      * @param authenticationSelector The authentication selector to use, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      * @see org.eclipse.aether.repository.RemoteRepository#getAuthentication()
@@ -642,6 +651,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public ArtifactTypeRegistry getArtifactTypeRegistry()
     {
         return artifactTypeRegistry;
@@ -649,7 +659,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the registry of artifact types recognized by this session.
-     * 
+     *
      * @param artifactTypeRegistry The artifact type registry, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -664,6 +674,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public DependencyTraverser getDependencyTraverser()
     {
         return dependencyTraverser;
@@ -671,7 +682,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the dependency traverser to use for building dependency graphs.
-     * 
+     *
      * @param dependencyTraverser The dependency traverser to use for building dependency graphs, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -682,6 +693,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public DependencyManager getDependencyManager()
     {
         return dependencyManager;
@@ -689,7 +701,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the dependency manager to use for building dependency graphs.
-     * 
+     *
      * @param dependencyManager The dependency manager to use for building dependency graphs, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -700,6 +712,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public DependencySelector getDependencySelector()
     {
         return dependencySelector;
@@ -707,7 +720,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the dependency selector to use for building dependency graphs.
-     * 
+     *
      * @param dependencySelector The dependency selector to use for building dependency graphs, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -718,6 +731,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public VersionFilter getVersionFilter()
     {
         return versionFilter;
@@ -725,9 +739,9 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the version filter to use for building dependency graphs.
-     * 
+     *
      * @param versionFilter The version filter to use for building dependency graphs, may be {@code null} to not filter
-     *            versions.
+     *                      versions.
      * @return This session for chaining, never {@code null}.
      */
     public DefaultRepositorySystemSession setVersionFilter( VersionFilter versionFilter )
@@ -737,6 +751,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public DependencyGraphTransformer getDependencyGraphTransformer()
     {
         return dependencyGraphTransformer;
@@ -744,9 +759,9 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the dependency graph transformer to use for building dependency graphs.
-     * 
+     *
      * @param dependencyGraphTransformer The dependency graph transformer to use for building dependency graphs, may be
-     *            {@code null}.
+     *                                   {@code null}.
      * @return This session for chaining, never {@code null}.
      */
     public DefaultRepositorySystemSession setDependencyGraphTransformer(
@@ -757,6 +772,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public SessionData getData()
     {
         return data;
@@ -764,7 +780,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the custom data associated with this session.
-     * 
+     *
      * @param data The session data, may be {@code null}.
      * @return This session for chaining, never {@code null}.
      */
@@ -779,6 +795,7 @@ public final class DefaultRepositorySystemSession
         return this;
     }
 
+    @Override
     public RepositoryCache getCache()
     {
         return cache;
@@ -786,7 +803,7 @@ public final class DefaultRepositorySystemSession
 
     /**
      * Sets the cache the repository system may use to save data for future reuse during the session.
-     * 
+     *
      * @param cache The repository cache, may be {@code null} if none.
      * @return This session for chaining, never {@code null}.
      */
@@ -816,14 +833,10 @@ public final class DefaultRepositorySystemSession
         {
             throw new IllegalStateException( "repository system session is read-only" );
         }
-        if ( closed.get() )
-        {
-            throw new IllegalStateException( "repository system session is already closed" );
-        }
     }
 
     static class NullProxySelector
-        implements ProxySelector
+            implements ProxySelector
     {
 
         public static final ProxySelector INSTANCE = new NullProxySelector();
@@ -837,7 +850,7 @@ public final class DefaultRepositorySystemSession
     }
 
     static class NullMirrorSelector
-        implements MirrorSelector
+            implements MirrorSelector
     {
 
         public static final MirrorSelector INSTANCE = new NullMirrorSelector();
@@ -851,7 +864,7 @@ public final class DefaultRepositorySystemSession
     }
 
     static class NullAuthenticationSelector
-        implements AuthenticationSelector
+            implements AuthenticationSelector
     {
 
         public static final AuthenticationSelector INSTANCE = new NullAuthenticationSelector();
@@ -865,7 +878,7 @@ public final class DefaultRepositorySystemSession
     }
 
     static final class NullArtifactTypeRegistry
-        implements ArtifactTypeRegistry
+            implements ArtifactTypeRegistry
     {
 
         public static final ArtifactTypeRegistry INSTANCE = new NullArtifactTypeRegistry();
@@ -885,47 +898,6 @@ public final class DefaultRepositorySystemSession
         public Collection<FileTransformer> getTransformersForArtifact( Artifact artifact )
         {
             return Collections.emptyList();
-        }
-    }
-
-    private final CopyOnWriteArrayList<Consumer<RepositorySystemSession>> onCloseHandlers
-            = new CopyOnWriteArrayList<>();
-
-    @Override
-    public void addOnCloseHandler( Consumer<RepositorySystemSession> handler )
-    {
-        requireNonNull( handler, "handler cannot be null" );
-        if ( closed.get() )
-        {
-            throw new IllegalStateException( "repository system session is already closed" );
-        }
-        onCloseHandlers.add( 0, handler );
-    }
-
-    @Override
-    public boolean isClosed()
-    {
-        return closed.get();
-    }
-
-    @Override
-    public void close()
-    {
-        if ( closed.compareAndSet( false, true ) )
-        {
-            ArrayList<Exception> exceptions = new ArrayList<>();
-            for ( Consumer<RepositorySystemSession> onCloseHandler : onCloseHandlers )
-            {
-                try
-                {
-                    onCloseHandler.accept( this );
-                }
-                catch ( Exception e )
-                {
-                    exceptions.add( e );
-                }
-            }
-            MultiRuntimeException.mayThrow( "session on-close handler failures", exceptions );
         }
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
@@ -8,9 +8,9 @@ package org.eclipse.aether;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -58,7 +58,10 @@ import org.eclipse.aether.resolution.VersionResult;
  * The main entry point to the repository system and its functionality. Note that obtaining a concrete implementation of
  * this interface (e.g. via dependency injection, service locator, etc.) is dependent on the application and its
  * specific needs, please consult the online documentation for examples and directions on booting the system.
- * 
+ * <p>
+ * When the repository system or the application integrating it is about to exit, invoke the {@link #shutdown()} to let
+ * resolver system perform possible resource cleanups.
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
  */
@@ -73,21 +76,21 @@ public interface RepositorySystem
      * <p>
      * The supplied request may also refer to a single concrete version rather than a version range. In this case
      * though, the result contains simply the (parsed) input version, regardless of the repositories and their contents.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The version range request, must not be {@code null}.
      * @return The version range result, never {@code null}.
      * @throws VersionRangeResolutionException If the requested range could not be parsed. Note that an empty range does
-     *             not raise an exception.
+     *                                         not raise an exception.
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     VersionRangeResult resolveVersionRange( RepositorySystemSession session, VersionRangeRequest request )
-        throws VersionRangeResolutionException;
+            throws VersionRangeResolutionException;
 
     /**
      * Resolves an artifact's meta version (if any) to a concrete version. For example, resolves "1.0-SNAPSHOT" to
      * "1.0-20090208.132618-23".
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The version request, must not be {@code null}.
      * @return The version result, never {@code null}.
@@ -95,11 +98,11 @@ public interface RepositorySystem
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
-        throws VersionResolutionException;
+            throws VersionResolutionException;
 
     /**
      * Gets information about an artifact like its direct dependencies and potential relocations.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The descriptor request, must not be {@code null}.
      * @return The descriptor result, never {@code null}.
@@ -109,13 +112,13 @@ public interface RepositorySystem
      */
     ArtifactDescriptorResult readArtifactDescriptor( RepositorySystemSession session,
                                                      ArtifactDescriptorRequest request )
-        throws ArtifactDescriptorException;
+            throws ArtifactDescriptorException;
 
     /**
      * Collects the transitive dependencies of an artifact and builds a dependency graph. Note that this operation is
      * only concerned about determining the coordinates of the transitive dependencies. To also resolve the actual
      * artifact files, use {@link #resolveDependencies(RepositorySystemSession, DependencyRequest)}.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The collection request, must not be {@code null}.
      * @return The collection result, never {@code null}.
@@ -128,29 +131,29 @@ public interface RepositorySystem
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     CollectResult collectDependencies( RepositorySystemSession session, CollectRequest request )
-        throws DependencyCollectionException;
+            throws DependencyCollectionException;
 
     /**
      * Collects and resolves the transitive dependencies of an artifact. This operation is essentially a combination of
      * {@link #collectDependencies(RepositorySystemSession, CollectRequest)} and
      * {@link #resolveArtifacts(RepositorySystemSession, Collection)}.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The dependency request, must not be {@code null}.
      * @return The dependency result, never {@code null}.
      * @throws DependencyResolutionException If the dependency tree could not be built or any dependency artifact could
-     *             not be resolved.
+     *                                       not be resolved.
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     DependencyResult resolveDependencies( RepositorySystemSession session, DependencyRequest request )
-        throws DependencyResolutionException;
+            throws DependencyResolutionException;
 
     /**
      * Resolves the path for an artifact. The artifact will be downloaded to the local repository if necessary. An
      * artifact that is already resolved will be skipped and is not re-resolved. In general, callers must not assume any
      * relationship between an artifact's resolved filename and its coordinates. Note that this method assumes that any
      * relocations have already been processed.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The resolution request, must not be {@code null}.
      * @return The resolution result, never {@code null}.
@@ -159,15 +162,15 @@ public interface RepositorySystem
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     ArtifactResult resolveArtifact( RepositorySystemSession session, ArtifactRequest request )
-        throws ArtifactResolutionException;
+            throws ArtifactResolutionException;
 
     /**
      * Resolves the paths for a collection of artifacts. Artifacts will be downloaded to the local repository if
      * necessary. Artifacts that are already resolved will be skipped and are not re-resolved. In general, callers must
      * not assume any relationship between an artifact's filename and its coordinates. Note that this method assumes
      * that any relocations have already been processed.
-     * 
-     * @param session The repository session, must not be {@code null}.
+     *
+     * @param session  The repository session, must not be {@code null}.
      * @param requests The resolution requests, must not be {@code null}.
      * @return The resolution results (in request order), never {@code null}.
      * @throws ArtifactResolutionException If any artifact could not be resolved.
@@ -176,13 +179,13 @@ public interface RepositorySystem
      */
     List<ArtifactResult> resolveArtifacts( RepositorySystemSession session,
                                            Collection<? extends ArtifactRequest> requests )
-        throws ArtifactResolutionException;
+            throws ArtifactResolutionException;
 
     /**
      * Resolves the paths for a collection of metadata. Metadata will be downloaded to the local repository if
      * necessary, e.g. because it hasn't been cached yet or the cache is deemed outdated.
-     * 
-     * @param session The repository session, must not be {@code null}.
+     *
+     * @param session  The repository session, must not be {@code null}.
      * @param requests The resolution requests, must not be {@code null}.
      * @return The resolution results (in request order), never {@code null}.
      * @see Metadata#getFile()
@@ -193,18 +196,18 @@ public interface RepositorySystem
 
     /**
      * Installs a collection of artifacts and their accompanying metadata to the local repository.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The installation request, must not be {@code null}.
      * @return The installation result, never {@code null}.
      * @throws InstallationException If any artifact/metadata from the request could not be installed.
      */
     InstallResult install( RepositorySystemSession session, InstallRequest request )
-        throws InstallationException;
+            throws InstallationException;
 
     /**
      * Uploads a collection of artifacts and their accompanying metadata to a remote repository.
-     * 
+     *
      * @param session The repository session, must not be {@code null}.
      * @param request The deployment request, must not be {@code null}.
      * @return The deployment result, never {@code null}.
@@ -212,29 +215,30 @@ public interface RepositorySystem
      * @see #newDeploymentRepository(RepositorySystemSession, RemoteRepository)
      */
     DeployResult deploy( RepositorySystemSession session, DeployRequest request )
-        throws DeploymentException;
+            throws DeploymentException;
 
     /**
      * Creates a new manager for the specified local repository. If the specified local repository has no type, the
      * default local repository type of the system will be used. <em>Note:</em> It is expected that this method
      * invocation is one of the last steps of setting up a new session, in particular any configuration properties
      * should have been set already.
-     * 
-     * @param session The repository system session from which to configure the manager, must not be {@code null}.
+     *
+     * @param session         The repository system session from which to configure the manager, must not be
+     *                        {@code null}.
      * @param localRepository The local repository to create a manager for, must not be {@code null}.
      * @return The local repository manager, never {@code null}.
      * @throws IllegalArgumentException If the specified repository type is not recognized or no base directory is
-     *             given.
+     *                                  given.
      */
     LocalRepositoryManager newLocalRepositoryManager( RepositorySystemSession session,
                                                       LocalRepository localRepository );
 
     /**
      * Creates a new synchronization context.
-     * 
+     *
      * @param session The repository session during which the context will be used, must not be {@code null}.
-     * @param shared A flag indicating whether access to the artifacts/metadata associated with the new context can be
-     *            shared among concurrent readers or whether access needs to be exclusive to the calling thread.
+     * @param shared  A flag indicating whether access to the artifacts/metadata associated with the new context can be
+     *                shared among concurrent readers or whether access needs to be exclusive to the calling thread.
      * @return The synchronization context, never {@code null}.
      */
     SyncContext newSyncContext( RepositorySystemSession session, boolean shared );
@@ -247,13 +251,14 @@ public interface RepositorySystem
      * to already carry any required authentication or proxy configuration. This method can be used to apply the
      * authentication/proxy configuration from a session to a bare repository definition to obtain the complete
      * repository definition for use in the resolution request.
-     * 
-     * @param session The repository system session from which to configure the repositories, must not be {@code null}.
+     *
+     * @param session      The repository system session from which to configure the repositories, must not be
+     *                     {@code null}.
      * @param repositories The repository prototypes from which to derive the resolution repositories, must not be
-     *            {@code null} or contain {@code null} elements.
+     *                     {@code null} or contain {@code null} elements.
      * @return The resolution repositories, never {@code null}. Note that there is generally no 1:1 relationship of the
-     *         obtained repositories to the original inputs due to mirror selection potentially aggregating multiple
-     *         repositories.
+     * obtained repositories to the original inputs due to mirror selection potentially aggregating multiple
+     * repositories.
      * @see #newDeploymentRepository(RepositorySystemSession, RemoteRepository)
      */
     List<RemoteRepository> newResolutionRepositories( RepositorySystemSession session,
@@ -267,13 +272,34 @@ public interface RepositorySystem
      * required authentication or proxy configuration. This method can be used to apply the authentication/proxy
      * configuration from a session to a bare repository definition to obtain the complete repository definition for use
      * in the deploy request.
-     * 
-     * @param session The repository system session from which to configure the repository, must not be {@code null}.
+     *
+     * @param session    The repository system session from which to configure the repository, must not be {@code null}.
      * @param repository The repository prototype from which to derive the deployment repository, must not be
-     *            {@code null}.
+     *                   {@code null}.
      * @return The deployment repository, never {@code null}.
      * @see #newResolutionRepositories(RepositorySystemSession, List)
      */
     RemoteRepository newDeploymentRepository( RepositorySystemSession session, RemoteRepository repository );
 
+    /**
+     * Registers an "on repository system end" handler, executed after repository system is shut down.
+     *
+     * @param handler The handler, must not be {@code null}.
+     * @since 1.9.0
+     */
+    void addOnSystemEndedHandler( Runnable handler );
+
+    /**
+     * Signals to repository system to shut down. Shut down instance is not usable anymore.
+     * <p>
+     * Repository system may perform some resource cleanup, if applicable. Not using this method may cause leaks or
+     * unclean shutdown of some subsystem.
+     * <p>
+     * When shutdown happens, all the registered on-close handlers will be invoked (even if some throws), and at end
+     * of operation a {@link MultiRuntimeException} may be thrown, signaling that some handler(s) failed. This exception
+     * may be ignored, is at the discretion of caller.
+     *
+     * @since 1.9.0
+     */
+    void shutdown();
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -20,7 +20,6 @@ package org.eclipse.aether;
  */
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
@@ -45,11 +44,11 @@ import org.eclipse.aether.transform.FileTransformerManager;
  * supposed to be immutable and hence can safely be shared across an entire application and any concurrent threads
  * reading it. Components that wish to tweak some aspects of an existing session should use the copy constructor of
  * {@link DefaultRepositorySystemSession} and its mutators to derive a custom session.
- * 
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
  */
-public interface RepositorySystemSession extends AutoCloseable
+public interface RepositorySystemSession
 {
 
     /**
@@ -271,58 +270,4 @@ public interface RepositorySystemSession extends AutoCloseable
      */
     @Deprecated
     FileTransformerManager getFileTransformerManager();
-
-    /**
-     * Adds "on close" handler to this session, it must not be {@code null}. Note: when handlers are invoked, the
-     * passed in (this) session is ALREADY CLOSED (the {@link #isClosed()} method returns {@code true}). This implies,
-     * that handlers cannot use {@link RepositorySystem} to resolve/collect/and so on, handlers are meant to perform
-     * some internal cleanup on session close. Attempt to add handler to closed session will throw.
-     *
-     * @since 1.9.0
-     */
-    void addOnCloseHandler( Consumer<RepositorySystemSession> handler );
-
-    /**
-     * Returns {@code true} if this instance was already closed. Closed sessions should NOT be used anymore.
-     *
-     * @return {@code true} if session was closed.
-     * @since 1.9.0
-     */
-    boolean isClosed();
-
-    /**
-     * Closes this session and possibly releases related resources by invoking "on close" handlers added by
-     * {@link #addOnCloseHandler(Consumer<RepositorySystemSession>)} method. This method may be invoked multiple times,
-     * but only first invocation will actually invoke handlers, subsequent invocations will be no-op.
-     * <p>
-     * When close action happens, all the registered handlers will be invoked (even if some throws), and at end
-     * of operation a {@link MultiRuntimeException} may be thrown signaling that some handler(s) failed. This exception
-     * may be ignored, is at the discretion of caller.
-     * <p>
-     * Important: ideally it is the session creator who should be responsible to close the session. The "nested"
-     * (delegating, wrapped) sessions {@link AbstractForwardingRepositorySystemSession} and alike) by default
-     * (without overriding the {@link AbstractForwardingRepositorySystemSession#close()} method) are prevented to close
-     * session, and it is the "recommended" behaviour as well. On the other hand, "nested" session may receive new
-     * "on close" handler registrations, but those registrations are passed to delegated session, and will be invoked
-     * once the "top level" (delegated) session is closed.
-     * <p>
-     * New session "copy" instances created using copy-constructor
-     * {@link DefaultRepositorySystemSession#DefaultRepositorySystemSession(RepositorySystemSession)} result in new,
-     * independent session instances, and they do NOT share states like "read-only", "closed" and "on close handlers"
-     * with the copied session. Hence, they should be treated as "top level" sessions as well.
-     * <p>
-     * The recommended pattern for "top level" sessions is the usual try-with-resource:
-     *
-     * <pre> {@code
-     * try ( RepositorySystemSession session = create session... )
-     * {
-     *   ... use/nest session
-     * }
-     * }</pre>
-     *
-     * @since 1.9.0
-     */
-    @Override
-    void close();
-
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.LocalPathComposer;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
@@ -229,6 +230,7 @@ public final class DefaultServiceLocator
         addService( ChecksumAlgorithmFactorySelector.class, DefaultChecksumAlgorithmFactorySelector.class );
         addService( LocalPathComposer.class, DefaultLocalPathComposer.class );
         addService( RemoteRepositoryFilterManager.class, DefaultRemoteRepositoryFilterManager.class );
+        addService( RepositorySystemLifecycle.class, DefaultRepositorySystemLifecycle.class );
     }
 
     private <T> Entry<T> getEntry( Class<T> type, boolean create )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RepositorySystemLifecycle.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RepositorySystemLifecycle.java
@@ -1,0 +1,44 @@
+package org.eclipse.aether.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Lifecycle managing component for repository system.
+ *
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ * @provisional This type is provisional and can be changed, moved or removed without prior notice.
+ * @since 1.9.0
+ */
+public interface RepositorySystemLifecycle
+{
+    /**
+     * Marks the repository system as ended (shut down): all "on close" handlers will be invoked. This method may be
+     * invoked multiple times, only once will execute, subsequent calls will be no-op.
+     */
+    void systemEnded();
+
+    /**
+     * Registers an "on repository system end" handler.
+     * <p>
+     * Throws if repository system is already shut down.
+     */
+    void addOnSystemEndedHandler( Runnable handler );
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -41,7 +41,9 @@ import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.impl.RepositoryConnectorProvider;
 import org.eclipse.aether.impl.RepositoryEventDispatcher;
+import org.eclipse.aether.impl.RepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultLocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.LocalPathComposer;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
@@ -64,6 +66,8 @@ import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSou
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactorySelector;
+import org.eclipse.aether.internal.impl.synccontext.named.ParameterizedNamedLockFactorySelector;
 import org.eclipse.aether.internal.impl.synccontext.named.providers.DiscriminatingNameMapperProvider;
 import org.eclipse.aether.internal.impl.synccontext.named.providers.FileGAVNameMapperProvider;
 import org.eclipse.aether.internal.impl.synccontext.named.providers.FileHashingGAVNameMapperProvider;
@@ -222,6 +226,10 @@ public class AetherModule
         bind( ChecksumAlgorithmFactorySelector.class )
                 .to( DefaultChecksumAlgorithmFactorySelector.class ).in ( Singleton.class );
 
+        bind( RepositorySystemLifecycle.class )
+                .to( DefaultRepositorySystemLifecycle.class ).in( Singleton.class );
+
+        bind( NamedLockFactorySelector.class ).toInstance( new ParameterizedNamedLockFactorySelector() );
         bind( SyncContextFactory.class ).to( DefaultSyncContextFactory.class ).in( Singleton.class );
         bind( org.eclipse.aether.impl.SyncContextFactory.class )
                 .to( org.eclipse.aether.internal.impl.synccontext.legacy.DefaultSyncContextFactory.class )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemLifecycle.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemLifecycle.java
@@ -1,0 +1,90 @@
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.aether.MultiRuntimeException;
+import org.eclipse.aether.impl.RepositorySystemLifecycle;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ *
+ */
+@Singleton
+@Named
+public class DefaultRepositorySystemLifecycle
+        implements RepositorySystemLifecycle
+{
+    private final AtomicBoolean shutdown;
+
+    private final CopyOnWriteArrayList<Runnable> onSystemEndedHandlers;
+
+    @Inject
+    public DefaultRepositorySystemLifecycle()
+    {
+        this.shutdown = new AtomicBoolean( false );
+        this.onSystemEndedHandlers = new CopyOnWriteArrayList<>();
+    }
+
+    @Override
+    public void systemEnded()
+    {
+        if ( shutdown.compareAndSet( false, true ) )
+        {
+            final ArrayList<Exception> exceptions = new ArrayList<>();
+            for ( Runnable onCloseHandler : onSystemEndedHandlers )
+            {
+                try
+                {
+                    onCloseHandler.run();
+                }
+                catch ( Exception e )
+                {
+                    exceptions.add( e );
+                }
+            }
+            MultiRuntimeException.mayThrow( "system on-close handler failures", exceptions );
+        }
+    }
+
+    @Override
+    public void addOnSystemEndedHandler( Runnable handler )
+    {
+        requireNonNull( handler, "handler cannot be null" );
+        requireNotShutdown();
+        onSystemEndedHandlers.add( 0, handler );
+    }
+
+    private void requireNotShutdown()
+    {
+        if ( shutdown.get() )
+        {
+            throw new IllegalStateException( "repository system is already shut down" );
+        }
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
@@ -53,7 +53,7 @@ import static java.util.Objects.requireNonNull;
  * up. This implementation can be simultaneously used to lookup and also write checksums. The written checksums
  * will become visible across all sessions right after the moment they were written.
  * <p>
- * The name of this implementation is "sparse-directory".
+ * The name of this implementation is "sparseDirectory".
  *
  * @see LocalPathComposer
  * @since 1.9.0
@@ -63,7 +63,7 @@ import static java.util.Objects.requireNonNull;
 public final class SparseDirectoryTrustedChecksumsSource
         extends FileTrustedChecksumsSourceSupport
 {
-    public static final String NAME = "sparse-directory";
+    public static final String NAME = "sparseDirectory";
 
     private static final Logger LOGGER = LoggerFactory.getLogger( SparseDirectoryTrustedChecksumsSource.class );
 
@@ -167,11 +167,5 @@ public final class SparseDirectoryTrustedChecksumsSource
                 fileProcessor.writeChecksum( checksumPath.toFile(), checksum );
             }
         }
-
-        @Override
-        public void close()
-        {
-            // nop
-        }
-    }
+   }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -98,8 +98,8 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
     }
 
     protected DependencyCollectorDelegate( RemoteRepositoryManager remoteRepositoryManager,
-                           ArtifactDescriptorReader artifactDescriptorReader,
-                           VersionRangeResolver versionRangeResolver )
+                                           ArtifactDescriptorReader artifactDescriptorReader,
+                                           VersionRangeResolver versionRangeResolver )
     {
         setRemoteRepositoryManager( remoteRepositoryManager );
         setArtifactDescriptorReader( artifactDescriptorReader );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactorySelector.java
@@ -1,4 +1,4 @@
-package org.eclipse.aether.internal.impl.checksum;
+package org.eclipse.aether.internal.impl.synccontext.named;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,21 +19,23 @@ package org.eclipse.aether.internal.impl.checksum;
  * under the License.
  */
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.impl.RepositorySystemLifecycle;
-import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.named.NamedLockFactory;
 
-public class SummaryFileTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport
+/**
+ * Selector for {@link NamedLockFactory} and {@link NameMapper} that selects and exposes selected ones. Essentially
+ * all the named locks configuration is here. Implementations may use different strategies to perform selection.
+ *
+ * @since 1.7.3
+ */
+public interface NamedLockFactorySelector
 {
-    @Override
-    protected FileTrustedChecksumsSourceSupport prepareSubject( RepositorySystemLifecycle lifecycle )
-    {
-        return new SummaryFileTrustedChecksumsSource( new DefaultLocalPathComposer(), lifecycle );
-    }
+    /**
+     * Returns the selected {@link NamedLockFactory}, never {@code null}.
+     */
+    NamedLockFactory getSelectedNamedLockFactory();
 
-    @Override
-    protected void enableSource( DefaultRepositorySystemSession session )
-    {
-        session.setConfigProperty( "aether.trustedChecksumsSource.summaryFile", Boolean.TRUE.toString() );
-    }
+    /**
+     * Returns the selected {@link NameMapper}, never {@code null}.
+     */
+    NameMapper getSelectedNameMapper();
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ParameterizedNamedLockFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/ParameterizedNamedLockFactorySelector.java
@@ -1,0 +1,147 @@
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.aether.internal.impl.synccontext.named.providers.DiscriminatingNameMapperProvider;
+import org.eclipse.aether.internal.impl.synccontext.named.providers.FileGAVNameMapperProvider;
+import org.eclipse.aether.internal.impl.synccontext.named.providers.FileHashingGAVNameMapperProvider;
+import org.eclipse.aether.internal.impl.synccontext.named.providers.GAVNameMapperProvider;
+import org.eclipse.aether.internal.impl.synccontext.named.providers.StaticNameMapperProvider;
+import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalSemaphoreNamedLockFactory;
+import org.eclipse.aether.named.providers.NoopNamedLockFactory;
+
+/**
+ * Parameterized selector implementation that selects based on injected parameters.
+ *
+ * @since 1.9.0
+ */
+@Singleton
+@Named
+public final class ParameterizedNamedLockFactorySelector
+        implements NamedLockFactorySelector
+{
+    private static final String FACTORY_KEY = "aether.syncContext.named.factory";
+
+    private static final String NAME_MAPPER_KEY = "aether.syncContext.named.nameMapper";
+
+    private static final Map<String, NamedLockFactory> FACTORIES;
+
+    private static final String DEFAULT_FACTORY = LocalReadWriteLockNamedLockFactory.NAME;
+
+    private static final Map<String, NameMapper> NAME_MAPPERS;
+
+    private static final String DEFAULT_NAME_MAPPER = GAVNameMapperProvider.NAME;
+
+    static
+    {
+        HashMap<String, NamedLockFactory> factories = new HashMap<>();
+        factories.put( NoopNamedLockFactory.NAME, new NoopNamedLockFactory() );
+        factories.put( LocalReadWriteLockNamedLockFactory.NAME, new LocalReadWriteLockNamedLockFactory() );
+        factories.put( LocalSemaphoreNamedLockFactory.NAME, new LocalSemaphoreNamedLockFactory() );
+        factories.put( FileLockNamedLockFactory.NAME, new FileLockNamedLockFactory() );
+        FACTORIES = factories;
+
+        HashMap<String, NameMapper> mappers = new HashMap<>();
+        mappers.put( StaticNameMapperProvider.NAME, new StaticNameMapperProvider().get() );
+        mappers.put( GAVNameMapperProvider.NAME, new GAVNameMapperProvider().get() );
+        mappers.put( DiscriminatingNameMapperProvider.NAME, new DiscriminatingNameMapperProvider().get() );
+        mappers.put( FileGAVNameMapperProvider.NAME, new FileGAVNameMapperProvider().get() );
+        mappers.put( FileHashingGAVNameMapperProvider.NAME, new FileHashingGAVNameMapperProvider().get() );
+        NAME_MAPPERS = mappers;
+    }
+
+    private final NamedLockFactory namedLockFactory;
+
+    private final NameMapper nameMapper;
+
+    /**
+     * Default constructor for non Eclipse Sisu uses.
+     */
+    public ParameterizedNamedLockFactorySelector()
+    {
+        this( FACTORIES, DEFAULT_FACTORY, NAME_MAPPERS, DEFAULT_NAME_MAPPER );
+    }
+
+    /**
+     * Constructor that uses Eclipse Sisu parameter injection.
+     */
+    @SuppressWarnings( "checkstyle:LineLength" )
+    @Inject
+    public ParameterizedNamedLockFactorySelector( final Map<String, NamedLockFactory> factories,
+                                                  @Named( "${" + FACTORY_KEY + ":-" + DEFAULT_FACTORY + "}" ) final String selectedFactoryName,
+                                                  final Map<String, NameMapper> nameMappers,
+                                                  @Named( "${" + NAME_MAPPER_KEY + ":-" + DEFAULT_NAME_MAPPER + "}" ) final String selectedMapperName )
+    {
+        this.namedLockFactory = selectNamedLockFactory( factories, selectedFactoryName );
+        this.nameMapper = selectNameMapper( nameMappers, selectedMapperName );
+    }
+
+    /**
+     * Returns the selected {@link NamedLockFactory}, never null.
+     */
+    @Override
+    public NamedLockFactory getSelectedNamedLockFactory()
+    {
+        return namedLockFactory;
+    }
+
+    /**
+     * Returns the selected {@link NameMapper}, never null.
+     */
+    @Override
+    public NameMapper getSelectedNameMapper()
+    {
+        return nameMapper;
+    }
+
+    private static NamedLockFactory selectNamedLockFactory( final Map<String, NamedLockFactory> factories,
+                                                     final String factoryName )
+    {
+        NamedLockFactory factory = factories.get( factoryName );
+        if ( factory == null )
+        {
+            throw new IllegalArgumentException( "Unknown NamedLockFactory name: " + factoryName
+                    + ", known ones: " + factories.keySet() );
+        }
+        return factory;
+    }
+
+    private static NameMapper selectNameMapper( final Map<String, NameMapper> nameMappers,
+                                         final String nameMapperName )
+    {
+        NameMapper nameMapper = nameMappers.get( nameMapperName );
+        if ( nameMapper == null )
+        {
+            throw new IllegalArgumentException( "Unknown NameMapper name: " + nameMapperName
+                    + ", known ones: " + nameMappers.keySet() );
+        }
+        return nameMapper;
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
@@ -21,13 +21,14 @@ package org.eclipse.aether.internal.impl.checksum;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultFileProcessor;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 
 public class SparseDirectoryTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport
 {
     @Override
-    protected FileTrustedChecksumsSourceSupport prepareSubject()
+    protected FileTrustedChecksumsSourceSupport prepareSubject( RepositorySystemLifecycle lifecycle )
     {
         return new SparseDirectoryTrustedChecksumsSource( new DefaultFileProcessor(), new DefaultLocalPathComposer() );
     }
@@ -35,6 +36,6 @@ public class SparseDirectoryTrustedChecksumsSourceTest extends FileTrustedChecks
     @Override
     protected void enableSource( DefaultRepositorySystemSession session )
     {
-        session.setConfigProperty( "aether.trustedChecksumsSource.sparse-directory", Boolean.TRUE.toString() );
+        session.setConfigProperty( "aether.trustedChecksumsSource.sparseDirectory", Boolean.TRUE.toString() );
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -103,7 +103,7 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
         subject = new TrustedChecksumsArtifactResolverPostProcessor( selector,
                 Collections.singletonMap( TRUSTED_SOURCE_NAME, this ) );
         trustedChecksumsWriter = null;
-        session.setConfigProperty( "aether.artifactResolver.postProcessor.trusted-checksums", Boolean.TRUE.toString() );
+        session.setConfigProperty( "aether.artifactResolver.postProcessor.trustedChecksums", Boolean.TRUE.toString() );
     }
 
     // -- TrustedChecksumsSource interface BEGIN
@@ -163,7 +163,7 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
     @Test
     public void haveNoChecksumFailIfMissingEnabledFail()
     {
-        session.setConfigProperty( "aether.artifactResolver.postProcessor.trusted-checksums.failIfMissing",
+        session.setConfigProperty( "aether.artifactResolver.postProcessor.trustedChecksums.failIfMissing",
                 Boolean.TRUE.toString() );
         ArtifactResult artifactResult = createArtifactResult( artifactWithoutTrustedChecksum );
         assertThat( artifactResult.isResolved(), equalTo( true ) );
@@ -204,14 +204,8 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
             {
                 recordedChecksum.set( trustedArtifactChecksums.get( checksumAlgorithmFactory.getName() ) );
             }
-
-            @Override
-            public void close()
-            {
-                // nop
-            }
         };
-        session.setConfigProperty( "aether.artifactResolver.postProcessor.trusted-checksums.record",
+        session.setConfigProperty( "aether.artifactResolver.postProcessor.trustedChecksums.record",
                 Boolean.TRUE.toString() );
         ArtifactResult artifactResult = createArtifactResult( artifactWithTrustedChecksum );
         assertThat( artifactResult.isResolved(), equalTo( true ) );

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/checksums/TrustedChecksumsSource.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/checksums/TrustedChecksumsSource.java
@@ -19,7 +19,6 @@ package org.eclipse.aether.spi.checksums;
  * under the License.
  */
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -58,10 +57,9 @@ public interface TrustedChecksumsSource
                                                      List<ChecksumAlgorithmFactory> checksumAlgorithmFactories );
 
     /**
-     * A writer that is able to write/add trusted checksums to this implementation. Should be treated as a resource
-     * as underlying implementation may rely on being closed after not used anymore.
+     * A writer that is able to write/add trusted checksums to this implementation.
      */
-    interface Writer extends Closeable
+    interface Writer
     {
         /**
          * Performs whatever implementation requires to "set" (write/add/append) given map of trusted checksums.

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -22,11 +22,11 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 --- | --- | --- | --- | ---
 `aether.artifactResolver.snapshotNormalization` | boolean | It replaces the timestamped snapshot file name with a filename containing the `SNAPSHOT` qualifier only. This only affects resolving/retrieving artifacts but not uploading those. | `true` | no
 `aether.artifactResolver.simpleLrmInterop` | boolean | Enable interop with Simple LRM. Ignored when RRF used. | `false` | no
-`aether.artifactResolver.postProcessor.trusted-checksums` | boolean | Enable `trusted-checksums` resolver post processor. | `false` | no 
-`aether.artifactResolver.postProcessor.trusted-checksums.checksumAlgorithms` | String | Comma-separated list of checksum algorithms with which `trusted-checksums` should operate (validate or record). | `"SHA-1"` | no 
-`aether.artifactResolver.postProcessor.trusted-checksums.failIfMissing` | boolean | Makes `trusted-checksums` fail validation if a trusted checksum for an artifact is missing. | `false` | no 
-`aether.artifactResolver.postProcessor.trusted-checksums.record` | boolean | Makes `trusted-checksums` calculate and record checksums. | `false` | no 
-`aether.artifactResolver.postProcessor.trusted-checksums.snapshots` | boolean | Enables or disables snapshot processing in `trusted-checksum` post processor. | `false` | no 
+`aether.artifactResolver.postProcessor.trustedChecksums` | boolean | Enable `trustedChecksums` resolver post processor. | `false` | no 
+`aether.artifactResolver.postProcessor.trustedChecksums.checksumAlgorithms` | String | Comma-separated list of checksum algorithms with which `trustedChecksums` should operate (validate or record). | `"SHA-1"` | no 
+`aether.artifactResolver.postProcessor.trustedChecksums.failIfMissing` | boolean | Makes `trustedChecksums` fail validation if a trusted checksum for an artifact is missing. | `false` | no 
+`aether.artifactResolver.postProcessor.trustedChecksums.record` | boolean | Makes `trustedChecksums` calculate and record checksums. | `false` | no 
+`aether.artifactResolver.postProcessor.trustedChecksums.snapshots` | boolean | Enables or disables snapshot processing in `trustedChecksums` post processor. | `false` | no 
 `aether.checksums.omitChecksumsForExtensions` | String | Comma-separated list of extensions with leading dot (example `.asc`) that should have checksums omitted. These are applied to sub-artifacts only. Note: to achieve 1.7.x `aether.checksums.forSignature=true` behaviour, pass empty string as value for this property. | `.asc` | no
 `aether.checksums.algorithms` | String | Comma-separated list of checksum algorithms with which checksums are validated (downloaded) and generated (uploaded). Resolver by default supports following algorithms: `MD5`, `SHA-1`, `SHA-256` and `SHA-512`. New algorithms can be added by implementing `ChecksumAlgorithmFactory` component. | `"SHA-1,MD5"` | no
 `aether.conflictResolver.verbose` | boolean | Flag controlling the conflict resolver's verbose mode. | `false` | no
@@ -86,12 +86,12 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.syncContext.named.discriminating.discriminator` | String | A discriminator name prefix identifying a Resolver instance. | `"sha1('${hostname:-localhost}:${maven.repo.local}')"` or `"sha1('')"` if generation fails | no
 `aether.syncContext.named.discriminating.hostname` | String | The hostname to be used with discriminating mapper. | Detected with `InetAddress.getLocalHost().getHostName()` | no
 `aether.syncContext.named.redisson.configFile` | String | Path to a Redisson configuration file in YAML format. Read [official documentation](https://github.com/redisson/redisson/wiki/2.-Configuration) for details. | none or `"${maven.conf}/maven-resolver-redisson.yaml"` if present | no
-`aether.trustedChecksumsSource.sparse-directory` | boolean | Enable `sparse-directory` trusted checksum source. | `false` | no
-`aether.trustedChecksumsSource.sparse-directory.basedir` | String | The basedir path for `sparse-directory` trusted checksum source. If relative, resolved against local repository root, if absolute, used as is. | `".checksums"` | no
-`aether.trustedChecksumsSource.sparse-directory.originAware` | boolean | Is trusted checksum source origin aware (factors in Repository ID into path) or not. | `true` | no
-`aether.trustedChecksumsSource.summary-file` | boolean | Enable `summary-file` trusted checksum source. | `false` | no
-`aether.trustedChecksumsSource.summary-file.basedir` | String | The basedir path for `summary-file` trusted checksum source. If relative, resolved against local repository root, if absolute, used as is. | `".checksums"` | no
-`aether.trustedChecksumsSource.summary-file.originAware` | boolean | Is trusted checksum source origin aware (factors in Repository ID into path) or not. | `true` | no
+`aether.trustedChecksumsSource.sparseDirectory` | boolean | Enable `sparseDirectory` trusted checksum source. | `false` | no
+`aether.trustedChecksumsSource.sparseDirectory.basedir` | String | The basedir path for `sparseDirectory` trusted checksum source. If relative, resolved against local repository root, if absolute, used as is. | `".checksums"` | no
+`aether.trustedChecksumsSource.sparseDirectory.originAware` | boolean | Is trusted checksum source origin aware (factors in Repository ID into path) or not. | `true` | no
+`aether.trustedChecksumsSource.summaryFile` | boolean | Enable `summaryFile` trusted checksum source. | `false` | no
+`aether.trustedChecksumsSource.summaryFile.basedir` | String | The basedir path for `summaryFile` trusted checksum source. If relative, resolved against local repository root, if absolute, used as is. | `".checksums"` | no
+`aether.trustedChecksumsSource.summaryFile.originAware` | boolean | Is trusted checksum source origin aware (factors in Repository ID into path) or not. | `true` | no
 `aether.updateCheckManager.sessionState` | String | Manages the session state, i.e. influences if the same download requests to artifacts/metadata will happen multiple times within the same RepositorySystemSession. If `"enabled"` will enable the session state. If `"bypass"` will enable bypassing (i.e. store all artifact ids/metadata ids which have been updates but not evaluating those). All other values lead to disabling the session state completely. | `"enabled"` | no
 
 All properties which have `yes` in the column `Supports Repo ID Suffix` can be optionally configured specifically for a repository id. In that case the configuration property needs to be suffixed with a period followed by the repository id of the repository to configure, e.g. `aether.connector.http.headers.central` for repository with id `central`.


### PR DESCRIPTION
Drops problematic onSessionClose, keeps only onSystemClose support. Issue will be adjusted accordingly.

Key changes:
* undone all related to onSessionClose
* kept onRepositorySystemClose + shutdown
* all 3 users on onSessionClose (locking + 2 "recording" features) will act on shutdown
* moved out of session.data use as it is completely unreliable, now singleton components hold caches (hence the shutdown persistence)
* DefaultSyncContext: fixed as explained, does not use system properties anymore, but is made pretty much same as before https://github.com/apache/maven-resolver/pull/196
* renamed all new components to `camelCase`

----

https://issues.apache.org/jira/browse/MRESOLVER-278