### PR TITLE
[MRESOLVER-220] Refuse proactively unsupported operation

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/NamedLockFactoryAdapterTestSupport.java
@@ -31,6 +31,7 @@ import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.impl.synccontext.named.*;
 import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.named.support.LockUpgradeNotSupportedException;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
 import org.junit.AfterClass;
@@ -266,7 +267,7 @@ public abstract class NamedLockFactoryAdapterTestSupport {
                         chained.run();
                     }
                     loser.await();
-                } catch (IllegalStateException e) {
+                } catch (IllegalStateException | LockUpgradeNotSupportedException e) {
                     e.printStackTrace(); // for ref purposes
                     loser.countDown();
                     winner.await();

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/AdaptedSemaphoreNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/AdaptedSemaphoreNamedLock.java
@@ -87,7 +87,9 @@ public class AdaptedSemaphoreNamedLock extends NamedLockSupport {
                 perms.push(NONE);
                 return true;
             } else {
-                return false; // Lock upgrade not supported
+                throw new LockUpgradeNotSupportedException(
+                        "Thread " + Thread.currentThread().getName() + " already possesses shared lock fpr '" + name()
+                                + "', but wants exclusive lock; upgrade not supported"); // Lock upgrade not supported
             }
         }
         if (semaphore.tryAcquire(EXCLUSIVE, time, unit)) {

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
@@ -137,7 +137,11 @@ public final class FileLockNamedLock extends NamedLockSupport {
                         // if we own shared, that's attempted upgrade
                         boolean weOwnShared = steps.contains(Boolean.TRUE);
                         if (weOwnShared) {
-                            return false; // Lock upgrade not supported
+                            throw new LockUpgradeNotSupportedException(
+                                    "Thread " + Thread.currentThread().getName()
+                                            + " already possesses shared lock fpr '" + name()
+                                            + "', but wants exclusive lock; upgrade not supported"); // Lock upgrade not
+                            // supported
                         } else {
                             // someone else owns shared, let's wait
                             return null;

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/LockUpgradeNotSupportedException.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/LockUpgradeNotSupportedException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.named.support;
+
+/**
+ * Exception thrown when lock upgrade attempted that we do not support.
+ *
+ * @since 1.9.13
+ */
+public final class LockUpgradeNotSupportedException extends RuntimeException {
+    public LockUpgradeNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/ReadWriteLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/ReadWriteLockNamedLock.java
@@ -67,7 +67,9 @@ public class ReadWriteLockNamedLock extends NamedLockSupport {
         Deque<Step> steps = threadSteps.get();
         if (!steps.isEmpty()) { // we already own shared or exclusive lock
             if (!steps.contains(Step.EXCLUSIVE)) {
-                return false; // Lock upgrade not supported
+                throw new LockUpgradeNotSupportedException(
+                        "Thread " + Thread.currentThread().getName() + " already possesses shared lock fpr '" + name()
+                                + "', but wants exclusive lock; upgrade not supported"); // Lock upgrade not supported
             }
         }
         if (readWriteLock.writeLock().tryLock(time, unit)) {

--- a/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
+++ b/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/NamedLockFactoryTestSupport.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.named;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.aether.named.support.LockUpgradeNotSupportedException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -132,7 +133,11 @@ public abstract class NamedLockFactoryTestSupport {
         final String name = lockName();
         try (NamedLock one = namedLockFactory.getLock(name)) {
             assertThat(one.lockShared(1L, TimeUnit.MILLISECONDS), is(true));
-            assertThat(one.lockExclusively(1L, TimeUnit.MILLISECONDS), is(false));
+            try {
+                one.lockExclusively(1L, TimeUnit.MILLISECONDS);
+            } catch (LockUpgradeNotSupportedException e) {
+                // good
+            }
             one.unlock();
         }
     }


### PR DESCRIPTION
Instead to silently "send result" (that is false) to caller, as this makes totally strange outcome: "failed to lock within 30sec" but caller did not wait anything. Moreover, the bug where upgrade is attempted slips in unnoticed.

---

https://issues.apache.org/jira/browse/MRESOLVER-220