### PR TITLE
[MRESOLVER-32] Parallel deploy and more

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -207,7 +207,7 @@ final class BasicRepositoryConnector
         Collection<? extends ArtifactDownload> safeArtifactDownloads = safe( artifactDownloads );
         Collection<? extends MetadataDownload> safeMetadataDownloads = safe( metadataDownloads );
 
-        Executor executor = getExecutor( safeMetadataDownloads.size() + safeMetadataDownloads.size() );
+        Executor executor = getExecutor( safeArtifactDownloads.size() + safeMetadataDownloads.size() );
         RunnableErrorForwarder errorForwarder = new RunnableErrorForwarder();
         List<ChecksumAlgorithmFactory> checksumAlgorithmFactories = layout.getChecksumAlgorithmFactories();
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -370,7 +370,8 @@ public class DefaultMetadataResolver
         if ( !tasks.isEmpty() )
         {
             int threads = ThreadsUtils.threadCount( session, 4, CONFIG_PROP_THREADS );
-            Executor executor =  ThreadsUtils.executor( Math.min( tasks.size(), threads ), getClass().getSimpleName() );
+            Executor executor =  ThreadsUtils.executor(
+                    Math.min( tasks.size(), threads ), getClass().getSimpleName() + '-' );
             try
             {
                 RunnableErrorForwarder errorForwarder = new RunnableErrorForwarder();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -36,9 +36,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -73,7 +70,7 @@ import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.util.ConfigUtils;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
-import org.eclipse.aether.util.concurrency.WorkerThreadFactory;
+import org.eclipse.aether.util.concurrency.ThreadsUtils;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 import org.eclipse.aether.version.Version;
 import org.slf4j.Logger;
@@ -512,10 +509,10 @@ public class BfDependencyCollector
 
         private ExecutorService getExecutorService( RepositorySystemSession session )
         {
-            int nThreads = ConfigUtils.getInteger( session, 5, CONFIG_PROP_THREADS, "maven.artifact.threads" );
+            int nThreads = ThreadsUtils.threadCount(
+                    session, 5, CONFIG_PROP_THREADS, "maven.artifact.threads" );
             logger.debug( "Created thread pool with {} threads to resolve descriptors.", nThreads );
-            return new ThreadPoolExecutor( nThreads, nThreads, 3L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
-                    new WorkerThreadFactory( getClass().getSimpleName() ) );
+            return ThreadsUtils.threadPool( nThreads, getClass().getSimpleName() );
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -472,7 +472,7 @@ public class BfDependencyCollector
 
     static class ParallelDescriptorResolver
     {
-        final ExecutorService executorService;
+        private final ExecutorService executorService;
 
         /**
          * Artifact ID -> Future of DescriptorResolutionResult
@@ -512,7 +512,7 @@ public class BfDependencyCollector
             int nThreads = ThreadsUtils.threadCount(
                     session, 5, CONFIG_PROP_THREADS, "maven.artifact.threads" );
             logger.debug( "Created thread pool with {} threads to resolve descriptors.", nThreads );
-            return ThreadsUtils.threadPool( nThreads, getClass().getSimpleName() );
+            return ThreadsUtils.threadPool( nThreads, getClass().getSimpleName() + "-" );
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyResolutionSkipper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyResolutionSkipper.java
@@ -25,6 +25,7 @@ import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @since 1.8.0
  */
-abstract class DependencyResolutionSkipper
+abstract class DependencyResolutionSkipper implements Closeable
 {
     /**
      * Check whether the resolution of current node can be skipped before resolving.
@@ -58,9 +59,10 @@ abstract class DependencyResolutionSkipper
     abstract void cache( DependencyNode node, List<DependencyNode> parents );
 
     /**
-     * Print the skip/resolve status report for all nodes.
+     * Close: Print the skip/resolve status report for all nodes.
      */
-    abstract void report();
+    @Override
+    public abstract void close();
 
     /**
      * Returns new instance of "default" skipper.
@@ -99,7 +101,7 @@ abstract class DependencyResolutionSkipper
         }
 
         @Override
-        public void report()
+        public void close()
         {
         }
     }
@@ -205,7 +207,7 @@ abstract class DependencyResolutionSkipper
         }
 
         @Override
-        public void report()
+        public void close()
         {
             if ( LOGGER.isTraceEnabled() )
             {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/ThreadsUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/ThreadsUtils.java
@@ -1,0 +1,158 @@
+package org.eclipse.aether.util.concurrency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.util.ConfigUtils;
+
+/**
+ * Utilities for handling threads.
+ *
+ * @since 1.9.5
+ */
+public final class ThreadsUtils
+{
+    /**
+     * Shared instance of "direct executor".
+     */
+    public static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+    /**
+     * Creates new thread pool {@link ExecutorService}. The {@code poolSize} parameter but be greater than 1.
+     */
+    public static ExecutorService threadPool( int poolSize, String namePrefix )
+    {
+        if ( poolSize < 2 )
+        {
+            throw new IllegalArgumentException(
+                    "Invalid poolSize: " + poolSize + ". Must be greater than 1." );
+        }
+        return new ThreadPoolExecutor( poolSize, poolSize, 3L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(),
+                new WorkerThreadFactory( namePrefix )
+        );
+    }
+
+    /**
+     * Returns {@link #DIRECT_EXECUTOR} or result of {@link #threadPool(int, String)} depending on value of
+     * {@code size} parameter.
+     */
+    public static Executor executor( int size, String namePrefix )
+    {
+        if ( size <= 1 )
+        {
+            return DIRECT_EXECUTOR;
+        }
+        else
+        {
+            return threadPool( size, namePrefix );
+        }
+    }
+
+    /**
+     * To be used with result of {@link #executor(int, String)} method, shuts down instance if it is
+     * {@link ExecutorService}.
+     */
+    public static void shutdown( Executor executor )
+    {
+        if ( executor instanceof ExecutorService )
+        {
+            ( (ExecutorService) executor ).shutdown();
+        }
+    }
+
+    /**
+     * Calculates requested thread count based on user configuration, or if none provided, the provided default value.
+     */
+    public static int threadCount( RepositorySystemSession session, int defaultValue, String... keys )
+    {
+        if ( defaultValue <= 0 )
+        {
+            throw new IllegalArgumentException(
+                    "Invalid defaultValue: " + defaultValue + ". Must be positive." );
+        }
+        String threadConfiguration = ConfigUtils.getString( session, Integer.toString( defaultValue ), keys );
+        try
+        {
+            return calculateDegreeOfConcurrency( threadConfiguration );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Blatantly copied (and simplified) from maven-embedder
+     * {@code org.apache.maven.cli.MavenCli#calculateDegreeOfConcurrency} class.
+     */
+    private static int calculateDegreeOfConcurrency( String threadConfiguration )
+    {
+        if ( threadConfiguration.endsWith( "C" ) )
+        {
+            threadConfiguration = threadConfiguration.substring( 0, threadConfiguration.length() - 1 );
+
+            try
+            {
+                float coreMultiplier = Float.parseFloat( threadConfiguration );
+
+                if ( coreMultiplier <= 0.0f )
+                {
+                    throw new IllegalArgumentException( "Invalid threads core multiplier value: '" + threadConfiguration
+                            + "C'. Value must be positive." );
+                }
+
+                int threads = (int) ( coreMultiplier * Runtime.getRuntime().availableProcessors() );
+                return threads == 0 ? 1 : threads;
+            }
+            catch ( NumberFormatException e )
+            {
+                throw new IllegalArgumentException(
+                        "Invalid threads value: '" + threadConfiguration + "C'. Value must be positive." );
+            }
+        }
+        else
+        {
+            try
+            {
+                int threads = Integer.parseInt( threadConfiguration );
+
+                if ( threads <= 0 )
+                {
+                    throw new IllegalArgumentException(
+                            "Invalid threads value: '" + threadConfiguration + "'. Value must be positive." );
+                }
+
+                return threads;
+            }
+            catch ( NumberFormatException e )
+            {
+                throw new IllegalArgumentException(
+                        "Invalid threads value: '" + threadConfiguration + "'. Supported are integer values." );
+            }
+        }
+    }
+}

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -30,7 +30,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.checksums.omitChecksumsForExtensions` | String | Comma-separated list of extensions with leading dot (example `.asc`) that should have checksums omitted. These are applied to sub-artifacts only. Note: to achieve 1.7.x `aether.checksums.forSignature=true` behaviour, pass empty string as value for this property. | `.asc` | no
 `aether.checksums.algorithms` | String | Comma-separated list of checksum algorithms with which checksums are validated (downloaded) and generated (uploaded). Resolver by default supports following algorithms: `MD5`, `SHA-1`, `SHA-256` and `SHA-512`. New algorithms can be added by implementing `ChecksumAlgorithmFactory` component. | `"SHA-1,MD5"` | no
 `aether.conflictResolver.verbose` | boolean | Flag controlling the conflict resolver's verbose mode. | `false` | no
-`aether.connector.basic.threads` or `maven.artifact.threads` | int | Number of threads to use for uploading/downloading. | `5` | no
+`aether.connector.basic.threads` or `maven.artifact.threads` | String | Number of threads to use for uploading/downloading. Accepts "dynamic" expressions like `1.5C` as well, or plain integer. | `5` | no
 `aether.connector.classpath.loader` | ClassLoader | `ClassLoader` from which resources should be retrieved which start with the `classpath:` protocol. | `Thread.currentThread().getContextClassLoader()` | no
 `aether.connector.connectTimeout` | long | Connect timeout in milliseconds. | `10000` | yes
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no
@@ -50,7 +50,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.dependencyCollector.maxExceptions` | int | Only exceptions up to the number given in this configuration property are emitted. Exceptions which exceed that number are swallowed. | `50` | no
 `aether.dependencyCollector.impl` | String | The name of the dependency collector implementation to use: depth-first (original) named `df`, and breadth-first (new in 1.8.0) named `bf`. Both collectors produce equivalent results, but they may differ performance wise, depending on project being applied to. Our experience shows that existing `df` is well suited for smaller to medium size projects, while `bf` may perform better on huge projects with many dependencies. Experiment (and come back to us!) to figure out which one suits you the better. | `"df"` | no
 `aether.dependencyCollector.bf.skipper` | boolean | Flag controlling whether to skip resolving duplicate/conflicting nodes during the breadth-first (`bf`) dependency collection process. | `true` | no
-`aether.dependencyCollector.bf.threads` or `maven.artifact.threads` | int | Number of threads to use for collecting POMs and version ranges in BF collector. | `5` | no
+`aether.dependencyCollector.bf.threads` or `maven.artifact.threads` | String | Number of threads to use for collecting POMs and version ranges in BF collector. Accepts "dynamic" expressions like `1.5C` as well, or plain integer. | `5` | no
 `aether.dependencyManager.verbose` | boolean | Flag controlling the verbose mode for dependency management. If enabled, the original attributes of a dependency before its update due to dependency managemnent will be recorded in the node's `DependencyNode#getData()` when building a dependency graph. | `false` | no
 `aether.enhancedLocalRepository.localPrefix` | String | The prefix to use for locally installed artifacts. | `"installed"` | no
 `aether.enhancedLocalRepository.snapshotsPrefix` | String | The prefix to use for snapshot artifacts. | `"snapshots"` | no
@@ -63,7 +63,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.enhancedLocalRepository.releasesPrefix` | String | The prefix to use for release artifacts. | `"releases"` | no
 `aether.enhancedLocalRepository.trackingFilename` | String | Filename of the file in which to track the remote repositories. | `"_remote.repositories"` | no
 `aether.interactive` | boolean | A flag indicating whether interaction with the user is allowed. | `false` | no
-`aether.metadataResolver.threads` | int | Number of threads to use in parallel for resolving metadata. | `4` | no
+`aether.metadataResolver.threads` | String | Number of threads to use in parallel for resolving metadata. Accepts "dynamic" expressions like `1.5C` as well, or plain integer. | `4` | no
 `aether.offline.protocols` | String | Comma-separated list of protocols which are supposed to be resolved offline. | - | no
 `aether.offline.hosts` | String | Comma-separated list of hosts which are supposed to be resolved offline. | - | no
 `aether.priority.<class>` | float | The priority to use for a certain extension class. `class` can either be the fully qualified name or the simple name stands for fully qualified class name. If the class name ends with `Factory` that suffix could optionally be left out. | - |  no

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -31,6 +31,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.checksums.algorithms` | String | Comma-separated list of checksum algorithms with which checksums are validated (downloaded) and generated (uploaded). Resolver by default supports following algorithms: `MD5`, `SHA-1`, `SHA-256` and `SHA-512`. New algorithms can be added by implementing `ChecksumAlgorithmFactory` component. | `"SHA-1,MD5"` | no
 `aether.conflictResolver.verbose` | boolean | Flag controlling the conflict resolver's verbose mode. | `false` | no
 `aether.connector.basic.threads` or `maven.artifact.threads` | String | Number of threads to use for uploading/downloading. Accepts "dynamic" expressions like `1.5C` as well, or plain integer. | `5` | no
+`aether.connector.basic.parallelPut` | boolean | Enables parallel PUT processing (parallel deploys) on basic connector. | `false` | no
 `aether.connector.classpath.loader` | ClassLoader | `ClassLoader` from which resources should be retrieved which start with the `classpath:` protocol. | `Thread.currentThread().getContextClassLoader()` | no
 `aether.connector.connectTimeout` | long | Connect timeout in milliseconds. | `10000` | yes
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no


### PR DESCRIPTION
General improvements regarding threads and thread pool use in code, leaving all the functionality untouched (same things are done, just centralized), while basic connector is the only modified one, that is now able to perform parallel upload as well.

Changes:
* introduced ThreadUtils that supports "core count" expressions (blatantly copied from Maven `-T` parsing)
* all thread using components redirected to ThreadUtils, removed scattered boiler plate and duplications
* BF collector enhanced: now skipper and parallelCollector are both closeable, ensuring there is no thread pool left dangling
* connector new feature (disabled by default): perform PUTs in parallel

---

In action: https://asciinema.org/a/fBTcOTSJF0cRmHsr8hZuIQrpw
(note: local repo contained m-deploy-p 3.1.0-SNAPSHOT installed, needed to fully utilize deployAtEnd https://github.com/apache/maven-deploy-plugin/pull/38)

---

https://issues.apache.org/jira/browse/MRESOLVER-32