### PR TITLE
[MRESOLVER-290] Expand use of atomic file ops

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -455,9 +456,7 @@ final class BasicRepositoryConnector
         protected void runTask()
                 throws Exception
         {
-            fileProcessor.mkdirs( file.getParentFile() );
-
-            try ( FileUtils.TempFile tempFile = FileUtils.newTempFile( file.toPath() ) )
+            try ( FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile( file.toPath() ) )
             {
                 final File tmp = tempFile.getPath().toFile();
                 listener.setChecksumCalculator( checksumValidator.newChecksumCalculator( tmp ) );
@@ -489,7 +488,7 @@ final class BasicRepositoryConnector
                         }
                     }
                 }
-                fileProcessor.move( tmp, file );
+                tempFile.move();
                 if ( persistedChecksums )
                 {
                     checksumValidator.commit();
@@ -602,6 +601,7 @@ final class BasicRepositoryConnector
             catch ( IOException e )
             {
                 LOGGER.warn( "Failed to upload checksums for {}", file, e );
+                throw new UncheckedIOException( e );
             }
         }
 

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
@@ -21,11 +21,11 @@ package org.eclipse.aether.connector.basic;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -126,11 +126,11 @@ final class ChecksumCalculator
             return;
         }
 
-        try ( InputStream in = new BufferedInputStream( new FileInputStream( targetFile ) ) )
+        try ( InputStream in = new BufferedInputStream( Files.newInputStream( targetFile.toPath() ) ) )
         {
             long total = 0;
             final byte[] buffer = new byte[ 1024 * 32 ];
-            for ( ; total < dataOffset; )
+            while ( total < dataOffset )
             {
                 int read = in.read( buffer );
                 if ( read < 0 )

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.connector.basic;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
@@ -259,6 +260,7 @@ final class ChecksumValidator
             catch ( IOException e )
             {
                 LOGGER.debug( "Failed to write checksum file {}", checksumFile, e );
+                throw new UncheckedIOException( e );
             }
         }
         checksumExpectedValues.clear();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
@@ -19,19 +19,20 @@ package org.eclipse.aether.internal.impl;
  * under the License.
  */
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.util.Map;
-import java.util.Properties;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.aether.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,66 +42,55 @@ import org.slf4j.LoggerFactory;
 @Singleton
 @Named
 public final class DefaultTrackingFileManager
-    implements TrackingFileManager
+        implements TrackingFileManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger( DefaultTrackingFileManager.class );
 
     @Override
     public Properties read( File file )
     {
-        FileInputStream stream = null;
-        try
+        Path filePath = file.toPath();
+        if ( Files.isRegularFile( filePath ) )
         {
-            if ( !file.exists() )
+            try ( InputStream stream = Files.newInputStream( filePath ) )
             {
-                return null;
+                Properties props = new Properties();
+                props.load( stream );
+                return props;
             }
-
-            stream = new FileInputStream( file );
-
-            Properties props = new Properties();
-            props.load( stream );
-
-            return props;
+            catch ( IOException e )
+            {
+                LOGGER.warn( "Failed to read tracking file '{}'", file, e );
+                throw new UncheckedIOException( e );
+            }
         }
-        catch ( IOException e )
-        {
-            LOGGER.warn( "Failed to read tracking file {}", file, e );
-        }
-        finally
-        {
-            close( stream, file );
-        }
-
         return null;
     }
 
     @Override
     public Properties update( File file, Map<String, String> updates )
     {
+        Path filePath = file.toPath();
         Properties props = new Properties();
 
-        File directory = file.getParentFile();
-        if ( !directory.mkdirs() && !directory.exists() )
-        {
-            LOGGER.warn( "Failed to create parent directories for tracking file {}", file );
-            return props;
-        }
-
-        RandomAccessFile raf = null;
         try
         {
-            raf = new RandomAccessFile( file, "rw" );
+            Files.createDirectories( filePath.getParent() );
+        }
+        catch ( IOException e )
+        {
+            LOGGER.warn( "Failed to create tracking file parent '{}'", file, e );
+            throw new UncheckedIOException( e );
+        }
 
-            if ( file.canRead() )
+        try
+        {
+            if ( Files.isReadable( filePath ) )
             {
-                byte[] buffer = new byte[(int) raf.length()];
-
-                raf.readFully( buffer );
-
-                ByteArrayInputStream stream = new ByteArrayInputStream( buffer );
-
-                props.load( stream );
+                try ( InputStream stream = Files.newInputStream( filePath ) )
+                {
+                    props.load( stream );
+                }
             }
 
             for ( Map.Entry<String, String> update : updates.entrySet() )
@@ -115,41 +105,22 @@ public final class DefaultTrackingFileManager
                 }
             }
 
-            ByteArrayOutputStream stream = new ByteArrayOutputStream( 1024 * 2 );
-
-            LOGGER.debug( "Writing tracking file {}", file );
-            props.store( stream, "NOTE: This is a Maven Resolver internal implementation file"
-                + ", its format can be changed without prior notice." );
-
-            raf.seek( 0 );
-            raf.write( stream.toByteArray() );
-            raf.setLength( raf.getFilePointer() );
+            FileUtils.writeFile( filePath, p ->
+            {
+                try ( OutputStream stream = Files.newOutputStream( p ) )
+                {
+                    LOGGER.debug( "Writing tracking file '{}'", file );
+                    props.store( stream, "NOTE: This is a Maven Resolver internal implementation file"
+                            + ", its format can be changed without prior notice." );
+                }
+            } );
         }
         catch ( IOException e )
         {
-            LOGGER.warn( "Failed to write tracking file {}", file, e );
-        }
-        finally
-        {
-            close( raf, file );
+            LOGGER.warn( "Failed to write tracking file '{}'", file, e );
+            throw new UncheckedIOException( e );
         }
 
         return props;
     }
-
-    private void close( Closeable closeable, File file )
-    {
-        if ( closeable != null )
-        {
-            try
-            {
-                closeable.close();
-            }
-            catch ( IOException e )
-            {
-                LOGGER.warn( "Error closing tracking file {}", file, e );
-            }
-        }
-    }
-
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
@@ -28,7 +28,14 @@ import java.util.Properties;
  */
 public interface TrackingFileManager
 {
+    /**
+     * Reads up the specified properties file into {@link Properties}, if exists, otherwise {@code null} is returned.
+     */
     Properties read( File file );
 
+    /**
+     * Applies updates to specified properties file and returns resulting {@link Properties} with contents same
+     * as in updated file, never {@code null}.
+     */
     Properties update( File file, Map<String, String> updates );
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
@@ -24,6 +24,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -111,9 +112,10 @@ public final class SparseDirectoryTrustedChecksumsSource
                 }
                 catch ( IOException e )
                 {
-                    // unexpected, log, skip
+                    // unexpected, log
                     LOGGER.warn( "Could not read artifact '{}' trusted checksum on path '{}'", artifact, checksumPath,
                             e );
+                    throw new UncheckedIOException( e );
                 }
             }
         }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmHelper.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmHelper.java
@@ -22,10 +22,10 @@ package org.eclipse.aether.spi.connector.checksum;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +72,7 @@ public final class ChecksumAlgorithmHelper
     public static Map<String, String> calculate( File file, List<ChecksumAlgorithmFactory> factories )
             throws IOException
     {
-        try ( InputStream inputStream = new BufferedInputStream( new FileInputStream( file ) ) )
+        try ( InputStream inputStream = new BufferedInputStream( Files.newInputStream( file.toPath() ) ) )
         {
             return calculate( inputStream, factories );
         }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/GetTask.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/GetTask.java
@@ -21,11 +21,12 @@ package org.eclipse.aether.spi.connector.transport;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,7 +88,16 @@ public final class GetTask
     {
         if ( dataFile != null )
         {
-            return new FileOutputStream( dataFile, this.resume && resume );
+            if ( this.resume && resume )
+            {
+                return Files.newOutputStream( dataFile.toPath(),
+                        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND );
+            }
+            else
+            {
+                return Files.newOutputStream( dataFile.toPath(),
+                        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING );
+            }
         }
         if ( dataBytes == null )
         {

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/PutTask.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/PutTask.java
@@ -21,11 +21,11 @@ package org.eclipse.aether.spi.connector.transport;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * A task to upload a resource to the remote repository.
@@ -62,7 +62,7 @@ public final class PutTask
     {
         if ( dataFile != null )
         {
-            return new FileInputStream( dataFile );
+            return Files.newInputStream( dataFile.toPath() );
         }
         return new ByteArrayInputStream( dataBytes );
     }

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -20,8 +20,7 @@ package org.eclipse.aether.transport.file;
  */
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.AbstractTransporter;
@@ -80,7 +79,7 @@ final class FileTransporter
         throws Exception
     {
         File file = getFile( task, true );
-        utilGet( task, new FileInputStream( file ), true, file.length(), false );
+        utilGet( task, Files.newInputStream( file.toPath() ), true, file.length(), false );
     }
 
     @Override
@@ -91,7 +90,7 @@ final class FileTransporter
         file.getParentFile().mkdirs();
         try
         {
-            utilPut( task, new FileOutputStream( file ), true );
+            utilPut( task, Files.newOutputStream( file.toPath() ), true );
         }
         catch ( Exception e )
         {

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -611,7 +611,7 @@ final class HttpTransporter
             }
             else
             {
-                try ( FileUtils.TempFile tempFile = FileUtils.newTempFile( dataFile.toPath() ) )
+                try ( FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile( dataFile.toPath() ) )
                 {
                     task.setDataFile( tempFile.getPath().toFile(), resume );
                     if ( resume && Files.isRegularFile( dataFile.toPath() ) )
@@ -625,7 +625,7 @@ final class HttpTransporter
                     {
                         utilGet( task, is, true, length, resume );
                     }
-                    Files.move( tempFile.getPath(), dataFile.toPath(), StandardCopyOption.ATOMIC_MOVE );
+                    tempFile.move();
                 }
                 finally
                 {

--- a/maven-resolver-transport-wagon/src/main/java/org/eclipse/aether/transport/wagon/WagonTransporter.java
+++ b/maven-resolver-transport-wagon/src/main/java/org/eclipse/aether/transport/wagon/WagonTransporter.java
@@ -533,7 +533,7 @@ final class WagonTransporter
 
                     if ( file != null )
                     {
-                        Files.move( dst.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE );
+                        ( (FileUtils.CollocatedTempFile) tempFile ).move();
                     }
                     else
                     {


### PR DESCRIPTION
Drop old and legacy code doing smart(er) things, use common shared primitives instead.

Also, make IO handling stricter, do not be "forgiving" by swallowing IOEx-es as they will inevitably lead to failures, it does not make resolver more robust, but actually makes it harder to figure out the problems, and could lead to incomplete downloads or uploads. Simply put, if reading or writing a file on disk fails with IOEx, do not assume "is fine" in any case. This probably shows some existing issue like permissions or whatever.

---

https://issues.apache.org/jira/browse/MRESOLVER-290