### PR TITLE
[MRESOLVER-406] Update Jetty to 9.4.52.v20230823

### DIFF
--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-    <jettyVersion>9.4.51.v20230217</jettyVersion>
+    <jettyVersion>9.4.52.v20230823</jettyVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The older versions trigger nasty CVE reports. No real effect, as this is really just a test dependency.

---

https://issues.apache.org/jira/browse/MRESOLVER-406