### PR TITLE
[MRESOLVER-298] Make javax.inject optional again

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -65,6 +65,7 @@ import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSour
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapterFactoryImpl;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapterFactory;
@@ -236,15 +237,15 @@ public class AetherModule
                 .to( org.eclipse.aether.internal.impl.synccontext.legacy.DefaultSyncContextFactory.class )
                 .in( Singleton.class );
 
-        bind( NameMapper.class ).annotatedWith( Names.named( StaticNameMapperProvider.NAME ) )
+        bind( NameMapper.class ).annotatedWith( Names.named( NameMappers.STATIC_NAME ) )
                 .toProvider( StaticNameMapperProvider.class ).in( Singleton.class );
-        bind( NameMapper.class ).annotatedWith( Names.named( GAVNameMapperProvider.NAME ) )
+        bind( NameMapper.class ).annotatedWith( Names.named( NameMappers.GAV_NAME ) )
                 .toProvider( GAVNameMapperProvider.class ).in( Singleton.class );
-        bind( NameMapper.class ).annotatedWith( Names.named( DiscriminatingNameMapperProvider.NAME ) )
+        bind( NameMapper.class ).annotatedWith( Names.named( NameMappers.DISCRIMINATING_NAME ) )
                 .toProvider( DiscriminatingNameMapperProvider.class ).in( Singleton.class );
-        bind( NameMapper.class ).annotatedWith( Names.named( FileGAVNameMapperProvider.NAME ) )
+        bind( NameMapper.class ).annotatedWith( Names.named( NameMappers.FILE_GAV_NAME ) )
                 .toProvider( FileGAVNameMapperProvider.class ).in( Singleton.class );
-        bind( NameMapper.class ).annotatedWith( Names.named( FileHashingGAVNameMapperProvider.NAME ) )
+        bind( NameMapper.class ).annotatedWith( Names.named( NameMappers.FILE_HGAV_NAME ) )
                 .toProvider( FileHashingGAVNameMapperProvider.class ).in( Singleton.class );
 
         bind( NamedLockFactory.class ).annotatedWith( Names.named( NoopNamedLockFactory.NAME ) )
@@ -349,18 +350,18 @@ public class AetherModule
     @Provides
     @Singleton
     Map<String, NameMapper> provideNameMappers(
-            @Named( StaticNameMapperProvider.NAME ) NameMapper staticNameMapper,
-            @Named( GAVNameMapperProvider.NAME ) NameMapper gavNameMapper,
-            @Named( DiscriminatingNameMapperProvider.NAME ) NameMapper discriminatingNameMapper,
-            @Named( FileGAVNameMapperProvider.NAME ) NameMapper fileGavNameMapper,
-            @Named( FileHashingGAVNameMapperProvider.NAME ) NameMapper fileHashingGavNameMapper )
+            @Named( NameMappers.STATIC_NAME ) NameMapper staticNameMapper,
+            @Named( NameMappers.GAV_NAME ) NameMapper gavNameMapper,
+            @Named( NameMappers.DISCRIMINATING_NAME ) NameMapper discriminatingNameMapper,
+            @Named( NameMappers.FILE_GAV_NAME ) NameMapper fileGavNameMapper,
+            @Named( NameMappers.FILE_HGAV_NAME ) NameMapper fileHashingGavNameMapper )
     {
         Map<String, NameMapper> result = new HashMap<>();
-        result.put( StaticNameMapperProvider.NAME, staticNameMapper );
-        result.put( GAVNameMapperProvider.NAME, gavNameMapper );
-        result.put( DiscriminatingNameMapperProvider.NAME, discriminatingNameMapper );
-        result.put( FileGAVNameMapperProvider.NAME, fileGavNameMapper );
-        result.put( FileHashingGAVNameMapperProvider.NAME, fileHashingGavNameMapper );
+        result.put( NameMappers.STATIC_NAME, staticNameMapper );
+        result.put( NameMappers.GAV_NAME, gavNameMapper );
+        result.put( NameMappers.DISCRIMINATING_NAME, discriminatingNameMapper );
+        result.put( NameMappers.FILE_GAV_NAME, fileGavNameMapper );
+        result.put( NameMappers.FILE_HGAV_NAME, fileHashingGavNameMapper );
         return Collections.unmodifiableMap( result );
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
@@ -20,8 +20,9 @@ package org.eclipse.aether.internal.impl.synccontext.named;
  */
 
 /**
- * As end-user "mappers" are actually configurations/compositions, are constructed from several NameMapper
- * implementations, this helper class provides and are constructing them.
+ * As end-user "mappers" are actually configurations/compositions and are constructed from several NameMapper
+ * implementations, this helper class constructing them. This class also holds "names" used by service locator and
+ * Guice/Sisu as well.
  *
  * @since 1.9.4
  */

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
@@ -1,0 +1,64 @@
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * As end-user "mappers" are actually configurations/compositions, are constructed from several NameMapper
+ * implementations, this helper class provides and are constructing them.
+ *
+ * @since 1.9.4
+ */
+public final class NameMappers
+{
+    public static final String STATIC_NAME = "static";
+
+    public static final String GAV_NAME = "gav";
+
+    public static final String FILE_GAV_NAME = "file-gav";
+
+    public static final String FILE_HGAV_NAME = "file-hgav";
+
+    public static final String DISCRIMINATING_NAME = "discriminating";
+
+    public static NameMapper staticNameMapper()
+    {
+        return new StaticNameMapper();
+    }
+
+    public static NameMapper gavNameMapper()
+    {
+        return GAVNameMapper.gav();
+    }
+
+    public static NameMapper fileGavNameMapper()
+    {
+        return new BasedirNameMapper( GAVNameMapper.fileGav() );
+    }
+
+    public static NameMapper fileHashingGavNameMapper()
+    {
+        return new BasedirNameMapper( new HashingNameMapper( GAVNameMapper.gav() ) );
+    }
+
+    public static NameMapper discriminatingNameMapper()
+    {
+        return new DiscriminatingNameMapper( GAVNameMapper.gav() );
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
@@ -31,11 +31,6 @@ import java.util.Map;
 import org.eclipse.aether.MultiRuntimeException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RepositorySystemLifecycle;
-import org.eclipse.aether.internal.impl.synccontext.named.providers.DiscriminatingNameMapperProvider;
-import org.eclipse.aether.internal.impl.synccontext.named.providers.FileGAVNameMapperProvider;
-import org.eclipse.aether.internal.impl.synccontext.named.providers.FileHashingGAVNameMapperProvider;
-import org.eclipse.aether.internal.impl.synccontext.named.providers.GAVNameMapperProvider;
-import org.eclipse.aether.internal.impl.synccontext.named.providers.StaticNameMapperProvider;
 import org.eclipse.aether.named.NamedLockFactory;
 import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
 import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
@@ -67,7 +62,7 @@ public class NamedLockFactoryAdapterFactoryImpl implements NamedLockFactoryAdapt
 {
     private static final String DEFAULT_FACTORY_NAME = LocalReadWriteLockNamedLockFactory.NAME;
 
-    private static final String DEFAULT_NAME_MAPPER_NAME = GAVNameMapperProvider.NAME;
+    private static final String DEFAULT_NAME_MAPPER_NAME = NameMappers.GAV_NAME;
 
     private static Map<String, NamedLockFactory> getManuallyCreatedFactories()
     {
@@ -82,11 +77,11 @@ public class NamedLockFactoryAdapterFactoryImpl implements NamedLockFactoryAdapt
     private static Map<String, NameMapper> getManuallyCreatedNameMappers()
     {
         HashMap<String, NameMapper> mappers = new HashMap<>();
-        mappers.put( StaticNameMapperProvider.NAME, new StaticNameMapperProvider().get() );
-        mappers.put( GAVNameMapperProvider.NAME, new GAVNameMapperProvider().get() );
-        mappers.put( DiscriminatingNameMapperProvider.NAME, new DiscriminatingNameMapperProvider().get() );
-        mappers.put( FileGAVNameMapperProvider.NAME, new FileGAVNameMapperProvider().get() );
-        mappers.put( FileHashingGAVNameMapperProvider.NAME, new FileHashingGAVNameMapperProvider().get() );
+        mappers.put( NameMappers.STATIC_NAME, NameMappers.staticNameMapper() );
+        mappers.put( NameMappers.GAV_NAME, NameMappers.gavNameMapper() );
+        mappers.put( NameMappers.DISCRIMINATING_NAME, NameMappers.discriminatingNameMapper() );
+        mappers.put( NameMappers.FILE_GAV_NAME, NameMappers.fileGavNameMapper() );
+        mappers.put( NameMappers.FILE_HGAV_NAME, NameMappers.fileHashingGavNameMapper() );
         return Collections.unmodifiableMap( mappers );
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/DiscriminatingNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/DiscriminatingNameMapperProvider.java
@@ -23,9 +23,8 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.eclipse.aether.internal.impl.synccontext.named.DiscriminatingNameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 
 /**
  * The "discriminating" name mapper provider.
@@ -33,16 +32,14 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
  * @since 1.9.0
  */
 @Singleton
-@Named( DiscriminatingNameMapperProvider.NAME )
+@Named( NameMappers.DISCRIMINATING_NAME )
 public class DiscriminatingNameMapperProvider implements Provider<NameMapper>
 {
-    public static final String NAME = "discriminating";
-
     private final NameMapper mapper;
 
     public DiscriminatingNameMapperProvider()
     {
-        this.mapper = new DiscriminatingNameMapper( GAVNameMapper.gav() );
+        this.mapper = NameMappers.discriminatingNameMapper();
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileGAVNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileGAVNameMapperProvider.java
@@ -23,9 +23,8 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.eclipse.aether.internal.impl.synccontext.named.BasedirNameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 
 /**
  * The "file-gav" name mapper provider.
@@ -33,16 +32,14 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
  * @since 1.9.0
  */
 @Singleton
-@Named( FileGAVNameMapperProvider.NAME )
+@Named( NameMappers.FILE_GAV_NAME )
 public class FileGAVNameMapperProvider implements Provider<NameMapper>
 {
-    public static final String NAME = "file-gav";
-
     private final NameMapper mapper;
 
     public FileGAVNameMapperProvider()
     {
-        this.mapper = new BasedirNameMapper( GAVNameMapper.fileGav() );
+        this.mapper = NameMappers.fileGavNameMapper();
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileHashingGAVNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileHashingGAVNameMapperProvider.java
@@ -23,10 +23,8 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.eclipse.aether.internal.impl.synccontext.named.BasedirNameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.HashingNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 
 /**
  * The "file-hgav" name mapper provider.
@@ -34,16 +32,14 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
  * @since 1.9.0
  */
 @Singleton
-@Named( FileHashingGAVNameMapperProvider.NAME )
+@Named( NameMappers.FILE_HGAV_NAME )
 public class FileHashingGAVNameMapperProvider implements Provider<NameMapper>
 {
-    public static final String NAME = "file-hgav";
-
     private final NameMapper mapper;
 
     public FileHashingGAVNameMapperProvider()
     {
-        this.mapper = new BasedirNameMapper( new HashingNameMapper( GAVNameMapper.gav() ) );
+        this.mapper = NameMappers.fileHashingGavNameMapper();
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/GAVNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/GAVNameMapperProvider.java
@@ -23,8 +23,8 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.eclipse.aether.internal.impl.synccontext.named.GAVNameMapper;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 
 /**
  * The "gav" name mapper provider.
@@ -32,16 +32,14 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
  * @since 1.9.0
  */
 @Singleton
-@Named( GAVNameMapperProvider.NAME )
+@Named( NameMappers.GAV_NAME )
 public class GAVNameMapperProvider implements Provider<NameMapper>
 {
-    public static final String NAME = "gav";
-
     private final NameMapper mapper;
 
     public GAVNameMapperProvider()
     {
-        this.mapper = GAVNameMapper.gav();
+        this.mapper = NameMappers.gavNameMapper();
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/StaticNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/StaticNameMapperProvider.java
@@ -24,7 +24,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.StaticNameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 
 /**
  * The "static" name mapper provider.
@@ -32,16 +32,14 @@ import org.eclipse.aether.internal.impl.synccontext.named.StaticNameMapper;
  * @since 1.9.0
  */
 @Singleton
-@Named( StaticNameMapperProvider.NAME )
+@Named( NameMappers.STATIC_NAME )
 public class StaticNameMapperProvider implements Provider<NameMapper>
 {
-    public static final String NAME = "static";
-
     private final NameMapper mapper;
 
     public StaticNameMapperProvider()
     {
-        this.mapper = new StaticNameMapper();
+        this.mapper = NameMappers.staticNameMapper();
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/package-info.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/package-info.java
@@ -19,9 +19,9 @@
  */
 /**
  * As end-user "mappers" are actually configurations, constructed from several NameMapper implementations, this
- * package is holding providers exposing name mappers constructed by
- * {@link org.eclipse.aether.internal.impl.synccontext.named.NameMappers} helper class, as no NameMapper is a component
- * anymore. These classes are used when Guice/Sisu used, so javax.inject.Provider class is present.
+ * package have providers exposing name mappers constructed by
+ * {@link org.eclipse.aether.internal.impl.synccontext.named.NameMappers} helper class. These classes are used
+ * when Guice/Sisu is used, as they assume {@link javax.inject.Provider} class to be present.
  */
 package org.eclipse.aether.internal.impl.synccontext.named.providers;
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/package-info.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/package-info.java
@@ -19,7 +19,9 @@
  */
 /**
  * As end-user "mappers" are actually configurations, constructed from several NameMapper implementations, this
- * package is holding providers that are constructing them, as no NameMapper is a component anymore.
+ * package is holding providers exposing name mappers constructed by
+ * {@link org.eclipse.aether.internal.impl.synccontext.named.NameMappers} helper class, as no NameMapper is a component
+ * anymore. These classes are used when Guice/Sisu used, so javax.inject.Provider class is present.
  */
 package org.eclipse.aether.internal.impl.synccontext.named.providers;
 


### PR DESCRIPTION
javax.inject is and should be optional (used only when Guice and/or Sisu is being used), but in case SL is being used no javax.inject should be needed.

This rule was violated in 1.9.0 commit 5566bd5b3b0e59d124d820e6274da8e2da7804b0 where `javax.inject.Provider` was used in conjuction with SL as well.

This fix introduces `NameMappers` helper static class that constructs name mappers, and javax.inject.Provider classes are used ONLY when in Guice/Sisu, are NOT used with conjunction of SL.

---

https://issues.apache.org/jira/browse/MRESOLVER-298