### PR TITLE
[EXPERIMENT] Drop DELETE_ON_CLOSE flag

### DIFF
--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
@@ -70,7 +70,7 @@ public class FileLockNamedLockFactory
                 return FileChannel.open(
                         path,
                         StandardOpenOption.READ, StandardOpenOption.WRITE,
-                        StandardOpenOption.CREATE, StandardOpenOption.DELETE_ON_CLOSE
+                        StandardOpenOption.CREATE
                 );
             }
             catch ( IOException e )


### PR DESCRIPTION
This removes concurrency on delete (that seems to affect Windows users) on the other hand will leave lock structure present after Maven done.

Change for https://github.com/apache/maven-mvnd/issues/728