### PR TITLE
[MRESOLVER-420] Cache prioritized components

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -56,6 +56,21 @@ public final class ConfigurationProperties {
     public static final boolean DEFAULT_IMPLICIT_PRIORITIES = false;
 
     /**
+     * A flag indicating whether the created ordered components should be cached or not.
+     *
+     * @see #DEFAULT_CACHED_PRIORITIES
+     * @since TBD
+     */
+    public static final String CACHED_PRIORITIES = PREFIX_PRIORITY + "cached";
+
+    /**
+     * The default caching of priority components if {@link #CACHED_PRIORITIES} isn't set. Default value is {@code true}.
+     *
+     * @since TBD
+     */
+    public static final boolean DEFAULT_CACHED_PRIORITIES = true;
+
+    /**
      * A flag indicating whether interaction with the user is allowed.
      *
      * @see #DEFAULT_INTERACTIVE

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultDeployer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultDeployer.java
@@ -234,7 +234,7 @@ public class DefaultDeployer implements Deployer {
     private List<? extends MetadataGenerator> getMetadataGenerators(
             RepositorySystemSession session, DeployRequest request) {
         PrioritizedComponents<MetadataGeneratorFactory> factories =
-                Utils.sortMetadataGeneratorFactories(session, this.metadataFactories.values());
+                Utils.sortMetadataGeneratorFactories(session, metadataFactories);
 
         List<MetadataGenerator> generators = new ArrayList<>();
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultInstaller.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultInstaller.java
@@ -151,7 +151,7 @@ public class DefaultInstaller implements Installer {
     private List<? extends MetadataGenerator> getMetadataGenerators(
             RepositorySystemSession session, InstallRequest request) {
         PrioritizedComponents<MetadataGeneratorFactory> factories =
-                Utils.sortMetadataGeneratorFactories(session, this.metadataFactories.values());
+                Utils.sortMetadataGeneratorFactories(session, metadataFactories);
 
         List<MetadataGenerator> generators = new ArrayList<>();
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
@@ -61,7 +61,11 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        PrioritizedComponents<LocalRepositoryManagerFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.localRepositoryManagerFactories.values(), LocalRepositoryManagerFactory::getPriority);
+        PrioritizedComponents<LocalRepositoryManagerFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session,
+                PRIORITIZED_COMPONENTS,
+                this.localRepositoryManagerFactories.values(),
+                LocalRepositoryManagerFactory::getPriority);
 
         List<NoLocalRepositoryManagerException> errors = new ArrayList<>();
         for (PrioritizedComponent<LocalRepositoryManagerFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
@@ -46,6 +46,8 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLocalRepositoryProvider.class);
 
+    private static final String PRIORITIZED_COMPONENTS = DefaultLocalRepositoryProvider.class.getName() + ".pc";
+
     private final Map<String, LocalRepositoryManagerFactory> localRepositoryManagerFactories;
 
     @Inject
@@ -58,10 +60,8 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
             throws NoLocalRepositoryManagerException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
-        PrioritizedComponents<LocalRepositoryManagerFactory> factories = new PrioritizedComponents<>(session);
-        for (LocalRepositoryManagerFactory factory : this.localRepositoryManagerFactories.values()) {
-            factories.add(factory, factory.getPriority());
-        }
+
+        PrioritizedComponents<LocalRepositoryManagerFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.localRepositoryManagerFactories.values(), LocalRepositoryManagerFactory::getPriority);
 
         List<NoLocalRepositoryManagerException> errors = new ArrayList<>();
         for (PrioritizedComponent<LocalRepositoryManagerFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
@@ -46,8 +46,6 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLocalRepositoryProvider.class);
 
-    private static final String PRIORITIZED_COMPONENTS = DefaultLocalRepositoryProvider.class.getName() + ".pc";
-
     private final Map<String, LocalRepositoryManagerFactory> localRepositoryManagerFactories;
 
     @Inject
@@ -62,10 +60,7 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
         requireNonNull(repository, "repository cannot be null");
 
         PrioritizedComponents<LocalRepositoryManagerFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session,
-                PRIORITIZED_COMPONENTS,
-                this.localRepositoryManagerFactories.values(),
-                LocalRepositoryManagerFactory::getPriority);
+                session, localRepositoryManagerFactories, LocalRepositoryManagerFactory::getPriority);
 
         List<NoLocalRepositoryManagerException> errors = new ArrayList<>();
         for (PrioritizedComponent<LocalRepositoryManagerFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
@@ -51,6 +51,8 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryConnectorProvider.class);
 
+    private static final String PRIORITIZED_COMPONENTS = DefaultRepositoryConnectorProvider.class.getName() + ".pc";
+
     private final Map<String, RepositoryConnectorFactory> connectorFactories;
 
     private final RemoteRepositoryFilterManager remoteRepositoryFilterManager;
@@ -77,13 +79,9 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
             }
         }
 
+        PrioritizedComponents<RepositoryConnectorFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.connectorFactories.values(), RepositoryConnectorFactory::getPriority);
+
         RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter(session);
-
-        PrioritizedComponents<RepositoryConnectorFactory> factories = new PrioritizedComponents<>(session);
-        for (RepositoryConnectorFactory factory : this.connectorFactories.values()) {
-            factories.add(factory, factory.getPriority());
-        }
-
         List<NoRepositoryConnectorException> errors = new ArrayList<>();
         for (PrioritizedComponent<RepositoryConnectorFactory> factory : factories.getEnabled()) {
             try {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
@@ -79,7 +79,11 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
             }
         }
 
-        PrioritizedComponents<RepositoryConnectorFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.connectorFactories.values(), RepositoryConnectorFactory::getPriority);
+        PrioritizedComponents<RepositoryConnectorFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session,
+                PRIORITIZED_COMPONENTS,
+                this.connectorFactories.values(),
+                RepositoryConnectorFactory::getPriority);
 
         RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter(session);
         List<NoRepositoryConnectorException> errors = new ArrayList<>();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
@@ -51,8 +51,6 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryConnectorProvider.class);
 
-    private static final String PRIORITIZED_COMPONENTS = DefaultRepositoryConnectorProvider.class.getName() + ".pc";
-
     private final Map<String, RepositoryConnectorFactory> connectorFactories;
 
     private final RemoteRepositoryFilterManager remoteRepositoryFilterManager;
@@ -80,10 +78,7 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
         }
 
         PrioritizedComponents<RepositoryConnectorFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session,
-                PRIORITIZED_COMPONENTS,
-                this.connectorFactories.values(),
-                RepositoryConnectorFactory::getPriority);
+                session, connectorFactories, RepositoryConnectorFactory::getPriority);
 
         RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter(session);
         List<NoRepositoryConnectorException> errors = new ArrayList<>();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
@@ -46,6 +46,8 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryLayoutProvider.class);
 
+    private static final String PRIORITIZED_COMPONENTS = DefaultRepositoryLayoutProvider.class.getName() + ".pc";
+
     private final Map<String, RepositoryLayoutFactory> layoutFactories;
 
     @Inject
@@ -59,10 +61,7 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "remote repository cannot be null");
 
-        PrioritizedComponents<RepositoryLayoutFactory> factories = new PrioritizedComponents<>(session);
-        for (RepositoryLayoutFactory factory : this.layoutFactories.values()) {
-            factories.add(factory, factory.getPriority());
-        }
+        PrioritizedComponents<RepositoryLayoutFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.layoutFactories.values(), RepositoryLayoutFactory::getPriority);
 
         List<NoRepositoryLayoutException> errors = new ArrayList<>();
         for (PrioritizedComponent<RepositoryLayoutFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
@@ -61,7 +61,8 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "remote repository cannot be null");
 
-        PrioritizedComponents<RepositoryLayoutFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.layoutFactories.values(), RepositoryLayoutFactory::getPriority);
+        PrioritizedComponents<RepositoryLayoutFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session, PRIORITIZED_COMPONENTS, this.layoutFactories.values(), RepositoryLayoutFactory::getPriority);
 
         List<NoRepositoryLayoutException> errors = new ArrayList<>();
         for (PrioritizedComponent<RepositoryLayoutFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
@@ -46,8 +46,6 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryLayoutProvider.class);
 
-    private static final String PRIORITIZED_COMPONENTS = DefaultRepositoryLayoutProvider.class.getName() + ".pc";
-
     private final Map<String, RepositoryLayoutFactory> layoutFactories;
 
     @Inject
@@ -61,8 +59,8 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "remote repository cannot be null");
 
-        PrioritizedComponents<RepositoryLayoutFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session, PRIORITIZED_COMPONENTS, this.layoutFactories.values(), RepositoryLayoutFactory::getPriority);
+        PrioritizedComponents<RepositoryLayoutFactory> factories =
+                PrioritizedComponents.reuseOrCreate(session, layoutFactories, RepositoryLayoutFactory::getPriority);
 
         List<NoRepositoryLayoutException> errors = new ArrayList<>();
         for (PrioritizedComponent<RepositoryLayoutFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
@@ -61,7 +61,8 @@ public final class DefaultTransporterProvider implements TransporterProvider {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        PrioritizedComponents<TransporterFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.transporterFactories.values(), TransporterFactory::getPriority);
+        PrioritizedComponents<TransporterFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session, PRIORITIZED_COMPONENTS, this.transporterFactories.values(), TransporterFactory::getPriority);
 
         List<NoTransporterException> errors = new ArrayList<>();
         for (PrioritizedComponent<TransporterFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
@@ -46,8 +46,6 @@ public final class DefaultTransporterProvider implements TransporterProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTransporterProvider.class);
 
-    private static final String PRIORITIZED_COMPONENTS = DefaultTransporterProvider.class.getName() + ".pc";
-
     private final Map<String, TransporterFactory> transporterFactories;
 
     @Inject
@@ -61,8 +59,8 @@ public final class DefaultTransporterProvider implements TransporterProvider {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        PrioritizedComponents<TransporterFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session, PRIORITIZED_COMPONENTS, this.transporterFactories.values(), TransporterFactory::getPriority);
+        PrioritizedComponents<TransporterFactory> factories =
+                PrioritizedComponents.reuseOrCreate(session, transporterFactories, TransporterFactory::getPriority);
 
         List<NoTransporterException> errors = new ArrayList<>();
         for (PrioritizedComponent<TransporterFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
@@ -46,6 +46,8 @@ public final class DefaultTransporterProvider implements TransporterProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTransporterProvider.class);
 
+    private static final String PRIORITIZED_COMPONENTS = DefaultTransporterProvider.class.getName() + ".pc";
+
     private final Map<String, TransporterFactory> transporterFactories;
 
     @Inject
@@ -59,10 +61,7 @@ public final class DefaultTransporterProvider implements TransporterProvider {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        PrioritizedComponents<TransporterFactory> factories = new PrioritizedComponents<>(session);
-        for (TransporterFactory factory : this.transporterFactories.values()) {
-            factories.add(factory, factory.getPriority());
-        }
+        PrioritizedComponents<TransporterFactory> factories = PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, this.transporterFactories.values(), TransporterFactory::getPriority);
 
         List<NoTransporterException> errors = new ArrayList<>();
         for (PrioritizedComponent<TransporterFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -48,7 +48,7 @@ final class PrioritizedComponents<T> {
         return (PrioritizedComponents<C>) session.getData().computeIfAbsent(key, () -> {
             PrioritizedComponents<C> newInstance = new PrioritizedComponents<>(session);
             components.forEach(c -> newInstance.add(c, priorityFunction.apply(c)));
-            return components;
+            return newInstance;
         });
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -39,8 +39,12 @@ final class PrioritizedComponents<T> {
      *
      * @since TBD
      */
-    @SuppressWarnings( "unchecked" )
-    public static <C> PrioritizedComponents<C> reuseOrCreate(RepositorySystemSession session, String key, Collection<C> components, Function<C,Float> priorityFunction) {
+    @SuppressWarnings("unchecked")
+    public static <C> PrioritizedComponents<C> reuseOrCreate(
+            RepositorySystemSession session,
+            String key,
+            Collection<C> components,
+            Function<C, Float> priorityFunction) {
         return (PrioritizedComponents<C>) session.getData().computeIfAbsent(key, () -> {
             PrioritizedComponents<C> newInstance = new PrioritizedComponents<>(session);
             components.forEach(c -> newInstance.add(c, priorityFunction.apply(c)));

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -19,9 +19,11 @@
 package org.eclipse.aether.internal.impl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.RepositorySystemSession;
@@ -31,6 +33,20 @@ import org.eclipse.aether.util.ConfigUtils;
  * Helps to sort pluggable components by their priority.
  */
 final class PrioritizedComponents<T> {
+    /**
+     * Reuses or creates and stores (if session data does not contain yet) prioritized components under this key into
+     * given session. Same session is used to configure prioritized components.
+     *
+     * @since TBD
+     */
+    @SuppressWarnings( "unchecked" )
+    public static <C> PrioritizedComponents<C> reuseOrCreate(RepositorySystemSession session, String key, Collection<C> components, Function<C,Float> priorityFunction) {
+        return (PrioritizedComponents<C>) session.getData().computeIfAbsent(key, () -> {
+            PrioritizedComponents<C> newInstance = new PrioritizedComponents<>(session);
+            components.forEach(c -> newInstance.add(c, priorityFunction.apply(c)));
+            return components;
+        });
+    }
 
     private static final String FACTORY_SUFFIX = "Factory";
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
@@ -31,8 +31,6 @@ import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicyRequest;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
 import org.eclipse.aether.transfer.RepositoryOfflineException;
 
 /**
@@ -44,7 +42,8 @@ final class Utils {
 
     public static PrioritizedComponents<MetadataGeneratorFactory> sortMetadataGeneratorFactories(
             RepositorySystemSession session, Collection<MetadataGeneratorFactory> factories) {
-        return PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, factories, MetadataGeneratorFactory::getPriority);
+        return PrioritizedComponents.reuseOrCreate(
+                session, PRIORITIZED_COMPONENTS, factories, MetadataGeneratorFactory::getPriority);
     }
 
     public static List<Metadata> prepareMetadata(

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
@@ -31,6 +31,8 @@ import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicyRequest;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
 import org.eclipse.aether.transfer.RepositoryOfflineException;
 
 /**
@@ -38,13 +40,11 @@ import org.eclipse.aether.transfer.RepositoryOfflineException;
  */
 final class Utils {
 
+    private static final String PRIORITIZED_COMPONENTS = Utils.class.getName() + ".pc";
+
     public static PrioritizedComponents<MetadataGeneratorFactory> sortMetadataGeneratorFactories(
-            RepositorySystemSession session, Collection<? extends MetadataGeneratorFactory> factories) {
-        PrioritizedComponents<MetadataGeneratorFactory> result = new PrioritizedComponents<>(session);
-        for (MetadataGeneratorFactory factory : factories) {
-            result.add(factory, factory.getPriority());
-        }
-        return result;
+            RepositorySystemSession session, Collection<MetadataGeneratorFactory> factories) {
+        return PrioritizedComponents.reuseOrCreate(session, PRIORITIZED_COMPONENTS, factories, MetadataGeneratorFactory::getPriority);
     }
 
     public static List<Metadata> prepareMetadata(

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -38,12 +39,9 @@ import org.eclipse.aether.transfer.RepositoryOfflineException;
  */
 final class Utils {
 
-    private static final String PRIORITIZED_COMPONENTS = Utils.class.getName() + ".pc";
-
     public static PrioritizedComponents<MetadataGeneratorFactory> sortMetadataGeneratorFactories(
-            RepositorySystemSession session, Collection<MetadataGeneratorFactory> factories) {
-        return PrioritizedComponents.reuseOrCreate(
-                session, PRIORITIZED_COMPONENTS, factories, MetadataGeneratorFactory::getPriority);
+            RepositorySystemSession session, Map<String, MetadataGeneratorFactory> factories) {
+        return PrioritizedComponents.reuseOrCreate(session, factories, MetadataGeneratorFactory::getPriority);
     }
 
     public static List<Metadata> prepareMetadata(

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -85,6 +85,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.metadataResolver.threads` | int | Number of threads to use in parallel for resolving metadata. | `4` | no
 `aether.offline.protocols` | String | Comma-separated list of protocols which are supposed to be resolved offline. | - | no
 `aether.offline.hosts` | String | Comma-separated list of hosts which are supposed to be resolved offline. | - | no
+`aether.priority.cached` | boolean | Whether the created ordered list of components should be cached (in session) or not. | `true` | no
 `aether.priority.<class>` | float | The priority to use for a certain extension class. `class` can either be the fully qualified name or the simple name stands for fully qualified class name. If the class name ends with `Factory` that suffix could optionally be left out. | - |  no
 `aether.priority.implicit` | boolean | Flag indicating whether the priorities of pluggable extensions are implicitly given by their iteration order such that the first extension has the highest priority. If set, an extension's built-in priority as well as any corresponding `aether.priority.<class>` configuration properties are ignored when searching for a suitable implementation among the available extensions. This priority mode is meant for cases where the application will present/inject extensions in the desired search order. | `false` | no
 `aether.remoteRepositoryFilter.groupId` | boolean | Enable `groupId` remote repository filter. | `false` | no


### PR DESCRIPTION
Cache them, as creating of those is not cheap, but detect (dynamic injected) map changes. Allow users to disable this feature, in case of fire.

---

https://issues.apache.org/jira/browse/MRESOLVER-420