### PR TITLE
[MRESOLVER-376] UT for bug

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
@@ -514,6 +514,23 @@ public abstract class DependencyCollectorDelegateTestSupport {
 
     protected abstract String getTransitiveDepsUseRangesDirtyTreeResource();
 
+    @Test
+    public void testTransitiveDepsUseRangesAndRelocationDirtyTree() throws DependencyCollectionException, IOException {
+        // Note: DF depends on version order (ultimately the order of versions as returned by VersionRangeResolver
+        // that in case of Maven, means order as in maven-metadata.xml
+        // BF on the other hand explicitly sorts versions from range in descending order
+        //
+        // Hence, the "dirty tree" of two will not match.
+        DependencyNode root = parser.parseResource(getTransitiveDepsUseRangesAndRelocationDirtyTreeResource());
+        Dependency dependency = root.getDependency();
+        CollectRequest request = new CollectRequest(dependency, singletonList(repository));
+
+        CollectResult result = collector.collectDependencies(session, request);
+        assertEqualSubtree(root, result.getRoot());
+    }
+
+    protected abstract String getTransitiveDepsUseRangesAndRelocationDirtyTreeResource();
+
     private DependencyNode toDependencyResult(
             final DependencyNode root, final String rootScope, final Boolean optional) {
         // Make the root artifact resultion result a dependency resolution result for the subtree check.

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollectorTest.java
@@ -68,6 +68,11 @@ public class BfDependencyCollectorTest extends DependencyCollectorDelegateTestSu
         return "transitiveDepsUseRangesDirtyTreeResult_BF.txt";
     }
 
+    @Override
+    protected String getTransitiveDepsUseRangesAndRelocationDirtyTreeResource() {
+        return "transitiveDepsUseRangesAndRelocationDirtyTreeResult_BF.txt";
+    }
+
     private Dependency newDep(String coords, String scope, Collection<Exclusion> exclusions) {
         Dependency d = new Dependency(new DefaultArtifact(coords), scope);
         return d.setExclusions(exclusions);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollectorTest.java
@@ -36,4 +36,9 @@ public class DfDependencyCollectorTest extends DependencyCollectorDelegateTestSu
     protected String getTransitiveDepsUseRangesDirtyTreeResource() {
         return "transitiveDepsUseRangesDirtyTreeResult_DF.txt";
     }
+
+    @Override
+    protected String getTransitiveDepsUseRangesAndRelocationDirtyTreeResource() {
+        return "transitiveDepsUseRangesAndRelocationDirtyTreeResult_DF.txt";
+    }
 }

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_BF.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_BF.txt
@@ -1,0 +1,2 @@
+transitiveDepsUseRangesAndRelocationDirtyTree:aid:ext:1 compile
++- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:3 compile

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_DF.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_DF.txt
@@ -1,0 +1,2 @@
+transitiveDepsUseRangesAndRelocationDirtyTree:aid:ext:1 compile
+\- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:1 compile

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_aid_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_aid_1.ini
@@ -1,0 +1,2 @@
+[dependencies]
+transitiveDepsUseRangesAndRelocationDirtyTree:cid:ext:[1,3]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_1.ini
@@ -1,0 +1,4 @@
+[relocation]
+transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:1
+
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_2.ini
@@ -1,0 +1,4 @@
+[relocation]
+transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:2
+
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_3.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_cid_3.ini
@@ -1,0 +1,4 @@
+[relocation]
+transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:3
+
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_1.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_1.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_2.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_2.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_3.ini
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTree_relocatedcid_3.ini
@@ -1,0 +1,1 @@
+[dependencies]

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/IniArtifactDescriptorReader.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/IniArtifactDescriptorReader.java
@@ -100,6 +100,7 @@ public class IniArtifactDescriptorReader {
                 ArtifactDescription data = reader.parse(resourceName);
                 if (data.getRelocation() != null) {
                     result.addRelocation(artifact);
+                    result.setArtifact(data.getRelocation());
                     artifact = data.getRelocation();
                 } else {
                     result.setArtifact(artifact);


### PR DESCRIPTION
This UT on master makes old DF work, while BF break with SOError.

If same UT ran on fixed branch, both pass.

Still, seems combo of range+relocation has some other issues as well, as all this works only partially, as the range is not resolved, only first applicant (lowest version in DF and highest version in BF as it sort-reverse the versions). This may be UT support class issue as well, unsure.

---

https://issues.apache.org/jira/browse/MRESOLVER-376