### PR TITLE
[MRESOLVER-283] Shared executor service

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -200,7 +200,7 @@ final class BasicRepositoryConnector
         List<ChecksumAlgorithmFactory> checksumAlgorithmFactories = layout.getChecksumAlgorithmFactories();
         Collection<? extends MetadataDownload> mds = safe( metadataDownloads );
         Collection<? extends ArtifactDownload> ads = safe( artifactDownloads );
-        ArrayList<Runnable> runnable = new ArrayList<>( mds.size() + ads.size() );
+        ArrayList<Runnable> runnables = new ArrayList<>( mds.size() + ads.size() );
 
         for ( MetadataDownload transfer : mds )
         {
@@ -219,7 +219,7 @@ final class BasicRepositoryConnector
 
             Runnable task = new GetTaskRunner( location, transfer.getFile(), checksumPolicy,
                     checksumAlgorithmFactories, checksumLocations, null, listener );
-            runnable.add( errorForwarder.wrap( task ) );
+            runnables.add( errorForwarder.wrap( task ) );
         }
 
         for ( ArtifactDownload transfer : ads )
@@ -260,10 +260,10 @@ final class BasicRepositoryConnector
                 task = new GetTaskRunner( location, transfer.getFile(), checksumPolicy,
                         checksumAlgorithmFactories, checksumLocations, providedChecksums, listener );
             }
-            runnable.add( errorForwarder.wrap( task ) );
+            runnables.add( errorForwarder.wrap( task ) );
         }
 
-        resolverExecutor.submitBatch( runnable );
+        resolverExecutor.submitBatch( runnables );
         errorForwarder.await();
     }
 

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -147,13 +147,13 @@ final class BasicRepositoryConnector
         this.fileProcessor = fileProcessor;
         this.providedChecksumsSources = providedChecksumsSources;
         this.closed = new AtomicBoolean( false );
-        this.resolverExecutor = resolverExecutorService.getResolverExecutor( session,
-                resolverExecutorService.getKey( RepositoryConnector.class, repository.getId() ),
+        this.resolverExecutor = resolverExecutorService.getResolverExecutor(
+                resolverExecutorService.getName( BasicRepositoryConnector.class, repository.getId() ),
                 ConfigUtils.getInteger( session, CONFIG_PROP_THREADS_DEFAULT, CONFIG_PROP_THREADS,
                         "maven.artifact.threads" ) );
 
-        smartChecksums = ConfigUtils.getBoolean( session, true, CONFIG_PROP_SMART_CHECKSUMS );
-        persistedChecksums =
+        this.smartChecksums = ConfigUtils.getBoolean( session, true, CONFIG_PROP_SMART_CHECKSUMS );
+        this.persistedChecksums =
                 ConfigUtils.getBoolean( session, ConfigurationProperties.DEFAULT_PERSISTED_CHECKSUMS,
                         ConfigurationProperties.PERSISTED_CHECKSUMS );
     }
@@ -177,6 +177,7 @@ final class BasicRepositoryConnector
     {
         if ( closed.compareAndSet( false, true ) )
         {
+            resolverExecutor.close();
             transporter.close();
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/DefaultServiceLocator.java
@@ -57,9 +57,11 @@ import org.eclipse.aether.internal.impl.DefaultUpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.internal.impl.concurrency.DefaultResolverExecutorService;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
+import org.eclipse.aether.spi.concurrency.ResolverExecutorService;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
@@ -231,6 +233,7 @@ public final class DefaultServiceLocator
         addService( LocalPathComposer.class, DefaultLocalPathComposer.class );
         addService( RemoteRepositoryFilterManager.class, DefaultRemoteRepositoryFilterManager.class );
         addService( RepositorySystemLifecycle.class, DefaultRepositorySystemLifecycle.class );
+        addService( ResolverExecutorService.class, DefaultResolverExecutorService.class );
     }
 
     private <T> Entry<T> getEntry( Class<T> type, boolean create )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -60,6 +60,7 @@ import org.eclipse.aether.internal.impl.checksum.TrustedToProvidedChecksumsSourc
 import org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate;
 import org.eclipse.aether.internal.impl.collect.bf.BfDependencyCollector;
 import org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector;
+import org.eclipse.aether.internal.impl.concurrency.DefaultResolverExecutorService;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
@@ -102,6 +103,7 @@ import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.slf4j.Slf4jLoggerFactory;
 import org.eclipse.aether.named.providers.NoopNamedLockFactory;
 import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.concurrency.ResolverExecutorService;
 import org.eclipse.aether.spi.connector.checksum.ProvidedChecksumsSource;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
@@ -228,6 +230,9 @@ public class AetherModule
 
         bind( RepositorySystemLifecycle.class )
                 .to( DefaultRepositorySystemLifecycle.class ).in( Singleton.class );
+
+        bind( ResolverExecutorService.class )
+                .to( DefaultResolverExecutorService.class ).in( Singleton.class );
 
         bind( NamedLockFactorySelector.class ).toInstance( new ParameterizedNamedLockFactorySelector() );
         bind( SyncContextFactory.class ).to( DefaultSyncContextFactory.class ).in( Singleton.class );

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -393,17 +393,17 @@ public class DefaultMetadataResolver
         if ( !tasks.isEmpty() )
         {
             RunnableErrorForwarder errorForwarder = new RunnableErrorForwarder();
-            ArrayList<Runnable> runnable = new ArrayList<>( tasks.size() );
+            ArrayList<Runnable> runnables = new ArrayList<>( tasks.size() );
             for ( ResolveTask task : tasks )
             {
-                runnable.add( errorForwarder.wrap( task ) );
+                runnables.add( errorForwarder.wrap( task ) );
             }
 
             try ( ResolverExecutor resolverExecutor = resolverExecutorService.getResolverExecutor(
                     resolverExecutorService.getName( DefaultMetadataResolver.class ),
                     ConfigUtils.getInteger( session, CONFIG_PROP_THREADS_DEFAULT, CONFIG_PROP_THREADS ) ) )
             {
-                resolverExecutor.submitBatch( runnable );
+                resolverExecutor.submitBatch( runnables );
                 errorForwarder.await();
             }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutor.java
@@ -1,0 +1,93 @@
+package org.eclipse.aether.internal.impl.concurrency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.eclipse.aether.spi.concurrency.ResolverExecutor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default implementation of {@link ResolverExecutor}.
+ * <p>
+ * It relies on ctor passed {@link ExecutorService} that may be {@code null}, in which case "direct invocation" (on
+ * caller thread) happens, otherwise the non-null executor service is used.
+ */
+final class DefaultResolverExecutor implements ResolverExecutor
+{
+    private final ExecutorService executorService;
+
+    DefaultResolverExecutor( final ExecutorService executorService )
+    {
+        this.executorService = executorService;
+    }
+
+    @Override
+    public void submitBatch( Collection<Runnable> tasks )
+    {
+        requireNonNull( tasks );
+        if ( tasks.size() == 1 )
+        {
+            directlyExecute( Executors.callable( tasks.iterator().next() ) );
+        }
+        else
+        {
+            for ( Runnable task : tasks )
+            {
+                submit( Executors.callable( task ) );
+            }
+        }
+    }
+
+    @Override
+    public void submit( Runnable task )
+    {
+        requireNonNull( task );
+        submit( Executors.callable( task ) );
+    }
+
+    @Override
+    public <T> Future<T> submit( Callable<T> task )
+    {
+        requireNonNull( task );
+        return executorService == null ? directlyExecute( task ) : executorService.submit( task );
+    }
+
+    private static <T> Future<T> directlyExecute( Callable<T> task )
+    {
+        CompletableFuture<T> future;
+        try
+        {
+            future = CompletableFuture.completedFuture( task.call() );
+        }
+        catch ( Exception e )
+        {
+            future = new CompletableFuture<>();
+            future.completeExceptionally( e );
+        }
+        return future;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutor.java
@@ -63,17 +63,16 @@ final class DefaultResolverExecutor implements ResolverExecutor
     }
 
     @Override
-    public void submit( Runnable task )
-    {
-        requireNonNull( task );
-        submit( Executors.callable( task ) );
-    }
-
-    @Override
     public <T> Future<T> submit( Callable<T> task )
     {
         requireNonNull( task );
         return executorService == null ? directlyExecute( task ) : executorService.submit( task );
+    }
+
+    @Override
+    public void close()
+    {
+        executorService.shutdown();
     }
 
     private static <T> Future<T> directlyExecute( Callable<T> task )

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutorService.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/concurrency/DefaultResolverExecutorService.java
@@ -1,0 +1,136 @@
+package org.eclipse.aether.internal.impl.concurrency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.concurrency.ResolverExecutor;
+import org.eclipse.aether.spi.concurrency.ResolverExecutorService;
+import org.eclipse.aether.util.concurrency.WorkerThreadFactory;
+
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Default implementation of {@link ResolverExecutor}.
+ * <p>
+ * This implementation uses {@link RepositorySystemSession#getData()} to store created {@link ExecutorService}
+ * instances. It creates instances that may be eventually garbage collected, so no explicit shutdown happens on
+ * them. When {@code maxThreads} parameter is 1 (accepted values are greater than zero), this implementation assumes
+ * caller wants "direct execution" (on caller thread) and creates {@link ResolverExecutor} instances accordingly.
+ */
+@Singleton
+@Named
+public final class DefaultResolverExecutorService implements ResolverExecutorService
+{
+    @Override
+    public Key getKey( Class<?> service, String... discriminators )
+    {
+        requireNonNull( service );
+        return new KeyImpl( DefaultResolverExecutorService.class.getName()
+                + "-" + service.getSimpleName()
+                + String.join( "-", discriminators ) );
+    }
+
+    @Override
+    public ResolverExecutor getResolverExecutor( RepositorySystemSession session, Key key, int maxThreads )
+    {
+        requireNonNull( session );
+        requireNonNull( key );
+        if ( maxThreads < 1 )
+        {
+            throw new IllegalArgumentException( "maxThreads must be greater than zero" );
+        }
+
+        final ExecutorService executorService;
+        if ( maxThreads == 1 ) // direct
+        {
+            executorService = null;
+        }
+        else // shared && pooled
+        {
+            executorService = (ExecutorService) session.getData()
+                    .computeIfAbsent( key, () -> createExecutorService( key, maxThreads ) );
+        }
+        return new DefaultResolverExecutor( executorService );
+    }
+
+    /**
+     * Creates am {@link ExecutorService} that allows its core threads to die off in case of inactivity, and allows
+     * for proper garbage collection. This is important detail, as these instances are kept within session data, and
+     * currently there is no way to shut down them.
+     */
+    private ExecutorService createExecutorService( Key key, int maxThreads )
+    {
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
+                maxThreads,
+                maxThreads,
+                3L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(),
+                new WorkerThreadFactory( key.asString() + "-" )
+        );
+        threadPoolExecutor.allowCoreThreadTimeOut( true );
+        return threadPoolExecutor;
+    }
+
+    private static class KeyImpl implements Key
+    {
+        private final String keyString;
+
+        private KeyImpl( String keyString )
+        {
+            this.keyString = keyString;
+        }
+
+        @Override
+        public String asString()
+        {
+            return keyString;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            KeyImpl key = (KeyImpl) o;
+            return keyString.equals( key.keyString );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return hash( keyString );
+        }
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.concurrency.DefaultResolverExecutorService;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.Filters;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
@@ -91,6 +92,7 @@ public class DefaultMetadataResolverTest
         resolver.setSyncContextFactory( new StubSyncContextFactory() );
         resolver.setOfflineController( new DefaultOfflineController() );
         resolver.setRemoteRepositoryFilterManager( remoteRepositoryFilterManager );
+        resolver.setResolverExecutorService( new DefaultResolverExecutorService() );
         repository =
             new RemoteRepository.Builder( "test-DMRT", "default",
                                           TestFileUtils.createTempDir().toURI().toURL().toString() ).build();

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
@@ -33,6 +33,7 @@ import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.internal.impl.StubRemoteRepositoryManager;
 import org.eclipse.aether.internal.impl.StubVersionRangeResolver;
 import org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegateTestSupport;
+import org.eclipse.aether.internal.impl.concurrency.DefaultResolverExecutorService;
 import org.eclipse.aether.internal.test.util.DependencyGraphParser;
 import org.eclipse.aether.util.graph.manager.TransitiveDependencyManager;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
@@ -67,6 +68,7 @@ public class BfDependencyCollectorTest extends DependencyCollectorDelegateTestSu
         collector.setArtifactDescriptorReader( newReader( "" ) );
         collector.setVersionRangeResolver( new StubVersionRangeResolver() );
         collector.setRemoteRepositoryManager( new StubRemoteRepositoryManager() );
+        ((BfDependencyCollector) collector).setResolverExecutorService( new DefaultResolverExecutorService() );
     }
 
     private Dependency newDep( String coords, String scope, Collection<Exclusion> exclusions )

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutor.java
@@ -1,0 +1,60 @@
+package org.eclipse.aether.spi.concurrency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+/**
+ * Component providing shared {@link java.util.concurrent.Executor}-like service across resolver.
+ *
+ * @since 1.9.0
+ */
+public interface ResolverExecutor
+{
+    /**
+     * Submits a batch of {@link Runnable} tasks for execution. If collection has size greater than 1, this method
+     * will submit all tasks just like {@link #submit(Runnable)} does. Otherwise, "direct", on caller thread execution
+     * happens. Several resolver components may deal "sequentially" with tasks and rely on this behaviour for
+     * performance purposes.
+     * <p>
+     * Error handling: this method will never throw. If you are interested in possible outcome of submitted
+     * {@link Runnable} use some helper like the {@code RunnableErrorForwarder} in resolver utilities module.
+     */
+    void submitBatch( Collection<Runnable> batch );
+
+    /**
+     * Submits a {@link Runnable} task for execution. This call may block if thread pool is full. In certain
+     * circumstances this method may choose to directly invoke task (on caller thread) instead to submit it.
+     * <p>
+     * Error handling: this method will never throw. If you are interested in possible outcome of submitted
+     * {@link Runnable} use some helper like the {@code RunnableErrorForwarder} in resolver utilities module.
+     */
+    void submit( Runnable task );
+
+    /**
+     * Submits a {@link Callable} task for execution. This call may block if thread pool is full. In certain
+     * circumstances this method may choose to directly invoke task (on caller thread) instead to submit it.
+     * <p>
+     * Error handling: this method will never throw.
+     */
+    <T> Future<T> submit( Callable<T> task );
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutor.java
@@ -19,20 +19,22 @@ package org.eclipse.aether.spi.concurrency;
  * under the License.
  */
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 /**
- * Component providing shared {@link java.util.concurrent.Executor}-like service across resolver.
+ * Component providing {@link java.util.concurrent.Executor}-like service across resolver. Instances are to be treated
+ * like resources, best in try-with-resource constructs.
  *
  * @since 1.9.0
  */
-public interface ResolverExecutor
+public interface ResolverExecutor extends Closeable
 {
     /**
      * Submits a batch of {@link Runnable} tasks for execution. If collection has size greater than 1, this method
-     * will submit all tasks just like {@link #submit(Runnable)} does. Otherwise, "direct", on caller thread execution
+     * will submit all tasks just like {@link #submit(Callable)} does. Otherwise, "direct", on caller thread execution
      * happens. Several resolver components may deal "sequentially" with tasks and rely on this behaviour for
      * performance purposes.
      * <p>
@@ -42,19 +44,16 @@ public interface ResolverExecutor
     void submitBatch( Collection<Runnable> batch );
 
     /**
-     * Submits a {@link Runnable} task for execution. This call may block if thread pool is full. In certain
-     * circumstances this method may choose to directly invoke task (on caller thread) instead to submit it.
-     * <p>
-     * Error handling: this method will never throw. If you are interested in possible outcome of submitted
-     * {@link Runnable} use some helper like the {@code RunnableErrorForwarder} in resolver utilities module.
-     */
-    void submit( Runnable task );
-
-    /**
      * Submits a {@link Callable} task for execution. This call may block if thread pool is full. In certain
      * circumstances this method may choose to directly invoke task (on caller thread) instead to submit it.
      * <p>
      * Error handling: this method will never throw.
      */
     <T> Future<T> submit( Callable<T> task );
+
+    /**
+     * Caller notifies that is not using this instance anymore, it is up to implementation to shut it down, or do
+     * whatever is needed.
+     */
+    void close();
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutorService.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutorService.java
@@ -1,0 +1,61 @@
+package org.eclipse.aether.spi.concurrency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Component providing {@link ResolverExecutor} instances on demand.
+ *
+ * @since 1.9.0
+ */
+public interface ResolverExecutorService
+{
+    /**
+     * A hierarchical key to identify use cases for executors. Same {@link Key} designates same
+     * {@link ResolverExecutor}.
+     */
+    interface Key
+    {
+        String asString();
+    }
+
+    /**
+     * Creates service key with given parameters.
+     *
+     * @param service        The service that is to use executor, never {@code null}.
+     * @param discriminators Potential (sub) discriminators, if needed.
+     */
+    Key getKey( Class<?> service, String... discriminators );
+
+    /**
+     * Returns a resolver executor for requester service. The {@code service} parameter is used as "key", meaning
+     * multiple services using same "key" will share the executor as well. The very first invocation of this method
+     * may create thread pool as well (using {@code maxThreads} parameter), and subsequent calls with different
+     * parameter will reuse it, hence the parameter may be neglected.
+     * <p>
+     * None of parameters may be {@code null}.
+     *
+     * @param session    The session.
+     * @param key        A key for service, multiple components using same key will share same executor.
+     * @param maxThreads The count of configured threads (must be bigger than zero).
+     */
+    ResolverExecutor getResolverExecutor( RepositorySystemSession session, Key key, int maxThreads );
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutorService.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/concurrency/ResolverExecutorService.java
@@ -19,8 +19,6 @@ package org.eclipse.aether.spi.concurrency;
  * under the License.
  */
 
-import org.eclipse.aether.RepositorySystemSession;
-
 /**
  * Component providing {@link ResolverExecutor} instances on demand.
  *
@@ -29,33 +27,26 @@ import org.eclipse.aether.RepositorySystemSession;
 public interface ResolverExecutorService
 {
     /**
-     * A hierarchical key to identify use cases for executors. Same {@link Key} designates same
-     * {@link ResolverExecutor}.
+     * A hierarchical name to name threads for executors.
      */
-    interface Key
+    interface Name
     {
         String asString();
     }
 
     /**
-     * Creates service key with given parameters.
+     * Creates {@link Name} with given parameters.
      *
      * @param service        The service that is to use executor, never {@code null}.
      * @param discriminators Potential (sub) discriminators, if needed.
      */
-    Key getKey( Class<?> service, String... discriminators );
+    Name getName( Class<?> service, String... discriminators );
 
     /**
-     * Returns a resolver executor for requester service. The {@code service} parameter is used as "key", meaning
-     * multiple services using same "key" will share the executor as well. The very first invocation of this method
-     * may create thread pool as well (using {@code maxThreads} parameter), and subsequent calls with different
-     * parameter will reuse it, hence the parameter may be neglected.
-     * <p>
-     * None of parameters may be {@code null}.
+     * Returns a new resolver executor for requester service.
      *
-     * @param session    The session.
-     * @param key        A key for service, multiple components using same key will share same executor.
+     * @param name        A key for service, multiple components using same key will share same executor.
      * @param maxThreads The count of configured threads (must be bigger than zero).
      */
-    ResolverExecutor getResolverExecutor( RepositorySystemSession session, Key key, int maxThreads );
+    ResolverExecutor getResolverExecutor( Name name, int maxThreads );
 }


### PR DESCRIPTION
More and more component in resolver does parallel processing (BF collector, MD resolver, basic connector), and they all create, maintain their own executor instance.

Instead of this, create one shared service component and just reuse it accross resolver.

---

https://issues.apache.org/jira/browse/MRESOLVER-283