### PR TITLE
[MRESOLVER-319] Parallel Deploy Support

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -147,7 +147,8 @@ final class BasicRepositoryConnector
 
         maxThreads = ExecutorUtils.threadCount( session, 5, CONFIG_PROP_THREADS, "maven.artifact.threads" );
         smartChecksums = ConfigUtils.getBoolean( session, true, CONFIG_PROP_SMART_CHECKSUMS );
-        parallelPut = ConfigUtils.getBoolean( session, true, CONFIG_PROP_PARALLEL_PUT );
+        parallelPut = ConfigUtils.getBoolean( session, true,
+                CONFIG_PROP_PARALLEL_PUT + "." + repository.getId(),  CONFIG_PROP_PARALLEL_PUT );
         persistedChecksums =
                 ConfigUtils.getBoolean( session, ConfigurationProperties.DEFAULT_PERSISTED_CHECKSUMS,
                         ConfigurationProperties.PERSISTED_CHECKSUMS );

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -31,7 +31,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.checksums.algorithms` | String | Comma-separated list of checksum algorithms with which checksums are validated (downloaded) and generated (uploaded). Resolver by default supports following algorithms: `MD5`, `SHA-1`, `SHA-256` and `SHA-512`. New algorithms can be added by implementing `ChecksumAlgorithmFactory` component. | `"SHA-1,MD5"` | no
 `aether.conflictResolver.verbose` | boolean | Flag controlling the conflict resolver's verbose mode. | `false` | no
 `aether.connector.basic.threads` or `maven.artifact.threads` | int | Number of threads to use for uploading/downloading. | `5` | no
-`aether.connector.basic.parallelPut` | boolean | Enables or disables parallel PUT processing (parallel deploys) on basic connector. When disabled, connector behaves exactly as in Maven 3.8.x did: parallel GETs but sequential PUTs. | `true` | yes
+`aether.connector.basic.parallelPut` | boolean | Enables or disables parallel PUT processing (parallel deploys) on basic connector globally or per remote repository. When disabled, connector behaves exactly as in Maven 3.8.x did: GETs are parallel while PUTs are sequential. | `true` | yes
 `aether.connector.classpath.loader` | ClassLoader | `ClassLoader` from which resources should be retrieved which start with the `classpath:` protocol. | `Thread.currentThread().getContextClassLoader()` | no
 `aether.connector.connectTimeout` | long | Connect timeout in milliseconds. | `10000` | yes
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -31,6 +31,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.checksums.algorithms` | String | Comma-separated list of checksum algorithms with which checksums are validated (downloaded) and generated (uploaded). Resolver by default supports following algorithms: `MD5`, `SHA-1`, `SHA-256` and `SHA-512`. New algorithms can be added by implementing `ChecksumAlgorithmFactory` component. | `"SHA-1,MD5"` | no
 `aether.conflictResolver.verbose` | boolean | Flag controlling the conflict resolver's verbose mode. | `false` | no
 `aether.connector.basic.threads` or `maven.artifact.threads` | int | Number of threads to use for uploading/downloading. | `5` | no
+`aether.connector.basic.parallelPut` | boolean | Enables or disables parallel PUT processing (parallel deploys) on basic connector. When disabled, connector behaves exactly as in Maven 3.8.x did: parallel GETs but sequential PUTs. | `true` | yes
 `aether.connector.classpath.loader` | ClassLoader | `ClassLoader` from which resources should be retrieved which start with the `classpath:` protocol. | `Thread.currentThread().getContextClassLoader()` | no
 `aether.connector.connectTimeout` | long | Connect timeout in milliseconds. | `10000` | yes
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no


### PR DESCRIPTION
Make basic connector be able to perform parallel PUTs in very same manner as it did so far parallel GETs.

Still, there is a "safety switch" to turn off this new feature that is ENABLED by default.

Effects:
* set threads to 1: GET and PUT are executed sequentially
* set parallelPut to false: Behave as Maven 3.8.x line was
* default: perform parallel GETs and PUTs

---

https://issues.apache.org/jira/browse/MRESOLVER-319