### PR TITLE
IO Fixes

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
@@ -75,6 +76,8 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
             if (Files.isReadable(filePath)) {
                 try (InputStream stream = Files.newInputStream(filePath)) {
                     props.load(stream);
+                } catch (NoSuchFileException e) {
+                    // ignore
                 }
             }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
@@ -54,6 +54,9 @@ public final class NameMappers {
         return new BasedirNameMapper(new HashingNameMapper(GAVNameMapper.gav()));
     }
 
+    /**
+     * @since 1.9.5
+     */
     public static NameMapper fileStaticNameMapper() {
         return new BasedirNameMapper(new StaticNameMapper());
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
@@ -55,7 +55,7 @@ public final class NameMappers {
     }
 
     /**
-     * @since 1.9.5
+     * @since 1.9.6
      */
     public static NameMapper fileStaticNameMapper() {
         return new BasedirNameMapper(new StaticNameMapper());

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMappers.java
@@ -34,6 +34,8 @@ public final class NameMappers {
 
     public static final String FILE_HGAV_NAME = "file-hgav";
 
+    public static final String FILE_STATIC_NAME = "file-static";
+
     public static final String DISCRIMINATING_NAME = "discriminating";
 
     public static NameMapper staticNameMapper() {
@@ -50,6 +52,10 @@ public final class NameMappers {
 
     public static NameMapper fileHashingGavNameMapper() {
         return new BasedirNameMapper(new HashingNameMapper(GAVNameMapper.gav()));
+    }
+
+    public static NameMapper fileStaticNameMapper() {
+        return new BasedirNameMapper(new StaticNameMapper());
     }
 
     public static NameMapper discriminatingNameMapper() {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.synccontext.named.providers;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
+
+/**
+ * The "file static" name mapper provider.
+ *
+ * @since 1.9.0
+ */
+@Singleton
+@Named(NameMappers.FILE_STATIC_NAME)
+public class FileStaticNameMapperProvider implements Provider<NameMapper> {
+    private final NameMapper mapper;
+
+    public FileStaticNameMapperProvider() {
+        this.mapper = NameMappers.fileStaticNameMapper();
+    }
+
+    @Override
+    public NameMapper get() {
+        return mapper;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
@@ -28,7 +28,7 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 /**
  * The "file static" name mapper provider.
  *
- * @since 1.9.0
+ * @since 1.9.5
  */
 @Singleton
 @Named(NameMappers.FILE_STATIC_NAME)

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider.java
@@ -28,7 +28,7 @@ import org.eclipse.aether.internal.impl.synccontext.named.NameMappers;
 /**
  * The "file static" name mapper provider.
  *
- * @since 1.9.5
+ * @since 1.9.6
  */
 @Singleton
 @Named(NameMappers.FILE_STATIC_NAME)


### PR DESCRIPTION
Seems tracking file is concurrently being read/written.

Cumulative fixes:
* https://issues.apache.org/jira/browse/MNG-7705 file may be gone between isReadable check and opening it (just ignore if gone)
* https://issues.apache.org/jira/browse/MRESOLVER-325 On windows ATOMIC_MOVE is known to be problematic, retry the operation 3 times
* fix static name mapper, it does not work with file-lock

