### PR TITLE
[MRESOLVER-269] FileProcessor.write( File, InputStream ) is defunct

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultFileProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultFileProcessor.java
@@ -32,6 +32,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.util.ChecksumUtils;
@@ -94,7 +95,7 @@ public class DefaultFileProcessor
     public void write( File target, InputStream source )
             throws IOException
     {
-        FileUtils.writeFile( target.toPath(), p -> Files.copy( source, p ) );
+        FileUtils.writeFile( target.toPath(), p -> Files.copy( source, p, StandardCopyOption.REPLACE_EXISTING ) );
     }
 
     public void copy( File source, File target )

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultFileProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultFileProcessorTest.java
@@ -21,9 +21,11 @@ package org.eclipse.aether.internal.impl;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.internal.impl.DefaultFileProcessor;
@@ -121,6 +123,37 @@ public class DefaultFileProcessorTest
         assertTrue( "file was not created", target.isFile() );
         assertEquals( "file was not fully copied", 4L, target.length() );
         assertEquals( "listener not called", 4, progressed.intValue() );
+        target.delete();
+    }
+
+    @Test
+    public void testWrite()
+            throws IOException
+    {
+        String data = "testCopy\nasdf";
+        File target = new File( targetDir, "testWrite.txt" );
+
+        fileProcessor.write( target, data );
+
+        assertEquals( data, TestFileUtils.readString( target ) );
+
+        target.delete();
+    }
+
+    /**
+     * Used ONLY when FileProcessor present, never otherwise.
+     */
+    @Test
+    public void testWriteStream()
+            throws IOException
+    {
+        String data = "testCopy\nasdf";
+        File target = new File( targetDir, "testWriteStream.txt" );
+
+        fileProcessor.write( target, new ByteArrayInputStream( data.getBytes( StandardCharsets.UTF_8 ) ) );
+
+        assertEquals( data, TestFileUtils.readString( target ) );
+
         target.delete();
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -119,7 +119,9 @@ public final class FileUtils
     }
 
     /**
-     * A file writer, that accepts a {@link Path} to write some content to.
+     * A file writer, that accepts a {@link Path} to write some content to. Note: the file denoted by path may exist,
+     * hence implementation have to ensure it is able to achieve its goal ("replace existing" option or equivalent
+     * should be used).
      */
     @FunctionalInterface
     public interface FileWriter


### PR DESCRIPTION
The `FileProcessor.write( File, InputStream )` method  is completely broken, it always fails. This method is used ONLY when FileTransformer is present. Result of plain oversight and not being covered by tests.

---
https://issues.apache.org/jira/browse/MRESOLVER-296