### PR TITLE
[MRESOLVER-293] Update dependencies

### DIFF
--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -71,7 +71,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -40,21 +40,6 @@
     <Automatic-Module-Name>org.apache.maven.resolver.demo.snippets</Automatic-Module-Name>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.3.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4jVersion}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -105,19 +90,18 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -127,7 +111,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <scope>compile</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -77,20 +77,19 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>5.1.1</version>
+      <version>5.1.4</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -39,7 +39,7 @@
     <Automatic-Module-Name>org.apache.maven.resolver.named.redisson</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
     <!-- Used in site also -->
-    <redissonVersion>3.17.5</redissonVersion>
+    <redissonVersion>3.17.7</redissonVersion>
   </properties>
 
   <dependencies>

--- a/maven-resolver-named-locks-redisson/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks-redisson/src/site/markdown/index.md.vm
@@ -46,10 +46,10 @@ To use this implementation within your project, depending on how you integrate, 
 
 ${esc.hash}${esc.hash} Installation/Testing
 
-#set( $jacksonVersion = "2.13.3" )
+#set( $jacksonVersion = "2.13.4" )
 #set( $jbossMarshallingVersion = "2.0.11.Final" )
-#set( $nettyVersion = "4.1.79.Final" )
-#set( $snakeyamlVersion = "1.30" )
+#set( $nettyVersion = "4.1.82.Final" )
+#set( $snakeyamlVersion = "1.31" )
 
 - Create the directory `${maven.home}/lib/ext/redisson/`.
 - Modify `${maven.home}/bin/m2.conf` by adding `load ${maven.home}/lib/ext/redisson/*.jar`

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-    <jettyVersion>9.4.46.v20220331</jettyVersion>
+    <jettyVersion>9.4.49.v20220914</jettyVersion>
   </properties>
 
   <dependencies>
@@ -67,6 +67,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <version>4.4.15</version>
@@ -86,7 +91,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -41,6 +41,17 @@
     <jettyVersion>9.4.49.v20220914</jettyVersion>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- HttpClient pulls in 1.11 that has CVE. Is not used directly in code -->
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -65,11 +76,6 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>3.5.1</version>
+      <version>3.5.2</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -73,7 +73,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.4.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -84,7 +83,6 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <maven.site.path>resolver-archives/resolver-LATEST</maven.site.path>
     <checkstyle.violation.ignore>None</checkstyle.violation.ignore>
     <sisuVersion>0.3.5</sisuVersion>
-    <guiceVersion>4.2.3</guiceVersion>
+    <guiceVersion>5.1.0</guiceVersion>
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
@@ -161,12 +161,6 @@
       </dependency>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
         <version>2.2</version>
@@ -179,10 +173,22 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.7.7</version>
+        <version>4.8.1</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.5.0</version>
       </dependency>
 
       <dependency>
@@ -212,12 +218,7 @@
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guiceVersion}</version>
-        <classifier>no_aop</classifier>
         <exclusions>
-          <exclusion>
-            <groupId>aopalliance</groupId>
-            <artifactId>aopalliance</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
@@ -234,6 +235,7 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guavaVersion}</version>
+        <scope>runtime</scope>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Update dependencies, mostly to align with Maven.

Updates:
* Guice to 5.1.0 (align with Maven 3.9,0)
* Hazelcast 5.1.1 -> 5.1.4 (bugfixes)
* Redisson 3.17.5 -> 3.17.7 (bugfixes)
* plexus-utils multiple -> 3.5.0 (runtime dependency)
* http transport used HttpClient commons-codec 1.11 -> 1.15 (to get rid of CVEs)
* wagon transport Wagon API 3.5.1 -> 3.5.2
* test dependency Jetty 9.4.46 -> 9.4.49 (to get rid of CVEs, but not affecting us, as this is test dependency)
* test dependency Mockito core 3.7.7 -> 4.8.1

Make sure plexus-utils, guava are NEVER in compile scope, as resolver should not use classes from these
(exception is Wagon Transport).

---

https://issues.apache.org/jira/browse/MRESOLVER-293