### PR TITLE
[MRESOLVER-424] Make graph dumper extensible

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/DependencyGraphDumper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/DependencyGraphDumper.java
@@ -18,9 +18,9 @@
  */
 package org.eclipse.aether.util.graph.visitor;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.Consumer;
 
 import org.eclipse.aether.artifact.Artifact;
@@ -43,7 +43,7 @@ public class DependencyGraphDumper implements DependencyVisitor {
 
     private final Consumer<String> consumer;
 
-    private final List<ChildInfo> childInfos = new ArrayList<>();
+    private final Deque<DependencyNode> nodes = new ArrayDeque<>();
 
     public DependencyGraphDumper(Consumer<String> consumer) {
         this.consumer = requireNonNull(consumer);
@@ -51,24 +51,50 @@ public class DependencyGraphDumper implements DependencyVisitor {
 
     @Override
     public boolean visitEnter(DependencyNode node) {
-        consumer.accept(formatIndentation() + formatNode(node));
-        childInfos.add(new ChildInfo(node.getChildren().size()));
+        nodes.push(node);
+        consumer.accept(formatLine(nodes));
         return true;
     }
 
-    private String formatIndentation() {
+    @Override
+    public boolean visitLeave(DependencyNode node) {
+        if (!nodes.isEmpty()) {
+            nodes.pop();
+        }
+        return true;
+    }
+
+    protected String formatLine(Deque<DependencyNode> nodes) {
+        return formatIndentation(nodes) + formatNode(nodes);
+    }
+
+    protected String formatIndentation(Deque<DependencyNode> nodes) {
         StringBuilder buffer = new StringBuilder(128);
-        for (Iterator<ChildInfo> it = childInfos.iterator(); it.hasNext(); ) {
-            buffer.append(it.next().formatIndentation(!it.hasNext()));
+        Iterator<DependencyNode> iter = nodes.descendingIterator();
+        DependencyNode parent = iter.hasNext() ? iter.next() : null;
+        DependencyNode child = iter.hasNext() ? iter.next() : null;
+        while (parent != null && child != null) {
+            boolean lastChild = parent.getChildren().get(parent.getChildren().size() - 1) == child;
+            boolean end = child == nodes.peekFirst();
+            String indent;
+            if (end) {
+                indent = lastChild ? "\\- " : "+- ";
+            } else {
+                indent = lastChild ? "   " : "|  ";
+            }
+            buffer.append(indent);
+            parent = child;
+            child = iter.hasNext() ? iter.next() : null;
         }
         return buffer.toString();
     }
 
-    private String formatNode(DependencyNode node) {
+    protected String formatNode(Deque<DependencyNode> nodes) {
+        DependencyNode node = requireNonNull(nodes.peek(), "bug: should not happen");
         StringBuilder buffer = new StringBuilder(128);
         Artifact a = node.getArtifact();
-        Dependency d = node.getDependency();
         buffer.append(a);
+        Dependency d = node.getDependency();
         if (d != null && !d.getScope().isEmpty()) {
             buffer.append(" [").append(d.getScope());
             if (d.isOptional()) {
@@ -101,35 +127,5 @@ public class DependencyGraphDumper implements DependencyVisitor {
             }
         }
         return buffer.toString();
-    }
-
-    @Override
-    public boolean visitLeave(DependencyNode node) {
-        if (!childInfos.isEmpty()) {
-            childInfos.remove(childInfos.size() - 1);
-        }
-        if (!childInfos.isEmpty()) {
-            childInfos.get(childInfos.size() - 1).index++;
-        }
-        return true;
-    }
-
-    private static class ChildInfo {
-
-        final int count;
-
-        int index;
-
-        ChildInfo(int count) {
-            this.count = count;
-        }
-
-        public String formatIndentation(boolean end) {
-            boolean last = index + 1 >= count;
-            if (end) {
-                return last ? "\\- " : "+- ";
-            }
-            return last ? "   " : "|  ";
-        }
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/visitor/DependencyGraphDumperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/visitor/DependencyGraphDumperTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.graph.visitor;
+
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.internal.test.util.DependencyGraphParser;
+import org.junit.jupiter.api.Test;
+
+public class DependencyGraphDumperTest {
+
+    private DependencyNode parse(String resource) throws Exception {
+        return new DependencyGraphParser("visitor/ordered-list/").parseResource(resource);
+    }
+
+    @Test
+    void dumpSimple() throws Exception {
+        DependencyNode root = parse("simple.txt");
+        root.accept(new DependencyGraphDumper(System.out::println));
+    }
+
+    @Test
+    void dumpCycles() throws Exception {
+        DependencyNode root = parse("cycles.txt");
+        root.accept(new TreeDependencyVisitor(new DependencyGraphDumper(System.out::println)));
+    }
+}


### PR DESCRIPTION
Make graph dumper extensible, as it is meant to be reusable, but not everyone may want same info on output. Also, most of the methods were private...

---

https://issues.apache.org/jira/browse/MRESOLVER-424