### PR TITLE
[MRESOLVER-333] Better errors about artifact availability

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.repository.LocalArtifactResult;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.eclipse.aether.transfer.RepositoryOfflineException;
 
@@ -96,9 +97,21 @@ public class ArtifactResolutionException extends RepositoryException {
         for (ArtifactResult result : results) {
             if (!result.isResolved()) {
                 unresolved++;
-
                 buffer.append(sep);
                 buffer.append(result.getRequest().getArtifact());
+                LocalArtifactResult localResult = result.getLocalArtifactResult();
+                if (localResult != null) {
+                    buffer.append(" (");
+                    if (localResult.getFile() != null) {
+                        buffer.append("present");
+                        if (!localResult.isAvailable()) {
+                            buffer.append(", but unavailable");
+                        }
+                    } else {
+                        buffer.append("absent");
+                    }
+                    buffer.append(")");
+                }
                 sep = ", ";
             }
         }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
@@ -118,12 +118,7 @@ public class ArtifactResolutionException extends RepositoryException {
 
         Throwable cause = getCause(results);
         if (cause != null) {
-            if (unresolved == 1) {
-                buffer.setLength(0);
-                buffer.append(cause.getMessage());
-            } else {
-                buffer.append(": ").append(cause.getMessage());
-            }
+            buffer.append(": ").append(cause.getMessage());
         }
 
         return buffer.toString();

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
@@ -91,12 +91,9 @@ public class ArtifactResolutionException extends RepositoryException {
 
         buffer.append("The following artifacts could not be resolved: ");
 
-        int unresolved = 0;
-
         String sep = "";
         for (ArtifactResult result : results) {
             if (!result.isResolved()) {
-                unresolved++;
                 buffer.append(sep);
                 buffer.append(result.getRequest().getArtifact());
                 LocalArtifactResult localResult = result.getLocalArtifactResult();

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResult.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.ArtifactRepository;
+import org.eclipse.aether.repository.LocalArtifactResult;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
 import static java.util.Objects.requireNonNull;
@@ -44,6 +45,8 @@ public final class ArtifactResult {
     private Artifact artifact;
 
     private ArtifactRepository repository;
+
+    private LocalArtifactResult localArtifactResult;
 
     /**
      * Creates a new result for the specified request.
@@ -132,6 +135,26 @@ public final class ArtifactResult {
     public ArtifactResult setRepository(ArtifactRepository repository) {
         this.repository = repository;
         return this;
+    }
+
+    /**
+     * Gets the {@link LocalArtifactResult} received during artifact resolution.
+     *
+     * @return The {@link LocalArtifactResult} or {@code null}.
+     * @since 1.9.6
+     */
+    public LocalArtifactResult getLocalArtifactResult() {
+        return localArtifactResult;
+    }
+
+    /**
+     * Sets the {@link LocalArtifactResult} that is received during artifact resolution.
+     *
+     * @param localArtifactResult The local artifact result.
+     * @since 1.9.6
+     */
+    public void setLocalArtifactResult(LocalArtifactResult localArtifactResult) {
+        this.localArtifactResult = localArtifactResult;
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -350,6 +350,7 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
             LocalArtifactResult local = lrm.find(
                     session,
                     new LocalArtifactRequest(artifact, filteredRemoteRepositories, request.getRequestContext()));
+            result.setLocalArtifactResult(local);
             boolean found = (filter != null && local.isAvailable()) || isLocallyInstalled(local, versionResult);
             // with filtering it is availability that drives logic
             // without filtering it is simply presence of file that drives the logic
@@ -382,7 +383,11 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
             }
 
             if (local.getFile() != null) {
-                LOGGER.debug("Verifying availability of {} from {}", local.getFile(), remoteRepositories);
+                LOGGER.info(
+                        "Artifact {} is locally present, but unavailable, verifying availability of {} from {}",
+                        artifact,
+                        local.getFile(),
+                        remoteRepositories);
             }
 
             LOGGER.debug("Resolving artifact {} from {}", artifact, remoteRepositories);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -384,9 +384,8 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
 
             if (local.getFile() != null) {
                 LOGGER.info(
-                        "Artifact {} is locally present, but unavailable, verifying availability of {} from {}",
+                        "Artifact {} is present in local repository, but cached from a repository ID that is unavailable in current build context, verifying that is downloadable from {}",
                         artifact,
-                        local.getFile(),
                         remoteRepositories);
             }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -384,7 +384,7 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
 
             if (local.getFile() != null) {
                 LOGGER.info(
-                        "Artifact {} is present in local repository, but cached from a repository ID that is unavailable in current build context, verifying that is downloadable from {}",
+                        "Artifact {} is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from {}",
                         artifact,
                         remoteRepositories);
             }


### PR DESCRIPTION
Users get confused about artifact availability checks, and resolver should provide better error messages. Availability check is checking for (known) origin of locally cached artifact and the request repositories overlap, if none found, the artifact, despite being present locally, is not available.

Present this to end users, and educate them what is and what for is "artifact availability check".

---

https://issues.apache.org/jira/browse/MRESOLVER-333