### PR TITLE
Make ResolverDemo run as part of AllResolverDemos too.

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/AllResolverDemos.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/AllResolverDemos.java
@@ -19,6 +19,8 @@ package org.apache.maven.resolver.examples;
  * under the License.
  */
 
+import org.apache.maven.resolver.examples.resolver.ResolverDemo;
+
 /**
  * Runs all demos at once.
  */
@@ -42,6 +44,8 @@ public class AllResolverDemos
         ReverseDependencyTree.main( args );
         InstallArtifacts.main( args );
         DeployArtifacts.main( args );
+
+        ResolverDemo.main( args );
     }
 
 }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/Resolver.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/Resolver.java
@@ -65,6 +65,8 @@ public class Resolver
     {
         DefaultRepositorySystemSession session = Booter.newRepositorySystemSession( repositorySystem );
         session.setLocalRepositoryManager( repositorySystem.newLocalRepositoryManager( session, localRepository ) );
+        session.setTransferListener( null );
+        session.setRepositoryListener( null );
         return session;
     }
 
@@ -87,6 +89,8 @@ public class Resolver
 
         StringBuilder dump = new StringBuilder();
         displayTree( rootNode, dump );
+        System.out.println( "Tree:" );
+        System.out.println( dump );
 
         PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
         rootNode.accept( nlg );

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/resolver/ResolverDemo.java
@@ -22,6 +22,7 @@ package org.apache.maven.resolver.examples.resolver;
 import java.io.File;
 import java.util.List;
 
+import org.apache.maven.resolver.examples.util.Booter;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.deployment.DeploymentException;
@@ -35,6 +36,23 @@ import org.eclipse.aether.util.artifact.SubArtifact;
 @SuppressWarnings( "unused" )
 public class ResolverDemo
 {
+    public static void main( String[] args ) throws Exception
+    {
+        System.out.println( "------------------------------------------------------------" );
+        System.out.println( ResolverDemo.class.getSimpleName() );
+
+        Resolver resolver = new Resolver(
+                Booter.selectFactory( args ),
+                "https://repo.maven.apache.org/maven2/",
+                "target/aether-repo"
+        );
+        ResolverResult result = resolver.resolve( "junit", "junit", "4.13.2" );
+
+        System.out.println( "Result:" );
+        System.out.println( "classpath=" + result.getResolvedClassPath() );
+        System.out.println( "files=" + result.getResolvedFiles() );
+        System.out.println( "root=" + result.getRoot() );
+    }
 
     public void resolve( final String factory )
         throws DependencyResolutionException


### PR DESCRIPTION
The module `maven-resolver-demo-snippets` already had UT named `AllResolverDemos` that simply ran all the demos 3 times (sisu, guice and SL).

There was one last snippet that was not "tied in", so this PR ties that in as well.