### PR TITLE
[MRESOLVER-409] More deprecation removal

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
@@ -52,16 +52,6 @@ public final class DefaultRemoteRepositoryFilterManager implements RemoteReposit
 
     private final Map<String, RemoteRepositoryFilterSource> sources;
 
-    /**
-     * SL enabled ctor.
-     *
-     * @deprecated for SL and testing purposes only.
-     */
-    @Deprecated
-    public DefaultRemoteRepositoryFilterManager() {
-        this.sources = new HashMap<>();
-    }
-
     @Inject
     public DefaultRemoteRepositoryFilterManager(Map<String, RemoteRepositoryFilterSource> sources) {
         this.sources = requireNonNull(sources);

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporterFactory.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporterFactory.java
@@ -21,8 +21,6 @@ package org.eclipse.aether.transport.http;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -41,24 +39,9 @@ import static java.util.Objects.requireNonNull;
 public final class HttpTransporterFactory implements TransporterFactory {
     public static final String NAME = "http";
 
-    private static Map<String, ChecksumExtractor> getManuallyCreatedExtractors() {
-        HashMap<String, ChecksumExtractor> map = new HashMap<>();
-        map.put(Nexus2ChecksumExtractor.NAME, new Nexus2ChecksumExtractor());
-        map.put(XChecksumChecksumExtractor.NAME, new XChecksumChecksumExtractor());
-        return Collections.unmodifiableMap(map);
-    }
-
     private float priority = 5.0f;
 
     private final Map<String, ChecksumExtractor> extractors;
-
-    /**
-     * Ctor for ServiceLocator.
-     */
-    @Deprecated
-    public HttpTransporterFactory() {
-        this(getManuallyCreatedExtractors());
-    }
 
     /**
      * Creates an (uninitialized) instance of this transporter factory. <em>Note:</em> In case of manual instantiation

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpServer.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpServer.java
@@ -25,7 +25,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -44,9 +46,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
@@ -484,7 +484,7 @@ public class HttpServer {
                 String method = credentials.substring(0, space);
                 if ("basic".equalsIgnoreCase(method)) {
                     credentials = credentials.substring(space + 1);
-                    credentials = B64Code.decode(credentials, StringUtil.__ISO_8859_1);
+                    credentials = new String(Base64.getDecoder().decode(credentials), StandardCharsets.ISO_8859_1);
                     int i = credentials.indexOf(':');
                     if (i > 0) {
                         String user = credentials.substring(0, i);

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/HttpTransporterTest.java
@@ -105,7 +105,10 @@ public class HttpTransporterTest {
     void setUp(TestInfo testInfo) throws Exception {
         System.out.println("=== " + testInfo.getDisplayName() + " ===");
         session = TestUtils.newSession();
-        factory = new HttpTransporterFactory();
+        HashMap<String, ChecksumExtractor> extractors = new HashMap<>();
+        extractors.put(XChecksumChecksumExtractor.NAME, new XChecksumChecksumExtractor());
+        extractors.put(Nexus2ChecksumExtractor.NAME, new Nexus2ChecksumExtractor());
+        factory = new HttpTransporterFactory(extractors);
         repoDir = TestFileUtils.createTempDir();
         TestFileUtils.writeString(new File(repoDir, "file.txt"), "test");
         TestFileUtils.writeString(new File(repoDir, "dir/file.txt"), "test");


### PR DESCRIPTION
Now the last bit remaining is ChecksumUtils that is to be handled in different issue. This PR merely removes all the compiler warnings about deprecation but ChecksumUtils.

---

https://issues.apache.org/jira/browse/MRESOLVER-409