### PR TITLE
[MRESOLVER-305] Handle blocked state at connector level

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -575,20 +575,6 @@ public class DefaultArtifactResolver
 
         try
         {
-            RemoteRepository repo = group.repository;
-            if ( repo.isBlocked() )
-            {
-                if ( repo.getMirroredRepositories().isEmpty() )
-                {
-                    throw new NoRepositoryConnectorException( repo, "Blocked repository: " + repo );
-                }
-                else
-                {
-                    throw new NoRepositoryConnectorException( repo, "Blocked mirror for repositories: "
-                            + repo.getMirroredRepositories() );
-                }
-            }
-
             try ( RepositoryConnector connector =
                           repositoryConnectorProvider.newRepositoryConnector( session, group.repository ) )
             {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
@@ -109,6 +109,20 @@ public class DefaultRepositoryConnectorProvider
         throws NoRepositoryConnectorException
     {
         requireNonNull( repository, "remote repository cannot be null" );
+
+        if ( repository.isBlocked() )
+        {
+            if ( repository.getMirroredRepositories().isEmpty() )
+            {
+                throw new NoRepositoryConnectorException( repository, "Blocked repository: " + repository );
+            }
+            else
+            {
+                throw new NoRepositoryConnectorException( repository, "Blocked mirror for repositories: "
+                        + repository.getMirroredRepositories() );
+            }
+        }
+
         RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter( session );
 
         PrioritizedComponents<RepositoryConnectorFactory> factories = new PrioritizedComponents<>( session );


### PR DESCRIPTION
As blocked is really about block remote access. Locally cached things should not be affected, but current solution did not cover all execution paths.

---

https://issues.apache.org/jira/browse/MRESOLVER-305