### PR TITLE
[MRESOLVER-339] Preemptive auth fix

### DIFF
--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -362,7 +362,7 @@ final class HttpTransporter extends AbstractTransporter {
 
     private void prepare(HttpUriRequest request, SharingHttpContext context) {
         if (preemptiveAuth) {
-            state.setAuthScheme(server, new BasicScheme());
+            context.getAuthCache().put(server, new BasicScheme());
         }
         boolean put = HttpPut.METHOD_NAME.equalsIgnoreCase(request.getMethod());
         if (state.getWebDav() == null && (put || isPayloadPresent(request))) {

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/SharingHttpContext.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/SharingHttpContext.java
@@ -21,7 +21,6 @@ package org.eclipse.aether.transport.http;
 import java.io.Closeable;
 
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.protocol.BasicHttpContext;
 
 /**
  * HTTP context that shares certain attributes among requests to optimize the communication with the server.
@@ -29,7 +28,7 @@ import org.apache.http.protocol.BasicHttpContext;
  * @see <a href="http://hc.apache.org/httpcomponents-client-ga/tutorial/html/advanced.html#stateful_conn">Stateful HTTP
  *      connections</a>
  */
-final class SharingHttpContext extends BasicHttpContext implements Closeable {
+final class SharingHttpContext extends HttpClientContext implements Closeable {
 
     private final LocalState state;
 
@@ -65,10 +64,6 @@ final class SharingHttpContext extends BasicHttpContext implements Closeable {
             return null;
         }
         return super.removeAttribute(id);
-    }
-
-    public SharingAuthCache getAuthCache() {
-        return authCache;
     }
 
     @Override

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/SharingHttpContext.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/SharingHttpContext.java
@@ -67,6 +67,10 @@ final class SharingHttpContext extends BasicHttpContext implements Closeable {
         return super.removeAttribute(id);
     }
 
+    public SharingAuthCache getAuthCache() {
+        return authCache;
+    }
+
     @Override
     public void close() {
         authCache.clear();

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
@@ -905,6 +905,41 @@ public class HttpTransporterTest {
         assertEquals(1, listener.startedCount);
     }
 
+    @Test
+    public void testPut_AuthCache() throws Exception {
+        httpServer.setAuthentication("testuser", "testpass");
+        auth = new AuthenticationBuilder()
+                .addUsername("testuser")
+                .addPassword("testpass")
+                .build();
+        newTransporter(httpServer.getHttpUrl());
+        PutTask task = new PutTask(URI.create("repo/file.txt")).setDataString("upload");
+        transporter.put(task);
+        assertEquals(3, httpServer.getLogEntries().size()); // options (challenged) + options w/ auth + put w/ auth
+        httpServer.getLogEntries().clear();
+        task = new PutTask(URI.create("repo/file.txt")).setDataString("upload");
+        transporter.put(task);
+        assertEquals(1, httpServer.getLogEntries().size()); // put w/ auth
+    }
+
+    @Test
+    public void testPut_AuthCache_Preemptive() throws Exception {
+        httpServer.setAuthentication("testuser", "testpass");
+        auth = new AuthenticationBuilder()
+                .addUsername("testuser")
+                .addPassword("testpass")
+                .build();
+        session.setConfigProperty(ConfigurationProperties.HTTP_PREEMPTIVE_AUTH, true);
+        newTransporter(httpServer.getHttpUrl());
+        PutTask task = new PutTask(URI.create("repo/file.txt")).setDataString("upload");
+        transporter.put(task);
+        assertEquals(2, httpServer.getLogEntries().size()); // options w/ auth + put w/ auth
+        httpServer.getLogEntries().clear();
+        task = new PutTask(URI.create("repo/file.txt")).setDataString("upload");
+        transporter.put(task);
+        assertEquals(1, httpServer.getLogEntries().size()); // put w/ auth
+    }
+
     @Test(timeout = 20000L)
     public void testConcurrency() throws Exception {
         httpServer.setAuthentication("testuser", "testpass");


### PR DESCRIPTION
Code is broken when default HTTP or HTTPS (80 or 443) ports are used, as SharedAuthCache "normalized" host will not match those of pre-set in case of preemptive auth. The UT case (non-default ports) works and is valid, as UT cannot bind ports 80 or 443.

Fix: expose AuthCache and do things "by the book".

---

https://issues.apache.org/jira/browse/MRESOLVER-339