### PR TITLE
[MRESOLVER-422] Fix javadoc configuration

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-19/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-19/pom.xml
@@ -37,6 +37,9 @@
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
 
     <javaVersion>19</javaVersion>
+    <!-- Different workarounds for site -->
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <pmd.skip>true</pmd.skip>
   </properties>
 
   <dependencies>

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
@@ -37,6 +37,9 @@
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
 
     <javaVersion>21</javaVersion>
+    <!-- Different workarounds for site -->
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <pmd.skip>true</pmd.skip>
   </properties>
 
   <dependencies>

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
@@ -36,7 +36,7 @@
     <Automatic-Module-Name>org.apache.maven.resolver.transport.jdk</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
 
-    <javaVersion>19</javaVersion>
+    <javaVersion>21</javaVersion>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <!-- used by supplier and demo only -->
     <mavenVersion>4.0.0-alpha-8</mavenVersion>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
+    <!-- MRESOLVER-422: keep this in sync with Javadoc plugin configuration (but cannot directly, as this below is range) -->
     <minimalJavaBuildVersion>[21.0.1,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-11-02T11:01:10Z</project.build.outputTimestamp>
   </properties>
@@ -400,7 +401,7 @@
             <legacyMode>true</legacyMode>
             <release>11</release>
             <links>
-              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+              <link>https://docs.oracle.com/en/java/javase/21/docs/api/</link>
             </links>
             <tags>
               <tag>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
             <linksource>true</linksource>
             <notimestamp>true</notimestamp>
             <legacyMode>true</legacyMode>
-            <release>11</release>
+            <release>21</release>
             <links>
               <link>https://docs.oracle.com/en/java/javase/21/docs/api/</link>
             </links>


### PR DESCRIPTION
Not much to fix really, but simply put the "minimally required Java" and Javadoc URL needs to be kept in sync. But, as former is a range, latter is a "base version", it goes only manually.

Hence, I left a note in POM for this.

Site related fixes:
* Javadoc craps out on 19 and 21 JDK transport modules (nothing to document).
* PMD does not supports Java 21.

---

https://issues.apache.org/jira/browse/MRESOLVER-422