### PR TITLE
[MRESOLVER-292] Fix configuration name in documentation to match with actual name

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector.java
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 public class DefaultDependencyCollector
         implements DependencyCollector, Service
 {
-    private static final String CONFIG_PROP_COLLECTOR_IMPL = "aether.collector.impl";
+    private static final String CONFIG_PROP_COLLECTOR_IMPL = "aether.dependencyCollector.impl";
 
     private static final String DEFAULT_COLLECTOR_IMPL = DfDependencyCollector.NAME;
 


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/MNG-5896, the param in code does not match with the one in doc:
https://maven.apache.org/resolver/configuration.html

DOC: aether.dependencyCollector.impl
Code: aether.collector.impl

---

https://issues.apache.org/jira/browse/MRESOLVER-292