### PR TITLE
handle thread interrupts on transitive dependencies parsing (infinite loop)

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
@@ -145,6 +145,9 @@ public class DfDependencyCollector
                                     VersionFilter verFilter, Dependency dependency, List<Artifact> relocations,
                                     boolean disableVersionManagement )
     {
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
         if ( depSelector != null && !depSelector.selectDependency( dependency ) )
         {
             return;


### PR DESCRIPTION
Hello.
In the scope of our project (https://central.sonatype.dev - new (beta) version of https://search.maven.org) we do parsing pom-s for transitive dependencies, using Maven Resolver.
It works fine in most cases. But recently, during the upload musquette artifact
https://repo1.maven.org/maven2/org/webjars/npm/musquette/1.1.1/
we see 100% CPU load on our service. It appears that the resolver is stuck in process of resolving transitive dependencies
The reason: this component (musquette) has dependencies that in the dependencies resolving process lead to being stuck in an infinite loop.
Here profiler graph
<img width="972" alt="Screenshot 2023-01-27 at 14 08 48" src="https://user-images.githubusercontent.com/11440242/215098287-d5c32e2d-3520-4dcc-add2-4f8f5de8b6ab.png">
We run each pom file parsing in a separate thread, but have no way to interrupt parsing when it's stuck in resolver methods.
So the goal is to interrupt dependencies parsing after the thread with the parser receives an interrupt event.