### PR TITLE
[MRESOLVER-320] Return to original pool setup

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
@@ -54,7 +54,11 @@ import org.eclipse.aether.version.VersionConstraint;
  */
 public final class DataPool
 {
-    private static final String CONFIG_PROP_COLLECTOR_POOL = "aether.dependencyCollector.pool";
+    private static final String CONFIG_PROP_COLLECTOR_POOL_ARTIFACT = "aether.dependencyCollector.pool.artifact";
+
+    private static final String CONFIG_PROP_COLLECTOR_POOL_DEPENDENCY = "aether.dependencyCollector.pool.dependency";
+
+    private static final String CONFIG_PROP_COLLECTOR_POOL_DESCRIPTOR = "aether.dependencyCollector.pool.descriptor";
 
     private static final String ARTIFACT_POOL = DataPool.class.getName() + "$Artifact";
 
@@ -94,7 +98,6 @@ public final class DataPool
     public DataPool( RepositorySystemSession session )
     {
         final RepositoryCache cache = session.getCache();
-        final String poolType = ConfigUtils.getString( session, HARD, CONFIG_PROP_COLLECTOR_POOL );
 
         InternPool<Artifact, Artifact> artifactsPool = null;
         InternPool<Dependency, Dependency> dependenciesPool = null;
@@ -108,7 +111,10 @@ public final class DataPool
 
         if ( artifactsPool == null )
         {
-            artifactsPool = createPool( poolType );
+            final String artifactPoolType = ConfigUtils.getString( session, WEAK,
+                    CONFIG_PROP_COLLECTOR_POOL_ARTIFACT );
+
+            artifactsPool = createPool( artifactPoolType );
             if ( cache != null )
             {
                 cache.put( session, ARTIFACT_POOL, artifactsPool );
@@ -117,7 +123,10 @@ public final class DataPool
 
         if ( dependenciesPool == null )
         {
-            dependenciesPool = createPool( poolType );
+            final String dependencyPoolType = ConfigUtils.getString( session, WEAK,
+                    CONFIG_PROP_COLLECTOR_POOL_DEPENDENCY );
+
+            dependenciesPool = createPool( dependencyPoolType );
             if ( cache != null )
             {
                 cache.put( session, DEPENDENCY_POOL, dependenciesPool );
@@ -126,7 +135,10 @@ public final class DataPool
 
         if ( descriptorsPool == null )
         {
-            descriptorsPool = createPool( poolType );
+            final String descriptorPoolType = ConfigUtils.getString( session, HARD,
+                    CONFIG_PROP_COLLECTOR_POOL_DESCRIPTOR );
+
+            descriptorsPool = createPool( descriptorPoolType );
             if ( cache != null )
             {
                 cache.put( session, DESCRIPTORS, descriptorsPool );


### PR DESCRIPTION
There was some information lost on the way how we got to current master: artifact and dependency was ALWAYS weak, and the "cause" commit 6dda69980cf4c13228a4f6561bfa0d8384a0be68 modified ONLY the descriptor pool (was hard by mistake, made it weak). This also explain why we saw with yourkit excess Xpp3 and model building requests as well (as starting with 1.8.x descriptors/POMs were GCed, while before they were not).

This PR essentially returns the state of affairs to pre 1.8.x resolver state re data pools, but also adds ability to "tune" each three of them separately.

---

https://issues.apache.org/jira/browse/MRESOLVER-320