### PR TITLE
[MRESOLVER-397] Deprecate Guice integration

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/AetherModule.java
@@ -128,7 +128,10 @@ import org.slf4j.ILoggerFactory;
  *
  * @noextend This class must not be extended by clients and will eventually be marked {@code final} without prior
  * notice.
+ * @deprecated This class is about to be dropped in 2.0.0 release. Use SISU or use maven-resolver-supplier to
+ * get Resolver instances.
  */
+@Deprecated
 public class AetherModule extends AbstractModule {
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/package-info.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/guice/package-info.java
@@ -20,5 +20,7 @@
 /**
  * The integration with the dependency injection framework
  * <a href="https://github.com/google/guice" target="_blank">Google Guice</a>.
+ *
+ * @deprecated This package is about to be dropped in 2.0.0.
  */
 package org.eclipse.aether.impl.guice;


### PR DESCRIPTION
Lowering the provided instantiation support from 3 to 2, to lower resources for maintenance all these.

SL is about to be dropped, Guice same. Users should either use Sisu or use the new Supplier.

---

https://issues.apache.org/jira/browse/MRESOLVER-397