### PR TITLE
[MRESOLVER-303] Make checksum detection reusable

### DIFF
--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithm;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
@@ -101,12 +100,6 @@ public class TestChecksumAlgorithmSelector
 
     @Override
     public boolean isChecksumExtension( String extension )
-    {
-        throw new RuntimeException( "not implemented" );
-    }
-
-    @Override
-    public boolean isChecksumArtifact( Artifact artifact )
     {
         throw new RuntimeException( "not implemented" );
     }

--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
@@ -98,6 +98,12 @@ public class TestChecksumAlgorithmSelector
                 .collect( toList() );
     }
 
+    @Override
+    public boolean isChecksum( String extension )
+    {
+        throw new RuntimeException( "not used in test" );
+    }
+
     private static class MessageDigestChecksumAlgorithmFactory
             extends ChecksumAlgorithmFactorySupport
     {

--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/TestChecksumAlgorithmSelector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithm;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
@@ -99,9 +100,15 @@ public class TestChecksumAlgorithmSelector
     }
 
     @Override
-    public boolean isChecksum( String extension )
+    public boolean isChecksumExtension( String extension )
     {
-        throw new RuntimeException( "not used in test" );
+        throw new RuntimeException( "not implemented" );
+    }
+
+    @Override
+    public boolean isChecksumArtifact( Artifact artifact )
+    {
+        throw new RuntimeException( "not implemented" );
     }
 
     private static class MessageDigestChecksumAlgorithmFactory

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -244,7 +244,7 @@ public final class Maven2RepositoryLayoutFactory
         @Override
         public List<ChecksumLocation> getChecksumLocations( Artifact artifact, boolean upload, URI location )
         {
-            if ( !hasChecksums( artifact ) || isChecksum( artifact.getExtension() ) )
+            if ( !hasChecksums( artifact ) || isChecksum( artifact ) )
             {
                 return Collections.emptyList();
             }
@@ -267,9 +267,9 @@ public final class Maven2RepositoryLayoutFactory
             return checksumLocations;
         }
 
-        private boolean isChecksum( String extension )
+        private boolean isChecksum( Artifact artifact )
         {
-            return checksumAlgorithmFactorySelector.isChecksum( extension );
+            return checksumAlgorithmFactorySelector.isChecksumArtifact( artifact );
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -244,7 +244,7 @@ public final class Maven2RepositoryLayoutFactory
         @Override
         public List<ChecksumLocation> getChecksumLocations( Artifact artifact, boolean upload, URI location )
         {
-            if ( !hasChecksums( artifact ) || isChecksum( artifact ) )
+            if ( !hasChecksums( artifact ) || isChecksum( artifact.getExtension() ) )
             {
                 return Collections.emptyList();
             }
@@ -267,9 +267,9 @@ public final class Maven2RepositoryLayoutFactory
             return checksumLocations;
         }
 
-        private boolean isChecksum( Artifact artifact )
+        private boolean isChecksum( String extension )
         {
-            return checksumAlgorithmFactorySelector.isChecksumArtifact( artifact );
+            return checksumAlgorithmFactorySelector.isChecksumExtension( extension );
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -134,7 +134,7 @@ public final class Maven2RepositoryLayoutFactory
         }
 
         return new Maven2RepositoryLayout(
-                new ArrayList<>( checksumAlgorithmFactorySelector.getChecksumAlgorithmFactories() ),
+                checksumAlgorithmFactorySelector,
                 checksumsAlgorithms,
                 omitChecksumsForExtensions
         );
@@ -143,17 +143,17 @@ public final class Maven2RepositoryLayoutFactory
     private static class Maven2RepositoryLayout
             implements RepositoryLayout
     {
-        private final List<ChecksumAlgorithmFactory> allChecksumAlgorithms;
+        private final ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector;
 
         private final List<ChecksumAlgorithmFactory> configuredChecksumAlgorithms;
 
         private final Set<String> extensionsWithoutChecksums;
 
-        private Maven2RepositoryLayout( List<ChecksumAlgorithmFactory> allChecksumAlgorithms,
+        private Maven2RepositoryLayout( ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector,
                                         List<ChecksumAlgorithmFactory> configuredChecksumAlgorithms,
                                         Set<String> extensionsWithoutChecksums )
         {
-            this.allChecksumAlgorithms = Collections.unmodifiableList( allChecksumAlgorithms );
+            this.checksumAlgorithmFactorySelector = requireNonNull( checksumAlgorithmFactorySelector );
             this.configuredChecksumAlgorithms = Collections.unmodifiableList( configuredChecksumAlgorithms );
             this.extensionsWithoutChecksums = requireNonNull( extensionsWithoutChecksums );
         }
@@ -269,7 +269,7 @@ public final class Maven2RepositoryLayoutFactory
 
         private boolean isChecksum( String extension )
         {
-            return allChecksumAlgorithms.stream().anyMatch( a -> extension.endsWith( "." + a.getFileExtension() ) );
+            return checksumAlgorithmFactorySelector.isChecksum( extension );
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
@@ -98,4 +98,18 @@ public class DefaultChecksumAlgorithmFactorySelector
     {
         return new ArrayList<>( factories.values() );
     }
+
+    @Override
+    public boolean isChecksum( String extension )
+    {
+        requireNonNull( extension );
+        if ( extension.contains( "." ) )
+        {
+            return factories.values().stream().anyMatch( a -> extension.endsWith( "." + a.getFileExtension() ) );
+        }
+        else
+        {
+            return factories.values().stream().anyMatch( a -> extension.equals( a.getFileExtension() ) );
+        }
+    }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
@@ -23,13 +23,12 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 
@@ -95,9 +94,9 @@ public class DefaultChecksumAlgorithmFactorySelector
     }
 
     @Override
-    public List<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
+    public Collection<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories()
     {
-        return new ArrayList<>( factories.values() );
+        return Collections.unmodifiableCollection( factories.values() );
     }
 
     @Override
@@ -112,11 +111,5 @@ public class DefaultChecksumAlgorithmFactorySelector
         {
             return factories.values().stream().anyMatch( a -> extension.equals( a.getFileExtension() ) );
         }
-    }
-
-    @Override
-    public boolean isChecksumArtifact( Artifact artifact )
-    {
-        return isChecksumExtension( artifact.getExtension() );
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
 
@@ -100,7 +101,7 @@ public class DefaultChecksumAlgorithmFactorySelector
     }
 
     @Override
-    public boolean isChecksum( String extension )
+    public boolean isChecksumExtension( String extension )
     {
         requireNonNull( extension );
         if ( extension.contains( "." ) )
@@ -111,5 +112,11 @@ public class DefaultChecksumAlgorithmFactorySelector
         {
             return factories.values().stream().anyMatch( a -> extension.equals( a.getFileExtension() ) );
         }
+    }
+
+    @Override
+    public boolean isChecksumArtifact( Artifact artifact )
+    {
+        return isChecksumExtension( artifact.getExtension() );
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -114,12 +114,6 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
             {
                 throw new RuntimeException( "not implemented" );
             }
-
-            @Override
-            public boolean isChecksumArtifact( Artifact artifact )
-            {
-                throw new RuntimeException( "not implemented" );
-            }
         };
         subject = new TrustedChecksumsArtifactResolverPostProcessor( selector,
                 Collections.singletonMap( TRUSTED_SOURCE_NAME, this ) );

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -108,6 +108,12 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
             {
                 return Collections.singletonList( checksumAlgorithmFactory );
             }
+
+            @Override
+            public boolean isChecksum( String extension )
+            {
+                throw new RuntimeException( "not implemented" );
+            }
         };
         subject = new TrustedChecksumsArtifactResolverPostProcessor( selector,
                 Collections.singletonMap( TRUSTED_SOURCE_NAME, this ) );

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -110,7 +110,13 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
             }
 
             @Override
-            public boolean isChecksum( String extension )
+            public boolean isChecksumExtension( String extension )
+            {
+                throw new RuntimeException( "not implemented" );
+            }
+
+            @Override
+            public boolean isChecksumArtifact( Artifact artifact )
             {
                 throw new RuntimeException( "not implemented" );
             }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactory.java
@@ -37,6 +37,7 @@ public interface ChecksumAlgorithmFactory
     /**
      * Returns the file extension to be used for given checksum file (without leading dot), never {@code null}. The
      * extension should be file and URL path friendly, and may differ from value returned by {@link #getName()}.
+     * The checksum extension SHOULD NOT contain dot (".") character.
      * Example: "sha1".
      */
     String getFileExtension();

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
@@ -22,8 +22,6 @@ package org.eclipse.aether.spi.connector.checksum;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.aether.artifact.Artifact;
-
 /**
  * Component performing selection of {@link ChecksumAlgorithmFactory} based on known factory names.
  * Note: this component is NOT meant to be implemented or extended by client, is exposed ONLY to make clients
@@ -43,7 +41,7 @@ public interface ChecksumAlgorithmFactorySelector
     ChecksumAlgorithmFactory select( String algorithmName );
 
     /**
-     * Returns a list of factories for given algorithm names in order as collection is ordered, or throws if any of the
+     * Returns a list of factories in same order as algorithm names are ordered, or throws if any of the
      * algorithm name is not supported. The returned list has equal count of elements as passed in collection of names,
      * and if names contains duplicated elements, the returned list of algorithms will have duplicates as well.
      *
@@ -54,8 +52,8 @@ public interface ChecksumAlgorithmFactorySelector
     List<ChecksumAlgorithmFactory> selectList( Collection<String> algorithmNames );
 
     /**
-     * Returns a collection of supported algorithms. This set represents ALL the algorithms supported by Resolver,
-     * and is NOT in any relation to given repository layout used checksums, returned by method {@link
+     * Returns immutable collection of all supported algorithms. This set represents ALL the algorithms supported by
+     * Resolver, and is NOT in any relation to given repository layout used checksums, returned by method {@link
      * org.eclipse.aether.spi.connector.layout.RepositoryLayout#getChecksumAlgorithmFactories()} (in fact, is super set
      * of it).
      */
@@ -69,11 +67,4 @@ public interface ChecksumAlgorithmFactorySelector
      * @since 1.9.3
      */
     boolean isChecksumExtension( String extension );
-
-    /**
-     * Returns {@code true} if passed in artifact matches any known checksum artifact.
-     *
-     * @since 1.9.3
-     */
-    boolean isChecksumArtifact( Artifact artifact );
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
@@ -22,6 +22,8 @@ package org.eclipse.aether.spi.connector.checksum;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.aether.artifact.Artifact;
+
 /**
  * Component performing selection of {@link ChecksumAlgorithmFactory} based on known factory names.
  * Note: this component is NOT meant to be implemented or extended by client, is exposed ONLY to make clients
@@ -66,5 +68,12 @@ public interface ChecksumAlgorithmFactorySelector
      *
      * @since 1.9.3
      */
-    boolean isChecksum( String extension );
+    boolean isChecksumExtension( String extension );
+
+    /**
+     * Returns {@code true} if passed in artifact matches any known checksum artifact.
+     *
+     * @since 1.9.3
+     */
+    boolean isChecksumArtifact( Artifact artifact );
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector.java
@@ -58,4 +58,13 @@ public interface ChecksumAlgorithmFactorySelector
      * of it).
      */
     Collection<ChecksumAlgorithmFactory> getChecksumAlgorithmFactories();
+
+    /**
+     * Returns {@code true} if passed in extension matches any known checksum extension. The extension string may
+     * start or contain dot ("."), but does not have to. In former case "ends with" is checked (i.e. "jar.sha1" -> true;
+     * ".sha1" -> true) while in latter equality (i.e. "sha1" -> true).
+     *
+     * @since 1.9.3
+     */
+    boolean isChecksum( String extension );
 }


### PR DESCRIPTION
Expose it on selector., and also start "bending" things toward Artifact instead of plain string matching.

---

https://issues.apache.org/jira/browse/MRESOLVER-303