### PR TITLE
[MRESOLVER-329] More robust IO in DefaultTrackingFileManager

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
@@ -75,6 +76,8 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
             if (Files.isReadable(filePath)) {
                 try (InputStream stream = Files.newInputStream(filePath)) {
                     props.load(stream);
+                } catch (NoSuchFileException e) {
+                    // MRESOLVER-329: ignore; in case of concurrent r/w Files.isReadable may return true
                 }
             }
 


### PR DESCRIPTION
Make the code more robust to copy with concurrently accessed files and hopefully with Windows quirks re atomic move.

---

https://issues.apache.org/jira/browse/MRESOLVER-329