### PR TITLE
[MRESOLVER-376] SOError fix for BF collector

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -554,7 +554,14 @@ public class BfDependencyCollector extends DependencyCollectorDelegate implement
 
         DescriptorResolutionResult(
                 VersionRangeResult rangeResult, Version version, ArtifactDescriptorResult descriptor) {
-            this(descriptor.getArtifact(), rangeResult);
+            // NOTE: In case of A1 -> A2 relocation this happens:
+            // ArtifactDescriptorResult read by ArtifactDescriptorResultReader for A1
+            // will return instance that will have artifact = A2 (as RelocatedArtifact).
+            // So to properly "key" this instance, we need to use "originally requested" A1 instead!
+            // In short:
+            // ArtifactDescriptorRequest.artifact != ArtifactDescriptorResult.artifact WHEN relocation in play
+            // otherwise (no relocation), they are EQUAL.
+            this(descriptor.getRequest().getArtifact(), rangeResult);
             this.descriptors.put(version, descriptor);
         }
 


### PR DESCRIPTION
Solve the mixup of Artifact used as key, as in case of relocation A1 -> A2, when A1 descriptor is read, the result will have A2 artifact set.

So, in code, we must go for "originally asked" A1 artifact, as in case of relocation, the descriptor will hold A1 relocation target, that is A2, causing endless loop.

---

https://issues.apache.org/jira/browse/MRESOLVER-376