### PR TITLE
MRESOLVER-307 - Support listing of workspace artifacts

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/AbstractWorkspaceReader.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/AbstractWorkspaceReader.java
@@ -1,0 +1,78 @@
+package org.eclipse.aether.repository;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.aether.artifact.Artifact;
+
+/**
+ * A skeleton implementation for custom workspace readers. The default implementation represents an empty repository
+ * that never finds anything.
+ */
+public abstract class AbstractWorkspaceReader
+    implements WorkspaceReader
+{
+
+    protected final WorkspaceRepository repository;
+
+    protected AbstractWorkspaceReader()
+    {
+        this( "empty" );
+    }
+
+    protected AbstractWorkspaceReader( String type )
+    {
+        this( type, null );
+    }
+
+
+    protected AbstractWorkspaceReader( String type, Object key )
+    {
+        repository = new WorkspaceRepository( type, key );
+    }
+
+    @Override
+    public WorkspaceRepository getRepository()
+    {
+        return repository;
+    }
+
+    @Override
+    public File findArtifact( Artifact artifact )
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> findVersions( Artifact artifact )
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Stream<Artifact> listArtifacts()
+    {
+        return Stream.empty();
+    }
+}

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/WorkspaceReader.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/WorkspaceReader.java
@@ -21,13 +21,18 @@ package org.eclipse.aether.repository;
 
 import java.io.File;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.aether.artifact.Artifact;
 
 /**
  * Manages a repository backed by the IDE workspace, a build session or a similar ad-hoc collection of artifacts.
+ * <em>Note:</em> Implementors are strongly advised to inherit from {@link AbstractWorkspaceReader} instead of directly
+ * implementing this interface.
  * 
  * @see org.eclipse.aether.RepositorySystemSession#getWorkspaceReader()
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
  */
 public interface WorkspaceReader
 {
@@ -54,5 +59,12 @@ public interface WorkspaceReader
      * @return The available versions of the artifact, must not be {@code null}.
      */
     List<String> findVersions( Artifact artifact );
+
+    /**
+     * List all available artifacts this workspace repository manages.
+     * 
+     * @return a stream of artifacts in no particular order
+     */
+    Stream<Artifact> listArtifacts();
 
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -18,8 +18,13 @@ package org.eclipse.aether.internal.impl;
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,8 +37,8 @@ import java.util.Map;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent.EventType;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -46,6 +51,7 @@ import org.eclipse.aether.internal.test.util.TestFileUtils;
 import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.AbstractWorkspaceReader;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
@@ -57,7 +63,6 @@ import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.repository.WorkspaceReader;
-import org.eclipse.aether.repository.WorkspaceRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -453,20 +458,17 @@ public class DefaultArtifactResolverTest
     public void testResolveFromWorkspace()
         throws IOException, ArtifactResolutionException
     {
-        WorkspaceReader workspace = new WorkspaceReader()
+		WorkspaceReader workspace = new AbstractWorkspaceReader("default")
         {
 
-            public WorkspaceRepository getRepository()
-            {
-                return new WorkspaceRepository( "default" );
-            }
-
-            public List<String> findVersions( Artifact artifact )
+            @Override
+			public List<String> findVersions( Artifact artifact )
             {
                 return Arrays.asList( artifact.getVersion() );
             }
 
-            public File findArtifact( Artifact artifact )
+            @Override
+			public File findArtifact( Artifact artifact )
             {
                 try
                 {
@@ -502,23 +504,15 @@ public class DefaultArtifactResolverTest
     public void testResolveFromWorkspaceFallbackToRepository()
         throws ArtifactResolutionException
     {
-        WorkspaceReader workspace = new WorkspaceReader()
+		WorkspaceReader workspace = new AbstractWorkspaceReader("default")
         {
 
-            public WorkspaceRepository getRepository()
-            {
-                return new WorkspaceRepository( "default" );
-            }
-
-            public List<String> findVersions( Artifact artifact )
+            @Override
+			public List<String> findVersions( Artifact artifact )
             {
                 return Arrays.asList( artifact.getVersion() );
             }
 
-            public File findArtifact( Artifact artifact )
-            {
-                return null;
-            }
         };
         session.setWorkspaceReader( workspace );
 
@@ -704,7 +698,8 @@ public class DefaultArtifactResolverTest
         resolver.setVersionResolver( new VersionResolver()
         {
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
+            @Override
+			public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
                 throws VersionResolutionException
             {
                 throw new VersionResolutionException( new VersionResult( request ) );
@@ -741,7 +736,8 @@ public class DefaultArtifactResolverTest
         resolver.setVersionResolver( new VersionResolver()
         {
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
+            @Override
+			public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
                 throws VersionResolutionException
             {
                 throw new VersionResolutionException( new VersionResult( request ) );
@@ -782,32 +778,38 @@ public class DefaultArtifactResolverTest
         session.setLocalRepositoryManager( new LocalRepositoryManager()
         {
 
-            public LocalRepository getRepository()
+            @Override
+			public LocalRepository getRepository()
             {
                 return null;
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
+            @Override
+			public String getPathForLocalMetadata( Metadata metadata )
             {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
+            @Override
+			public String getPathForLocalArtifact( Artifact artifact )
             {
                 return null;
             }
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
+            @Override
+			public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
             {
 
                 LocalArtifactResult result = new LocalArtifactResult( request );
@@ -823,11 +825,13 @@ public class DefaultArtifactResolverTest
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalArtifactRegistration request )
             {
             }
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
+            @Override
+			public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
             {
                 LocalMetadataResult result = new LocalMetadataResult( request );
                 try
@@ -841,7 +845,8 @@ public class DefaultArtifactResolverTest
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalMetadataRegistration request )
             {
             }
         } );
@@ -868,32 +873,38 @@ public class DefaultArtifactResolverTest
         session.setLocalRepositoryManager( new LocalRepositoryManager()
         {
 
-            public LocalRepository getRepository()
+            @Override
+			public LocalRepository getRepository()
             {
                 return new LocalRepository( new File("") );
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
+            @Override
+			public String getPathForLocalMetadata( Metadata metadata )
             {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
+            @Override
+			public String getPathForLocalArtifact( Artifact artifact )
             {
                 return null;
             }
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
+            @Override
+			public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
             {
 
                 LocalArtifactResult result = new LocalArtifactResult( request );
@@ -909,16 +920,19 @@ public class DefaultArtifactResolverTest
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalArtifactRegistration request )
             {
             }
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
+            @Override
+			public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
             {
                 return new LocalMetadataResult( request );
             }
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalMetadataRegistration request )
             {
             }
         } );
@@ -928,7 +942,8 @@ public class DefaultArtifactResolverTest
         resolver.setVersionResolver( new VersionResolver()
         {
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
+            @Override
+			public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
             {
                 return new VersionResult( request ).setRepository( new LocalRepository( "id" ) ).setVersion( request.getArtifact().getVersion() );
             }
@@ -951,32 +966,38 @@ public class DefaultArtifactResolverTest
         session.setLocalRepositoryManager( new LocalRepositoryManager()
         {
 
-            public LocalRepository getRepository()
+            @Override
+			public LocalRepository getRepository()
             {
                 return new LocalRepository( new File( "" ) );
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
+            @Override
+			public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
             {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
+            @Override
+			public String getPathForLocalMetadata( Metadata metadata )
             {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
+            @Override
+			public String getPathForLocalArtifact( Artifact artifact )
             {
                 return null;
             }
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
+            @Override
+			public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
             {
 
                 LocalArtifactResult result = new LocalArtifactResult( request );
@@ -992,16 +1013,19 @@ public class DefaultArtifactResolverTest
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalArtifactRegistration request )
             {
             }
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
+            @Override
+			public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
             {
                 return new LocalMetadataResult( request );
             }
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
+            @Override
+			public void add( RepositorySystemSession session, LocalMetadataRegistration request )
             {
             }
 
@@ -1011,7 +1035,8 @@ public class DefaultArtifactResolverTest
         resolver.setVersionResolver( new VersionResolver()
         {
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
+            @Override
+			public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
             {
                 return new VersionResult( request ).setVersion( request.getArtifact().getVersion() );
             }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/ChainedWorkspaceReader.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/ChainedWorkspaceReader.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -90,6 +91,7 @@ public final class ChainedWorkspaceReader
         return new ChainedWorkspaceReader( reader1, reader2 );
     }
 
+    @Override
     public File findArtifact( Artifact artifact )
     {
         requireNonNull( artifact, "artifact cannot be null" );
@@ -107,6 +109,7 @@ public final class ChainedWorkspaceReader
         return file;
     }
 
+    @Override
     public List<String> findVersions( Artifact artifact )
     {
         requireNonNull( artifact, "artifact cannot be null" );
@@ -120,6 +123,13 @@ public final class ChainedWorkspaceReader
         return Collections.unmodifiableList( new ArrayList<>( versions ) );
     }
 
+    @Override
+    public Stream<Artifact> listArtifacts()
+    {
+        return readers.stream().flatMap( WorkspaceReader::listArtifacts );
+    }
+
+    @Override
     public WorkspaceRepository getRepository()
     {
         Key key = new Key( readers );

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,7 @@
                     <exclude>org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider</exclude>
                     <exclude>org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider</exclude>
                     <exclude>org.eclipse.aether.spi.connector.transport.TransporterProvider</exclude>
+                    <exclude>org.eclipse.aether.repository.WorkspaceReader</exclude>
                   </excludes>
                   <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
                   <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>


### PR DESCRIPTION
Add support for listing artifacts a `WorkspaceReader` know about. 
See https://issues.apache.org/jira/browse/MRESOLVER-307

Currently the build fails because of an incompatibility:
> There is at least one incompatibility:
> org.eclipse.aether.repository.WorkspaceReader.listArtifacts():METHOD_NEW_DEFAULT

As `WorkspaceReader` is a very specialized class and there is a default implementation I won't expect much problems but I'm not sure how to handle this here. Maybe it would be better to even not default implement it to make consumers aware of the new method? Any guidance would be appreciated.