### PR TITLE
[MRESOLVER-408] Make master 2.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
       ff-site-run: false
-      jdk-matrix: '[ "17" ]'
+      jdk-matrix: '[ "17", "21" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,6 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
       ff-site-run: false
-      maven_version: 3.9.5
       jdk-matrix: '[ "17" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,6 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
       ff-site-run: false
-
+      maven_version: 3.9.5
+      jdk-matrix: '[ "17" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
       ff-site-run: false
-      jdk-matrix: '[ "17", "21" ]'
+      jdk-matrix: '[ "11", "17", "21" ]'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,5 @@
  * under the License.
  */
 
-// Currently we can only build with JDK8+ based on the usage
-// of bnd-maven-plugin.
 asfMavenTlpStdBuild( 'jdks' : [ "17", "21" ] )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-asfMavenTlpStdBuild( 'jdks' : [ "17", "21" ] )
+asfMavenTlpStdBuild( 'jdks' : [ "11", "17", "21" ] )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,5 +19,5 @@
 
 // Currently we can only build with JDK8+ based on the usage
 // of bnd-maven-plugin.
-asfMavenTlpStdBuild( 'jdks' : [ "8", "11", "17" ] )
+asfMavenTlpStdBuild( 'jdks' : [ "17", "21" ] )
 

--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-api</artifactId>

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-connector-basic</artifactId>

--- a/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver-demos</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>resolver-demo-maven-plugin</artifactId>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver-demos</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-demo-snippets</artifactId>

--- a/maven-resolver-demos/pom.xml
+++ b/maven-resolver-demos/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-demos</artifactId>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-impl</artifactId>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks-hazelcast</artifactId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks-redisson</artifactId>

--- a/maven-resolver-named-locks/pom.xml
+++ b/maven-resolver-named-locks/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-named-locks</artifactId>

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-spi</artifactId>

--- a/maven-resolver-supplier/pom.xml
+++ b/maven-resolver-supplier/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-supplier</artifactId>

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-test-util</artifactId>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-classpath</artifactId>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-file</artifactId>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-http</artifactId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-transport-wagon</artifactId>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.resolver</groupId>
     <artifactId>maven-resolver</artifactId>
-    <version>1.9.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>maven-resolver-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <!-- used by supplier and demo only -->
     <mavenVersion>3.9.5</mavenVersion>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
-    <minimalJavaBuildVersion>[17.0.6,)</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>[11.0.20,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-10-10T21:40:45Z</project.build.outputTimestamp>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.maven.resolver</groupId>
   <artifactId>maven-resolver</artifactId>
-  <version>1.9.17-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Maven Artifact Resolver</name>
@@ -96,7 +96,7 @@
     <mavenVersion>3.9.4</mavenVersion>
     <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
-    <project.build.outputTimestamp>2023-09-22T18:13:46Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2023-10-10T21:40:45Z</project.build.outputTimestamp>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -85,17 +85,20 @@
 
   <properties>
     <javaVersion>8</javaVersion>
+    <maven.compiler.source>${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <maven.compiler.release>${javaVersion}</maven.compiler.release>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <failsafe.redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</failsafe.redirectTestOutputToFile>
     <maven.site.path>resolver-archives/resolver-LATEST</maven.site.path>
     <checkstyle.violation.ignore>None</checkstyle.violation.ignore>
-    <sisuVersion>0.3.5</sisuVersion>
-    <guiceVersion>5.1.0</guiceVersion>
+    <sisuVersion>0.9.0.M2</sisuVersion>
+    <guiceVersion>6.0.0</guiceVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <!-- used by supplier and demo only -->
-    <mavenVersion>3.9.4</mavenVersion>
-    <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
-    <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
+    <mavenVersion>3.9.5</mavenVersion>
+    <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
+    <minimalJavaBuildVersion>[17.0.6,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-10-10T21:40:45Z</project.build.outputTimestamp>
   </properties>
 
@@ -307,6 +310,27 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce-bytecode-version</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <enforceBytecodeVersion>
+                    <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
+                    <ignoredScopes>test</ignoredScopes>
+                  </enforceBytecodeVersion>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <detectOfflineLinks>false</detectOfflineLinks>
@@ -488,29 +512,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.23</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java18</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check-java-compat</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>process-classes</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -452,20 +452,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.eclipse.sisu</groupId>
-          <artifactId>sisu-maven-plugin</artifactId>
-          <version>${sisuVersion}</version>
-          <executions>
-            <execution>
-              <id>generate-index</id>
-              <goals>
-                <goal>main-index</goal>
-              </goals>
-              <phase>process-classes</phase>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
@@ -542,6 +528,22 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <proc>none</proc>
+          <compilerArgs>
+            <compilerArg>-Xlint:deprecation</compilerArg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,6 @@
 
   <properties>
     <javaVersion>8</javaVersion>
-    <maven.compiler.source>${javaVersion}</maven.compiler.source>
-    <maven.compiler.target>${javaVersion}</maven.compiler.target>
     <maven.compiler.release>${javaVersion}</maven.compiler.release>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <failsafe.redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</failsafe.redirectTestOutputToFile>
@@ -508,6 +506,38 @@
                 <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
               </manifestEntries>
             </archive>
+          </configuration>
+        </plugin>
+        <!-- Remove when Parent 41 used -->
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.40.0</version>
+          <configuration>
+            <java>
+              <!-- orders of used formatters are important MPOM-376 -->
+              <!-- eg. palantir override importOrder, so should be first -->
+              <palantirJavaFormat>
+                <version>2.38.0</version>
+              </palantirJavaFormat>
+              <removeUnusedImports />
+              <importOrder>
+                <file>config/maven-eclipse-importorder.txt</file>
+              </importOrder>
+              <licenseHeader>
+                <file>config/maven-header-plain.txt</file>
+              </licenseHeader>
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <!-- https://issues.apache.org/jira/browse/MRELEASE-1111 -->
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
           </configuration>
         </plugin>
       </plugins>

--- a/src/site/markdown/resolver-major-version-migration.md
+++ b/src/site/markdown/resolver-major-version-migration.md
@@ -1,0 +1,26 @@
+# Resolver major versions
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+This page will collect quick guides for developers upgrading from one to
+another major version of Resolver.
+
+# Upgrading from 1.x to 2.x
+
+Maven Resolver upcoming major version 2.x should be "smooth sailing", as long you
+do not depend (directly or indirectly) on **deprecated** classes from Resolver
+1.x line. Always use latest 1.x release to check for deprecated classes.

--- a/src/site/markdown/upgrading-resolver.md
+++ b/src/site/markdown/upgrading-resolver.md
@@ -1,4 +1,4 @@
-# Resolver major versions
+# Upgrading Resolver (major versions)
 <!---
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,7 +33,7 @@ under the License.
       <item name="About Local Repository" href="local-repository.html"/>
       <item name="Remote Repository Filtering" href="remote-repository-filtering.html"/>
       <item name="Third-party Integrations" href="third-party-integrations.html"/>
-      <item name="Upgrading Resolver" href="resolver-major-version-migration.html"/>
+      <item name="Upgrading Resolver" href="upgrading-resolver.html"/>
       <item name="Maven 3.8.x" href="maven-3.8.x.html"/>
       <item name="JavaDocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -33,6 +33,7 @@ under the License.
       <item name="About Local Repository" href="local-repository.html"/>
       <item name="Remote Repository Filtering" href="remote-repository-filtering.html"/>
       <item name="Third-party Integrations" href="third-party-integrations.html"/>
+      <item name="Upgrading Resolver" href="resolver-major-version-migration.html"/>
       <item name="Maven 3.8.x" href="maven-3.8.x.html"/>
       <item name="JavaDocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>


### PR DESCRIPTION
Changes:
* make version 2.0.0-SNAPSHOT
* build time JDK requirement: raise to 11 (raise as needed, preferably use LTS versions)
* existing modules are `release=8`
* drop animal sniffer
* redefine enforceBytecodeVersion: we do produce Java 8 stuff, but for **testing** we may want and will want to use something that is 8+ (ie. Jetty 12)
* fix sisu (was invoked twice, last parent POM update)
* compiler: proactively disable annotation processing (we do not use those, but Sisu APT is present, we do not want it auto-picked up, we explicitly index using sisu mojo)
* compiler: be chatty about deprecations, to help us down the line removing them

---

https://issues.apache.org/jira/browse/MRESOLVER-408