### PR TITLE
[MRESOLVER-350] Inline StringUtils

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -41,7 +41,6 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.spi.locator.ServiceLocator;
-import org.eclipse.aether.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,7 +280,7 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
         } else {
             String checksums = session.getChecksumPolicy();
             //noinspection StatementWithEmptyBody
-            if (globalPolicy && !StringUtils.isEmpty(checksums)) {
+            if (globalPolicy && checksums != null && !checksums.isEmpty()) {
                 // use global override
             } else {
                 checksums = checksumPolicyProvider.getEffectiveChecksumPolicy(
@@ -290,7 +289,7 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
 
             String updates = session.getUpdatePolicy();
             //noinspection StatementWithEmptyBody
-            if (globalPolicy && !StringUtils.isEmpty(updates)) {
+            if (globalPolicy && updates != null && !updates.isEmpty()) {
                 // use global override
             } else {
                 updates = updatePolicyAnalyzer.getEffectiveUpdatePolicy(
@@ -305,10 +304,10 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
 
     private RepositoryPolicy merge(RepositoryPolicy policy, String updates, String checksums) {
         if (policy != null) {
-            if (StringUtils.isEmpty(updates)) {
+            if (updates == null || updates.isEmpty()) {
                 updates = policy.getUpdatePolicy();
             }
-            if (StringUtils.isEmpty(checksums)) {
+            if (checksums == null || checksums.isEmpty()) {
                 checksums = policy.getChecksumPolicy();
             }
             if (!policy.getUpdatePolicy().equals(updates)

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/StubRemoteRepositoryManager.java
@@ -24,7 +24,6 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.util.StringUtils;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,11 +49,11 @@ public class StubRemoteRepositoryManager implements RemoteRepositoryManager {
         RepositoryPolicy policy = repository.getPolicy(snapshots);
 
         String checksums = session.getChecksumPolicy();
-        if (StringUtils.isEmpty(checksums)) {
+        if (checksums == null || checksums.isEmpty()) {
             checksums = policy.getChecksumPolicy();
         }
         String updates = session.getUpdatePolicy();
-        if (StringUtils.isEmpty(updates)) {
+        if (updates == null || updates.isEmpty()) {
             updates = policy.getUpdatePolicy();
         }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/StringUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/StringUtils.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.util;
 /**
  * A utility class to ease string processing.
  */
+@Deprecated
 public final class StringUtils {
 
     private StringUtils() {
@@ -32,7 +33,9 @@ public final class StringUtils {
      *
      * @param string The string to check, may be {@code null}.
      * @return {@code true} if the string is {@code null} or of zero length, {@code false} otherwise.
+     * @deprecated
      */
+    @Deprecated
     public static boolean isEmpty(String string) {
         return string == null || string.isEmpty();
     }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/StringUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/StringUtils.java
@@ -33,7 +33,7 @@ public final class StringUtils {
      *
      * @param string The string to check, may be {@code null}.
      * @return {@code true} if the string is {@code null} or of zero length, {@code false} otherwise.
-     * @deprecated
+     * @deprecated Deprecated since 1.5.0 without any alternative provided. Use Java 8 APIs instead.
      */
     @Deprecated
     public static boolean isEmpty(String string) {


### PR DESCRIPTION
Fwiwm `StringUtils` was deprecated since quite some time, but I'd agree that a micro release is not the best place to remove a public class.  Maybe wait for next minor...