### PR TITLE
[MRESOLVER-392] Remove change detection logic on install

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -325,7 +325,7 @@ public class DefaultInstallerTest {
     }
 
     @Test
-    @Disabled("Change detection is removed")
+    @Disabled("Naive change detection is removed (MRESOLVER-392)")
     void testDoNotUpdateUnchangedArtifact() throws InstallationException {
         request.addArtifact(artifact);
         installer.install(session, request);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -347,21 +347,6 @@ public class DefaultInstallerTest {
     }
 
     @Test
-    void testMissingSourceFails() {
-        artifact = artifact.setFile(new File("nonexistent artifact"));
-        request.addArtifact(artifact);
-        assertThrows(InstallationException.class, () -> installer.install(session, request));
-    }
-
-    @Test
-    void testMissingSourceSilentlySkippedIfSet() throws InstallationException {
-        session.setConfigProperty(DefaultInstaller.CONFIG_PROP_IGNORE_MISSING_FILE_INSTALL, true);
-        artifact = artifact.setFile(new File("nonexistent artifact"));
-        request.addArtifact(artifact);
-        installer.install(session, request);
-    }
-
-    @Test
     void testSetArtifactTimestamps() throws InstallationException {
         artifact.getFile().setLastModified(artifact.getFile().lastModified() - 60000);
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -40,6 +40,7 @@ import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.Metadata.Nature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -324,6 +325,7 @@ public class DefaultInstallerTest {
     }
 
     @Test
+    @Disabled("Change detection is removed")
     void testDoNotUpdateUnchangedArtifact() throws InstallationException {
         request.addArtifact(artifact);
         installer.install(session, request);
@@ -340,6 +342,21 @@ public class DefaultInstallerTest {
                 new StubSyncContextFactory());
 
         request = new InstallRequest();
+        request.addArtifact(artifact);
+        installer.install(session, request);
+    }
+
+    @Test
+    void testMissingSourceFails() {
+        artifact = artifact.setFile(new File("nonexistent artifact"));
+        request.addArtifact(artifact);
+        assertThrows(InstallationException.class, () -> installer.install(session, request));
+    }
+
+    @Test
+    void testMissingSourceSilentlySkippedIfSet() throws InstallationException {
+        session.setConfigProperty(DefaultInstaller.CONFIG_PROP_IGNORE_MISSING_FILE_INSTALL, true);
+        artifact = artifact.setFile(new File("nonexistent artifact"));
         request.addArtifact(artifact);
         installer.install(session, request);
     }


### PR DESCRIPTION
Still, make possible to restore the "skip if missing" as I find no reasonong for it, but my guess is that it may be about some legacy code somewhere, most probably adding Metadata without backing file (as in Maven2 metadata was added by hand).

---

https://issues.apache.org/jira/browse/MRESOLVER-392