### PR TITLE
[MRESOLVER-395] Update dependencies, tidy up

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
@@ -33,7 +33,7 @@
   <description>A simple Maven plugin using Maven Artifact Resolver with Maven repositories.</description>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>${minimalMavenBuildVersion}</maven>
   </prerequisites>
 
   <dependencies>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>5.3.0</version>
+      <version>5.3.1</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>3.21.3</version>
+      <version>3.23.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -135,7 +135,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.5.0</version>
         <executions>
           <execution>
             <id>bundle</id>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
+      <version>1.16.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <guiceVersion>5.1.0</guiceVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <!-- used by supplier and demo only -->
-    <mavenVersion>3.9.3</mavenVersion>
+    <mavenVersion>3.9.4</mavenVersion>
     <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-07-20T09:56:17Z</project.build.outputTimestamp>


### PR DESCRIPTION
Update dependencies:
* hazelcast 5.3.1
* redisson 3.23.2
* commons-codec 1.16.0
* maven (in demos and supplier) 3.9.4

Also, minor, but:
* remove redundant plugin assembly plugin version (redisson module, is defined in parent)
* fix demo plugin prerequisite, align with minimal maven build version

---

https://issues.apache.org/jira/browse/MRESOLVER-395