### PR TITLE
Alternate transform API

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
@@ -36,6 +36,7 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 import org.eclipse.aether.transform.FileTransformerManager;
 
 /**
@@ -216,5 +217,11 @@ public abstract class AbstractForwardingRepositorySystemSession
     public FileTransformerManager getFileTransformerManager()
     {
         return getSession().getFileTransformerManager();
+    }
+
+    @Override
+    public ArtifactTransformerManager getArtifactTransformerManager()
+    {
+        return getSession().getArtifactTransformerManager();
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -45,8 +45,10 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 import org.eclipse.aether.transform.FileTransformer;
 import org.eclipse.aether.transform.FileTransformerManager;
+import org.eclipse.aether.transform.Identity;
 
 import static java.util.Objects.requireNonNull;
 
@@ -79,6 +81,8 @@ public final class DefaultRepositorySystemSession
     private LocalRepositoryManager localRepositoryManager;
 
     private FileTransformerManager fileTransformerManager;
+
+    private ArtifactTransformerManager artifactTransformerManager;
 
     private WorkspaceReader workspaceReader;
 
@@ -138,6 +142,7 @@ public final class DefaultRepositorySystemSession
         authenticationSelector = NullAuthenticationSelector.INSTANCE;
         artifactTypeRegistry = NullArtifactTypeRegistry.INSTANCE;
         fileTransformerManager = NullFileTransformerManager.INSTANCE;
+        artifactTransformerManager = Identity.MANAGER;
         data = new DefaultSessionData();
     }
 
@@ -176,6 +181,7 @@ public final class DefaultRepositorySystemSession
         setVersionFilter( session.getVersionFilter() );
         setDependencyGraphTransformer( session.getDependencyGraphTransformer() );
         setFileTransformerManager( session.getFileTransformerManager() );
+        setArtifactTransformerManager( session.getArtifactTransformerManager() );
         setData( session.getData() );
         setCache( session.getCache() );
     }
@@ -349,6 +355,24 @@ public final class DefaultRepositorySystemSession
         if ( this.fileTransformerManager == null )
         {
             this.fileTransformerManager = NullFileTransformerManager.INSTANCE;
+        }
+        return this;
+    }
+
+    @Override
+    public ArtifactTransformerManager getArtifactTransformerManager()
+    {
+        return artifactTransformerManager;
+    }
+
+    public DefaultRepositorySystemSession setArtifactTransformerManager(
+            ArtifactTransformerManager artifactTransformerManager )
+    {
+        verifyStateForMutation();
+        this.artifactTransformerManager = artifactTransformerManager;
+        if ( this.artifactTransformerManager == null )
+        {
+            this.artifactTransformerManager = Identity.MANAGER;
         }
         return this;
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -37,6 +37,7 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transform.ArtifactTransformerManager;
 import org.eclipse.aether.transform.FileTransformerManager;
 
 /**
@@ -270,4 +271,12 @@ public interface RepositorySystemSession
      */
     @Deprecated
     FileTransformerManager getFileTransformerManager();
+
+    /**
+     * Get the artifact transformer manager.
+     *
+     * @since 1.9.3
+     * @return the manager, never {@code null}.
+     */
+    ArtifactTransformerManager getArtifactTransformerManager();
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformer.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformer.java
@@ -1,0 +1,54 @@
+package org.eclipse.aether.transform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * Can transform am artifact while installing/deploying.
+ * 
+ * @author Robert Scholte et al.
+ * @since 1.9.3
+ */
+public interface ArtifactTransformer
+{
+    /**
+     * Transform the target artifact for install.
+     *
+     * @param session the session.
+     * @param artifact the original artifact.
+     * @return the transformed artifact, never {@code null}.
+     */
+    TransformedArtifact transformInstallArtifact( RepositorySystemSession session, Artifact artifact )
+            throws TransformException, IOException;
+
+    /**
+     * Transform the target artifact for deploy.
+     *
+     * @param session the session.
+     * @param artifact the original artifact.
+     * @return the transformed artifact, never {@code null}.
+     */
+    TransformedArtifact transformDeployArtifact( RepositorySystemSession session, Artifact artifact )
+            throws TransformException, IOException;
+}

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformerManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/ArtifactTransformerManager.java
@@ -1,0 +1,48 @@
+package org.eclipse.aether.transform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Collection;
+
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * Manager for the {@link ArtifactTransformer}s.
+ * 
+ * @author Robert Scholte et al.
+ * @since 1.9.3
+ */
+public interface ArtifactTransformerManager
+{
+    /**
+     * All transformers for this specific artifact. Be aware that if you want to create additional files, but also want
+     * the original to be deployed, you must add an explicit transformer for that file too (one that doesn't
+     * transform the artifact and data, such as {@link Identity#TRANSFORMER}).
+     * <p>
+     * In other words, if transform is about to <strong>prevent</strong> artifact to be installed/deployed, return
+     * empty collection here, if is about to <strong>replace</strong> the artifact, it should return collection
+     * with one element, or if is about to <strong>add some extra</strong> artifacts, it should return collection
+     * with more than one element.
+     *
+     * @param artifact the artifact.
+     * @return a collection of {@link ArtifactTransformer}s to apply on the artifact, never {@code null}.
+     */
+    Collection<ArtifactTransformer> getTransformersForArtifact( Artifact artifact );
+}

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/Identity.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/Identity.java
@@ -1,0 +1,173 @@
+package org.eclipse.aether.transform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Identity {@link TransformedArtifact}, {@link ArtifactTransformer} and {@link ArtifactTransformerManager}.
+ *
+ * @since 1.9.3
+ */
+public final class Identity
+{
+    /**
+     * Identity {@link TransformedArtifact}.
+     */
+    public static final class IdentityTransformedArtifact implements TransformedArtifact
+    {
+        private final Artifact artifact;
+
+        public IdentityTransformedArtifact( Artifact artifact )
+        {
+            this.artifact = requireNonNull( artifact );
+        }
+
+        @Override
+        public Artifact getTransformedArtifact()
+        {
+            return artifact;
+        }
+
+        @Override
+        public void close()
+        {
+            // nop
+        }
+
+        @Override
+        public String getGroupId()
+        {
+            return artifact.getGroupId();
+        }
+
+        @Override
+        public String getArtifactId()
+        {
+            return artifact.getArtifactId();
+        }
+
+        @Override
+        public String getVersion()
+        {
+            return artifact.getVersion();
+        }
+
+        @Override
+        public Artifact setVersion( String version )
+        {
+            return artifact.setVersion( version );
+        }
+
+        @Override
+        public String getBaseVersion()
+        {
+            return artifact.getBaseVersion();
+        }
+
+        @Override
+        public boolean isSnapshot()
+        {
+            return artifact.isSnapshot();
+        }
+
+        @Override
+        public String getClassifier()
+        {
+            return artifact.getClassifier();
+        }
+
+        @Override
+        public String getExtension()
+        {
+            return artifact.getExtension();
+        }
+
+        @Override
+        public File getFile()
+        {
+            return artifact.getFile();
+        }
+
+        @Override
+        public Artifact setFile( File file )
+        {
+            return artifact.setFile( file );
+        }
+
+        @Override
+        public String getProperty( String key, String defaultValue )
+        {
+            return artifact.getProperty( key, defaultValue );
+        }
+
+        @Override
+        public Map<String, String> getProperties()
+        {
+            return artifact.getProperties();
+        }
+
+        @Override
+        public Artifact setProperties( Map<String, String> properties )
+        {
+            return artifact.setProperties( properties );
+        }
+    }
+
+    public static final ArtifactTransformer TRANSFORMER = new IdentityArtifactTransformer();
+
+    private static class IdentityArtifactTransformer implements ArtifactTransformer
+    {
+        @Override
+        public TransformedArtifact transformInstallArtifact( RepositorySystemSession session, Artifact artifact )
+        {
+            requireNonNull( session );
+            return new IdentityTransformedArtifact( artifact );
+        }
+
+        @Override
+        public TransformedArtifact transformDeployArtifact( RepositorySystemSession session, Artifact artifact )
+        {
+            requireNonNull( session );
+            return new IdentityTransformedArtifact( artifact );
+        }
+    }
+
+    public static final ArtifactTransformerManager MANAGER = new IdentityArtifactTransformerManager();
+
+    private static class IdentityArtifactTransformerManager implements ArtifactTransformerManager
+    {
+        private final Collection<ArtifactTransformer> identity = Collections.singletonList( TRANSFORMER );
+
+        @Override
+        public Collection<ArtifactTransformer> getTransformersForArtifact( Artifact artifact )
+        {
+            return identity;
+        }
+    }
+}

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformException.java
@@ -22,10 +22,9 @@ package org.eclipse.aether.transform;
 /**
  * Thrown when transformation failed.
  *
- * @deprecated Without any direct replacement for now. This API is OOM-prone, and also lacks a lot of context about
- * transforming.
+ *  @author Robert Scholte et al.
+ *  @since 1.3.0
  */
-@Deprecated
 public class TransformException
     extends Exception
 {

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformedArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transform/TransformedArtifact.java
@@ -1,0 +1,45 @@
+package org.eclipse.aether.transform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * The transformed artifact.
+ * 
+ * @since 1.9.3
+ */
+public interface TransformedArtifact extends Artifact, Closeable
+{
+    /**
+     * The transformed artifact.
+     *
+     * @return the transformed artifact, never {@code null}.
+     */
+    Artifact getTransformedArtifact();
+
+    /**
+     * Closes the handle instance, allowing it to perform any necessary cleanup.
+     */
+    void close() throws IOException;
+}


### PR DESCRIPTION
Is WIP, just some ideas...

Alternate transformation API, that is:
- logically simpler, as it ALWAYS get applied (unlike branching like FileTransformer)
- by default just uses "identity" transformation
- can inhibit (prevent), replace, or even "decorate" (add more) artifacts for single transformation
- caller is completely oblivious about what is happening
- distinguishes install and deploy ops

Heretic thought:
- one of the FIRST thought for artifact transformation (aside of consumer POM transformation) is SIGNING :) as resolver could symetrically support signing (with pluggable signers) just like it supports checksumming