### PR TITLE
[MRESOLVER-285] File locking tweaks for Windows OS

### DIFF
--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
@@ -55,7 +55,7 @@ public class FileLockNamedLockFactory
     /**
      * Tweak: on Windows, the presence of {@link StandardOpenOption#DELETE_ON_CLOSE} causes concurrency issues. This
      * flag allows to have it removed from effective flags, at the cost that lockfile directory becomes crowded
-     * with 0 byte sized lock files that are never cleaned up.
+     * with 0 byte sized lock files that are never cleaned up. Default value is {@code true}.
      *
      * @see <a href="https://bugs.openjdk.org/browse/JDK-8252883">JDK-8252883</a>
      */
@@ -73,7 +73,8 @@ public class FileLockNamedLockFactory
             System.getProperty( "aether.named.file-lock.attempts", "5" ) );
 
     /**
-     * Tweak: When {@link #ATTEMPTS} used, the amount of milliseconds to sleep between subsequent retries.
+     * Tweak: When {@link #ATTEMPTS} used, the amount of milliseconds to sleep between subsequent retries. Default
+     * value is 50 milliseconds.
      */
     private static final long SLEEP_MILLIS = Long.parseLong(
             System.getProperty( "aether.named.file-lock.sleepMillis", "50" ) );

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
@@ -132,7 +132,7 @@ public class FileLockNamedLockFactory
             catch ( InterruptedException e )
             {
                 Thread.currentThread().interrupt();
-                throw new RuntimeException( "Interrupted during open file channel for '"
+                throw new RuntimeException( "Interrupted while opening file channel for '"
                         + name + "'", e );
             }
             catch ( IOException e )

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
@@ -112,8 +112,6 @@ public final class FileLockNamedLock
                 {
                     if ( obtainedLock.isShared() )
                     {
-                        // TODO No counterpart in other lock impls, drop or make consistent?
-                        logger.trace( "{} lock (shared={})", name(), true );
                         steps.push( Boolean.TRUE );
                         return true;
                     }
@@ -123,8 +121,6 @@ public final class FileLockNamedLock
                         boolean weOwnExclusive = steps.contains( Boolean.FALSE );
                         if ( weOwnExclusive )
                         {
-                            // TODO No counterpart in other lock impls, drop or make consistent?
-                            logger.trace( "{} lock (shared={})", name(), true );
                             steps.push( Boolean.TRUE );
                             return true;
                         }
@@ -136,8 +132,6 @@ public final class FileLockNamedLock
                     }
                 }
 
-                // TODO No counterpart in other lock impls, drop or make consistent?
-                logger.trace( "{} no obtained lock: obtain shared file lock", name() );
                 FileLock fileLock = obtainFileLock( true );
                 if ( fileLock != null )
                 {
@@ -170,10 +164,6 @@ public final class FileLockNamedLock
                         boolean weOwnShared = steps.contains( Boolean.TRUE );
                         if ( weOwnShared )
                         {
-                            // TODO No counterpart in other lock impls, drop or make consistent?
-                            logger.trace(
-                                    "{} steps not empty, has not exclusive lock: lock-upgrade not supported", name()
-                            );
                             return false; // Lock upgrade not supported
                         }
                         else
@@ -188,8 +178,6 @@ public final class FileLockNamedLock
                         boolean weOwnExclusive = steps.contains( Boolean.FALSE );
                         if ( weOwnExclusive )
                         {
-                            // TODO No counterpart in other lock impls, drop or make consistent?
-                            logger.trace( "{} lock (shared={})", name(), false );
                             steps.push( Boolean.FALSE );
                             return true;
                         }
@@ -201,8 +189,6 @@ public final class FileLockNamedLock
                     }
                 }
 
-                // TODO No counterpart in other lock impls, drop or make consistent?
-                logger.trace( "{} no obtained lock: obtain exclusive file lock", name() );
                 FileLock fileLock = obtainFileLock( false );
                 if ( fileLock != null )
                 {
@@ -230,9 +216,7 @@ public final class FileLockNamedLock
             {
                 throw new IllegalStateException( "Wrong API usage: unlock without lock" );
             }
-            Boolean shared = steps.pop();
-            // TODO No counterpart in other lock impls, drop or make consistent?
-            logger.trace( "{} unlock (shared = {})", name(), shared );
+            steps.pop();
             if ( steps.isEmpty() && !anyOtherThreadHasSteps() )
             {
                 try

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/Retry.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/Retry.java
@@ -90,4 +90,50 @@ public final class Retry
         }
         return result == null ? defaultResult : result;
     }
+
+    /**
+     * Retries attempting max given times the passed in operation, sleeping given
+     * {@code sleepMills} between retries. In case operation returns {@code null}, it is assumed
+     * "is not done yet" state, so retry will happen (if attempt count allows). If all attempts
+     * used, and still {@code null} ("is not done yet") is returned from operation, the
+     * {@code defaultResult} is returned.
+     * <p>
+     * Just to clear things up: 5 attempts is really 4 retries (once do it and retry 4 times). 0 attempts means
+     * "do not even try it", and this method returns without doing anything.
+     */
+    public static  <R> R retry( final int attempts,
+                                final long sleepMillis,
+                                final Callable<R> operation,
+                                final Predicate<Exception> retryPredicate,
+                                final R defaultResult ) throws InterruptedException
+    {
+        int attempt = 1;
+        R result = null;
+        while ( attempt <= attempts && result == null )
+        {
+            try
+            {
+                result = operation.call();
+                if ( result == null )
+                {
+                    LOGGER.trace( "Retry attempt {}: no result", attempt );
+                    Thread.sleep( sleepMillis );
+                }
+            }
+            catch ( InterruptedException e )
+            {
+                throw e;
+            }
+            catch ( Exception e )
+            {
+                LOGGER.trace( "Retry attempt {}: operation failure", attempt, e );
+                if ( retryPredicate != null && !retryPredicate.test( e ) )
+                {
+                    throw new IllegalStateException( e );
+                }
+            }
+            attempt++;
+        }
+        return result == null ? defaultResult : result;
+    }
 }

--- a/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/RetryTest.java
+++ b/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/RetryTest.java
@@ -60,11 +60,38 @@ public class RetryTest
     }
 
     @Test
-    public void happyOnSomeAttempt() throws InterruptedException
+    public void happyAfterSomeTime() throws InterruptedException
     {
         LongAdder retries = new LongAdder();
         String result = retry( 1L, TimeUnit.SECONDS, RETRY_SLEEP_MILLIS, () -> { retries.increment(); return retries.sum() == 2 ? "got it" : null; }, null, "notHappy" );
         assertThat( result, equalTo( "got it" ) );
         assertThat( retries.sum(), equalTo( 2L ) );
+    }
+
+    @Test
+    public void happyFirstAttempt() throws InterruptedException
+    {
+        LongAdder retries = new LongAdder();
+        String result = retry( 5, RETRY_SLEEP_MILLIS, () -> { retries.increment(); return "happy"; }, null, "notHappy" );
+        assertThat( result, equalTo( "happy" ) );
+        assertThat( retries.sum(), equalTo( 1L ) );
+    }
+
+    @Test
+    public void notHappyAnyAttempt() throws InterruptedException
+    {
+        LongAdder retries = new LongAdder();
+        String result = retry( 5, RETRY_SLEEP_MILLIS, () -> { retries.increment(); return null; }, null, "notHappy" );
+        assertThat( result, equalTo( "notHappy" ) );
+        assertThat( retries.sum(), equalTo( 5L ) );
+    }
+
+    @Test
+    public void happyAfterSomeAttempt() throws InterruptedException
+    {
+        LongAdder retries = new LongAdder();
+        String result = retry( 5, RETRY_SLEEP_MILLIS, () -> { retries.increment(); return retries.sum() == 3 ? "got it" : null; }, null, "notHappy" );
+        assertThat( result, equalTo( "got it" ) );
+        assertThat( retries.sum(), equalTo( 3L ) );
     }
 }


### PR DESCRIPTION
That has concurrency issue at FS level when it comes to deletion of files.

This PR adds several "tweak" flags that allow users on Windows to circumvent the issue.

By default (w/o any user "tweaking") the file locking should now work fine on Windows, not leaving behind any "garbage" (0 byte lock files).

Related Java bug: https://bugs.openjdk.org/browse/JDK-8252883

---

https://issues.apache.org/jira/browse/MRESOLVER-285