### PR TITLE
[MRESOLVER-370] Lock factory diagnostic on failure

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
@@ -216,9 +216,7 @@ public final class NamedLockFactoryAdapter {
                 }
             }
             if (!illegalStateExceptions.isEmpty()) {
-                IllegalStateException ex = new IllegalStateException("Could not acquire lock(s)");
-                illegalStateExceptions.forEach(ex::addSuppressed);
-                throw ex;
+                throw namedLockFactory.failure(illegalStateExceptions);
             }
         }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter.java
@@ -216,7 +216,9 @@ public final class NamedLockFactoryAdapter {
                 }
             }
             if (!illegalStateExceptions.isEmpty()) {
-                throw namedLockFactory.failure(illegalStateExceptions);
+                IllegalStateException ex = new IllegalStateException("Could not acquire lock(s)");
+                illegalStateExceptions.forEach(ex::addSuppressed);
+                throw namedLockFactory.onFailure(ex);
             }
         }
 

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
@@ -42,13 +42,21 @@ public interface NamedLockFactory {
      * Utility method to provide more (factory specific) description when a locking operation failed. Assumption is
      * that provided list has at least one element (one failure) or more (in case of retries), must not be {@code null}
      * to get meaningful exceptions. The returned exception will be new instance of {@link IllegalStateException} with
-     * passed in list added as suppressed exceptions. Still, the fact this method has be invoked, means there is a
+     * passed in list added as suppressed exceptions. Still, the fact this method has been invoked, means there is a
      * "abort failure" ahead, so factory may either decorate (add info about state) or even log some diagnostic
      * about the state of the locks.
+     * <p>
+     * The default implementation merely does what happened before this change: adds no extra information.
      *
      * @since TBD
      * @return A new instance of {@link IllegalStateException} (decorated) and may have other side effects as well
-     * (dumping state), never {@code null}.
+     * (dumping state), never returns {@code null}.
      */
-    IllegalStateException failure(List<IllegalStateException> attempts);
+    default IllegalStateException failure(List<IllegalStateException> attempts) {
+        IllegalStateException ex = new IllegalStateException("Could not acquire lock(s)");
+        if (attempts != null) {
+            attempts.forEach(ex::addSuppressed);
+        }
+        return ex;
+    }
 }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
@@ -18,8 +18,6 @@
  */
 package org.eclipse.aether.named;
 
-import java.util.List;
-
 /**
  * A factory of {@link NamedLock}s.
  */
@@ -39,24 +37,15 @@ public interface NamedLockFactory {
     void shutdown();
 
     /**
-     * Utility method to provide more (factory specific) description when a locking operation failed. Assumption is
-     * that provided list has at least one element (one failure) or more (in case of retries), must not be {@code null}
-     * to get meaningful exceptions. The returned exception will be new instance of {@link IllegalStateException} with
-     * passed in list added as suppressed exceptions. Still, the fact this method has been invoked, means there is a
-     * "abort failure" ahead, so factory may either decorate (add info about state) or even log some diagnostic
-     * about the state of the locks.
+     * Method to notify factory about locking failure, to make it possible to provide more (factory specific)
+     * information about factory state when a locking operation failed. Factory may alter provided failure or
+     * provide information via some other side effect (for example via logging).
      * <p>
-     * The default implementation merely does what happened before this change: adds no extra information.
+     * The default implementation merely does what happened before: adds no extra information.
      *
      * @since TBD
-     * @return A new instance of {@link IllegalStateException} (decorated) and may have other side effects as well
-     * (dumping state), never returns {@code null}.
      */
-    default IllegalStateException failure(List<IllegalStateException> attempts) {
-        IllegalStateException ex = new IllegalStateException("Could not acquire lock(s)");
-        if (attempts != null) {
-            attempts.forEach(ex::addSuppressed);
-        }
-        return ex;
+    default <E extends Throwable> E onFailure(E failure) {
+        return failure;
     }
 }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/NamedLockFactory.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.named;
 
+import java.util.List;
+
 /**
  * A factory of {@link NamedLock}s.
  */
@@ -35,4 +37,18 @@ public interface NamedLockFactory {
      * Performs a clean shut down of the factory.
      */
     void shutdown();
+
+    /**
+     * Utility method to provide more (factory specific) description when a locking operation failed. Assumption is
+     * that provided list has at least one element (one failure) or more (in case of retries), must not be {@code null}
+     * to get meaningful exceptions. The returned exception will be new instance of {@link IllegalStateException} with
+     * passed in list added as suppressed exceptions. Still, the fact this method has be invoked, means there is a
+     * "abort failure" ahead, so factory may either decorate (add info about state) or even log some diagnostic
+     * about the state of the locks.
+     *
+     * @since TBD
+     * @return A new instance of {@link IllegalStateException} (decorated) and may have other side effects as well
+     * (dumping state), never {@code null}.
+     */
+    IllegalStateException failure(List<IllegalStateException> attempts);
 }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/NoopNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/NoopNamedLockFactory.java
@@ -45,17 +45,17 @@ public class NoopNamedLockFactory extends NamedLockFactorySupport {
         }
 
         @Override
-        public boolean lockShared(final long time, final TimeUnit unit) {
+        protected boolean doLockShared(final long time, final TimeUnit unit) {
             return true;
         }
 
         @Override
-        public boolean lockExclusively(final long time, final TimeUnit unit) {
+        protected boolean doLockExclusively(final long time, final TimeUnit unit) {
             return true;
         }
 
         @Override
-        public void unlock() {
+        protected void doUnlock() {
             // no-op
         }
     }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/AdaptedSemaphoreNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/AdaptedSemaphoreNamedLock.java
@@ -66,7 +66,7 @@ public class AdaptedSemaphoreNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public boolean lockShared(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockShared(final long time, final TimeUnit unit) throws InterruptedException {
         Deque<Integer> perms = threadPerms.get();
         if (!perms.isEmpty()) { // we already own shared or exclusive lock
             perms.push(NONE);
@@ -80,7 +80,7 @@ public class AdaptedSemaphoreNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public boolean lockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
         Deque<Integer> perms = threadPerms.get();
         if (!perms.isEmpty()) { // we already own shared or exclusive lock
             if (perms.contains(EXCLUSIVE)) {
@@ -98,7 +98,7 @@ public class AdaptedSemaphoreNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public void unlock() {
+    protected void doUnlock() {
         Deque<Integer> steps = threadPerms.get();
         if (steps.isEmpty()) {
             throw new IllegalStateException("Wrong API usage: unlock without lock");

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
@@ -83,12 +83,12 @@ public final class FileLockNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public boolean lockShared(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockShared(final long time, final TimeUnit unit) throws InterruptedException {
         return retry(time, unit, RETRY_SLEEP_MILLIS, this::doLockShared, null, false);
     }
 
     @Override
-    public boolean lockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
         return retry(time, unit, RETRY_SLEEP_MILLIS, this::doLockExclusively, null, false);
     }
 
@@ -169,7 +169,7 @@ public final class FileLockNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public void unlock() {
+    protected void doUnlock() {
         criticalRegion.lock();
         try {
             Deque<Boolean> steps = threadSteps.computeIfAbsent(Thread.currentThread(), k -> new ArrayDeque<>());

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -18,7 +18,6 @@
  */
 package org.eclipse.aether.named.support;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -62,7 +61,7 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory {
     }
 
     @Override
-    public IllegalStateException failure(List<IllegalStateException> attempts) {
+    public <E extends Throwable> E onFailure(E failure) {
         if (diagnostic) {
             logger.debug("{} with {} active lock(s)", getClass().getSimpleName(), locks.size());
             logger.debug("");
@@ -75,12 +74,7 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory {
                 logger.debug("");
             }
         }
-
-        IllegalStateException ex = new IllegalStateException("Could not acquire lock(s)");
-        if (attempts != null) {
-            attempts.forEach(ex::addSuppressed);
-        }
-        return ex;
+        return failure;
     }
 
     public void closeLock(final String name) {

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -37,16 +37,23 @@ import static java.util.Objects.requireNonNull;
 public abstract class NamedLockFactorySupport implements NamedLockFactory {
     private static final boolean DIAGNOSTIC_ENABLED = Boolean.getBoolean("aether.named.diagnostic.enabled");
 
-    public static boolean isDiagnosticEnabled() {
-        return DIAGNOSTIC_ENABLED;
-    }
-
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final ConcurrentMap<String, NamedLockHolder> locks;
 
+    private final boolean diagnosticEnabled;
+
     public NamedLockFactorySupport() {
+        this(DIAGNOSTIC_ENABLED);
+    }
+
+    public NamedLockFactorySupport(boolean diagnosticEnabled) {
         this.locks = new ConcurrentHashMap<>();
+        this.diagnosticEnabled = diagnosticEnabled;
+    }
+
+    public boolean isDiagnosticEnabled() {
+        return diagnosticEnabled;
     }
 
     @Override

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -35,7 +35,9 @@ import static java.util.Objects.requireNonNull;
 public abstract class NamedLockFactorySupport implements NamedLockFactory {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    final boolean diagnostic = logger.isDebugEnabled();
+    boolean isDiagnosticEnabled() {
+        return logger.isDebugEnabled();
+    }
 
     private final ConcurrentMap<String, NamedLockHolder> locks;
 
@@ -62,7 +64,7 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory {
 
     @Override
     public <E extends Throwable> E onFailure(E failure) {
-        if (diagnostic) {
+        if (isDiagnosticEnabled()) {
             logger.debug("{} with {} active lock(s)", getClass().getSimpleName(), locks.size());
             logger.debug("");
             for (Map.Entry<String, NamedLockHolder> entry : locks.entrySet()) {

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockFactorySupport.java
@@ -35,6 +35,11 @@ import static java.util.Objects.requireNonNull;
  * Support class for {@link NamedLockFactory} implementations providing reference counting.
  */
 public abstract class NamedLockFactorySupport implements NamedLockFactory {
+    /**
+     * System property key to enable locking diagnostic collection.
+     *
+     * @since TBD
+     */
     private static final boolean DIAGNOSTIC_ENABLED = Boolean.getBoolean("aether.named.diagnostic.enabled");
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -52,6 +57,11 @@ public abstract class NamedLockFactorySupport implements NamedLockFactory {
         this.diagnosticEnabled = diagnosticEnabled;
     }
 
+    /**
+     * Returns {@code true} if factory diagnostic collection is enabled.
+     *
+     * @since TBD
+     */
     public boolean isDiagnosticEnabled() {
         return diagnosticEnabled;
     }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
@@ -43,7 +43,7 @@ public abstract class NamedLockSupport implements NamedLock {
     public NamedLockSupport(final String name, final NamedLockFactorySupport factory) {
         this.name = name;
         this.factory = factory;
-        this.state = factory.diagnostic ? new ConcurrentHashMap<>() : null;
+        this.state = factory.isDiagnosticEnabled() ? new ConcurrentHashMap<>() : null;
     }
 
     @Override

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
@@ -55,7 +55,7 @@ public abstract class NamedLockSupport implements NamedLock {
     public boolean lockShared(long time, TimeUnit unit) throws InterruptedException {
         if (state != null) {
             state.computeIfAbsent(Thread.currentThread(), k -> new ArrayDeque<>())
-                    .push("S");
+                    .push("shared");
         }
         return doLockShared(time, unit);
     }
@@ -66,7 +66,7 @@ public abstract class NamedLockSupport implements NamedLock {
     public boolean lockExclusively(long time, TimeUnit unit) throws InterruptedException {
         if (state != null) {
             state.computeIfAbsent(Thread.currentThread(), k -> new ArrayDeque<>())
-                    .push("X");
+                    .push("exclusive");
         }
         return doLockExclusively(time, unit);
     }

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
@@ -97,6 +97,11 @@ public abstract class NamedLockSupport implements NamedLock {
         factory.closeLock(name);
     }
 
+    /**
+     * Returns the diagnostic state (if collected) or empty map, never {@code null}.
+     *
+     * @since TBD
+     */
     public Map<Thread, Deque<String>> diagnosticState() {
         if (diagnosticState != null) {
             return diagnosticState;

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/NamedLockSupport.java
@@ -44,7 +44,7 @@ public abstract class NamedLockSupport implements NamedLock {
     public NamedLockSupport(final String name, final NamedLockFactorySupport factory) {
         this.name = name;
         this.factory = factory;
-        this.diagnosticState = NamedLockFactorySupport.isDiagnosticEnabled() ? new ConcurrentHashMap<>() : null;
+        this.diagnosticState = factory.isDiagnosticEnabled() ? new ConcurrentHashMap<>() : null;
     }
 
     @Override

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/ReadWriteLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/ReadWriteLockNamedLock.java
@@ -53,7 +53,7 @@ public class ReadWriteLockNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public boolean lockShared(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockShared(final long time, final TimeUnit unit) throws InterruptedException {
         Deque<Step> steps = threadSteps.get();
         if (readWriteLock.readLock().tryLock(time, unit)) {
             steps.push(Step.SHARED);
@@ -63,7 +63,7 @@ public class ReadWriteLockNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public boolean lockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
+    protected boolean doLockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
         Deque<Step> steps = threadSteps.get();
         if (!steps.isEmpty()) { // we already own shared or exclusive lock
             if (!steps.contains(Step.EXCLUSIVE)) {
@@ -78,7 +78,7 @@ public class ReadWriteLockNamedLock extends NamedLockSupport {
     }
 
     @Override
-    public void unlock() {
+    protected void doUnlock() {
         Deque<Step> steps = threadSteps.get();
         if (steps.isEmpty()) {
             throw new IllegalStateException("Wrong API usage: unlock without lock");

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -70,12 +70,14 @@ Out of the box, name mapper implementations are the following:
 
 Note: the `file-gav` name mapper MUST be used with `file-lock` named locking, no other mapper will work with it.
 
-${esc.hash}${esc.hash} Diagnostic dump in case of failures
+${esc.hash}${esc.hash} Diagnostic collection in case of failures
 
 If you experience locking failures, to get access to full dump (may be huge in case of big builds) on failure,
-enable debug log level for the logger of the factory in use. When enabled, "diagnostic dump" will be emitted by factory
-to DEBUG log (console by default). Please note, that enabling diagnostic dump may increase heap requirement (as
+enable lock diagnostic collection. When enabled, "diagnostic dump" will be emitted by factory
+to INFO log (console by default). Please note, that enabling diagnostic dump may increase heap requirement (as
 diagnostic is collected in memory).
 
-For example, if you use `file-lock` (see above), then pass following parameter to Maven on command line:
-`-Dorg.slf4j.simpleLogger.log.org.eclipse.aether.named.providers.FileLockNamedLockFactory=debug`.
+To enable diagnostic collection, set Java System Property `aether.named.diagnostic.enabled` to `true`.
+
+If diagnostic collection is not enabled, Resolver will "just" fail, telling about failed lock, but not reveal any
+information about other active locks and threads.

--- a/maven-resolver-named-locks/src/site/markdown/index.md.vm
+++ b/maven-resolver-named-locks/src/site/markdown/index.md.vm
@@ -69,3 +69,13 @@ Out of the box, name mapper implementations are the following:
 - `file-gav` implemented in `org.eclipse.aether.internal.impl.synccontext.named.FileGAVNameMapper`.
 
 Note: the `file-gav` name mapper MUST be used with `file-lock` named locking, no other mapper will work with it.
+
+${esc.hash}${esc.hash} Diagnostic dump in case of failures
+
+If you experience locking failures, to get access to full dump (may be huge in case of big builds) on failure,
+enable debug log level for the logger of the factory in use. When enabled, "diagnostic dump" will be emitted by factory
+to DEBUG log (console by default). Please note, that enabling diagnostic dump may increase heap requirement (as
+diagnostic is collected in memory).
+
+For example, if you use `file-lock` (see above), then pass following parameter to Maven on command line:
+`-Dorg.slf4j.simpleLogger.log.org.eclipse.aether.named.providers.FileLockNamedLockFactory=debug`.

--- a/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
+++ b/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
@@ -45,6 +45,8 @@ public abstract class NamedLockFactoryTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void testFailure() throws InterruptedException {
+        // note: set system property "aether.named.diagnostic.enabled" to "true" to have log output
+        // this test does NOT assert its presence, only the proper flow
         Thread t1 = new Thread(() -> {
             try {
                 namedLockFactory.getLock(lockName()).lockShared(1L, TimeUnit.MINUTES);

--- a/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
+++ b/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
@@ -18,7 +18,6 @@
  */
 package org.eclipse.aether.named;
 
-import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +66,7 @@ public abstract class NamedLockFactoryTestSupport {
         t2.start();
         t1.join();
         t2.join();
-        throw namedLockFactory.failure(Collections.singletonList(new IllegalStateException("foo")));
+        throw namedLockFactory.onFailure(new IllegalStateException("failure"));
     }
 
     @Test


### PR DESCRIPTION
The change "pulls" all `NamedLock` interface methods "level up" from implementations to `NamedLockSupport`, to be able to augment instances at `NamedLockSupport` level.

If diagnostic enabled:
* factory makes all named lock instances to gather "diag stats" (in memory!)
* on adapter failure, factory will dump out diagnostic state,
* each active lock (non closed) will dump it's state out (per thread with "steps")
* output goes to lock factory INFO logger, potentially swarming console

By default, when "diagnostic" not turned on, no change really.

---

https://issues.apache.org/jira/browse/MRESOLVER-370