### PR TITLE
[MRESOLVER-430] Build time Java 21 required

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
+      ff-run: false
       ff-site-run: false
       jdk-matrix: '[ "21" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,5 +27,5 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
       ff-site-run: false
-      jdk-matrix: '[ "11", "17", "21" ]'
+      jdk-matrix: '[ "21" ]'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-asfMavenTlpStdBuild( 'jdks' : [ "11", "17", "21" ] )
+asfMavenTlpStdBuild( 'jdks' : [ "21" ] )
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!-- used by supplier and demo only -->
     <mavenVersion>4.0.0-alpha-8</mavenVersion>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
-    <minimalJavaBuildVersion>[11.0.16,)</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>[21.0.1,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-11-02T11:01:10Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
Actually, 21.0.1 as 21 had a bug that one of two needed preconditions are always met in case of Maven (m-compiler-p always sets debug=true).

---

https://issues.apache.org/jira/browse/MRESOLVER-430