### PR TITLE
[MRESOLVER-385] Maven connection max ttl to wagon 300

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -183,11 +183,11 @@ public final class ConfigurationProperties {
     public static final String HTTP_CONNECTION_MAX_TTL = PREFIX_CONNECTOR + "http.connectionMaxTtl";
 
     /**
-     * The default value to use if {@link #HTTP_CONNECTION_MAX_TTL} isn't set (600 seconds).
+     * The default value to use if {@link #HTTP_CONNECTION_MAX_TTL} isn't set (300 seconds).
      *
      * @since 1.9.8
      */
-    public static final int DEFAULT_HTTP_CONNECTION_MAX_TTL = 600;
+    public static final int DEFAULT_HTTP_CONNECTION_MAX_TTL = 300;
 
     /**
      * The maximum concurrent connections per route HTTP client is allowed to use.

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -36,7 +36,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.connector.connectTimeout` | long | Connect timeout in milliseconds. | `10000` | yes
 `aether.connector.http.bind.address` | String | Set the outgoing interface (globally or per remote repository). Valid values are local accessible IP addresses or host names. The default will use the system's default route. Invalid addresses will result in HttpTransport creation failure. | `null` | yes
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no
-`aether.connector.http.connectionMaxTtl` | int | Time to live in seconds for an HTTP connection, after that time, the connection will be dropped. | `600` | yes
+`aether.connector.http.connectionMaxTtl` | int | Time to live in seconds for an HTTP connection, after that time, the connection will be dropped. | `300` | yes
 `aether.connector.http.credentialEncoding` | String | The encoding/charset to use when exchanging credentials with HTTP servers. | `"ISO-8859-1"` | yes
 `aether.connector.http.headers` | `Map<String, String>` | The request headers to use for HTTP-based repository connectors. The headers are specified using a map of strings mapping a header name to its value. The repository-specific headers map is supposed to be complete, i.e. is not merged with the general headers map. | - | yes
 `aether.connector.http.maxConnectionsPerRoute` | int | The maximum concurrent connections per route HTTP client is allowed to use. | `50` | yes


### PR DESCRIPTION
To have it aligned with deprecated Wagon.

---

https://issues.apache.org/jira/browse/MRESOLVER-385