### PR TITLE
[MRESOLVER-373] Make GavNameResolver to distinguish names better

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -116,6 +116,6 @@ public class GAVNameMapper implements NameMapper {
     }
 
     public static NameMapper fileGav() {
-        return new GAVNameMapper(true, "", ".lock", "", ".lock", "~");
+        return new GAVNameMapper(true, "artifact~", ".lock", "metadata~", ".lock", "~");
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -59,7 +59,7 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         Collection<String> names = mapper.nameLocks(session, singletonList(artifact), null);
 
         assertThat(names, hasSize(1));
-        assertThat(names.iterator().next(), equalTo("group~artifact~1.0.lock"));
+        assertThat(names.iterator().next(), equalTo("artifact~group~artifact~1.0.lock"));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         Collection<String> names = mapper.nameLocks(session, null, singletonList(metadata));
 
         assertThat(names, hasSize(1));
-        assertThat(names.iterator().next(), equalTo("group~artifact.lock"));
+        assertThat(names.iterator().next(), equalTo("metadata~group~artifact.lock"));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         Iterator<String> namesIterator = names.iterator();
 
         // they are sorted as well
-        assertThat(namesIterator.next(), equalTo("agroup~artifact~1.0.lock"));
-        assertThat(namesIterator.next(), equalTo("bgroup~artifact.lock"));
+        assertThat(namesIterator.next(), equalTo("artifact~agroup~artifact~1.0.lock"));
+        assertThat(namesIterator.next(), equalTo("metadata~bgroup~artifact.lock"));
     }
 }


### PR DESCRIPTION
This class currently gives away same names for artifact and metadata locks, that causes MRESOLVER-373 where artifact and metadata resolver together attempt illegal "lock upgrade", as both operate on same named lock.

This is wrong, as all other name mappers distinguish among them, also in case of snapshots, there are cases when shared lock is enough for artifact but metadata MAY need refresh, hence exclusive.

Important note: changing "naming" implies, that Maven carrying resolver with this change will be UNABLE to properly "share" local repository with older Mavens (so if this gets into Maven 3.9.3, it will properly share local repository other Maven 3.9.3+ instances, but not with 3.9.2, 3.9.1 or 3.9.0!)

---

https://issues.apache.org/jira/browse/MRESOLVER-373