### PR TITLE
[MRESOLVER-359] Make build be explicit about build time requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <minimalMavenBuildVersion>[3.8.4,)</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-04-26T10:02:03Z</project.build.outputTimestamp>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,8 @@
     <guavaVersion>30.1-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <minimalMavenBuildVersion>3.8.4</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>[3.8.4,)</minimalMavenBuildVersion>
+    <minimalJavaBuildVersion>[1.8.0-371,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-04-26T10:02:03Z</project.build.outputTimestamp>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <minimalMavenBuildVersion>[3.8.4,)</minimalMavenBuildVersion>
-    <minimalJavaBuildVersion>[1.8.0-371,)</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-04-26T10:02:03Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
Fixes:
* make minimalMavenBuildVersion be "[3.8.7,)", we mean "recent" or maybe "maintained" Maven version.
* make minimalJavaBuildVersion be "[1.8.0-362,)" we mean "recent" Java 8. *CI helped to decide: 362*

Note: values taken from current CI setup.

---

https://issues.apache.org/jira/browse/MRESOLVER-359