### PR TITLE
[MRESOLVER-316] DF Collector may enter endless loop

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelector.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelector.java
@@ -32,6 +32,7 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver.ConflictContex
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.ConflictItem;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.VersionSelector;
 import org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor;
+import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionConstraint;
 
@@ -155,7 +156,7 @@ public final class NearestVersionSelector
             return context.isIncluded( node );
         };
         PathRecordingDependencyVisitor visitor = new PathRecordingDependencyVisitor( filter );
-        context.getRoot().accept( visitor );
+        context.getRoot().accept( new TreeDependencyVisitor( visitor ) );
         return new UnsolvableVersionConflictException( visitor.getPaths() );
     }
 


### PR DESCRIPTION
When resolving artifact from issue, the DF collector enters endless loop. But the loop is NOT in collecting, it happens when DF detect unsolvable problem, and tries to report it. To report it, it needs to visit the graph of collected nodes, but that graph contains loops (and it is expected).

But, the problem is that PathRecordingDependencyVisitor used to collect paths chokes on loops.

Fix: just like in RepositorySystem#resolveDependencies, wrap up the graph visitor into TreeDependencyVisitor, that creates tree-like (loopless, tree by def) "view" of graph.

With this fix, DF immediately detects that artifact in issue is unresolvable (just like BF does), as it contains unsolvable (not intersecting) ranges.

---

https://issues.apache.org/jira/browse/MRESOLVER-316