### PR TITLE
[MRESOLVER-372] Rework the FileUtils collocated temp file

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.util;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -105,7 +106,11 @@ public final class FileUtils {
 
             @Override
             public void move() throws IOException {
-                Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE);
+                try {
+                    Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE);
+                } catch (AccessDeniedException e) {
+                    Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+                }
             }
 
             @Override


### PR DESCRIPTION
Fixes:
* move() call should NOT perform the move, as writer stream to tmp file may still be open
* move the file move logic to close, make it happen only when closing collocated temp file
* perform fsync before atomic move to ensure there is no OS dirty buffers related to newly written file
* on windows go with old code that for some reason works (avoid NIO2)
* on non-Win OS fsync the parent directory as well.

---

https://issues.apache.org/jira/browse/MRESOLVER-372

Backport to 1.9.x branch of the https://github.com/apache/maven-resolver/pull/364