### PR TITLE
[MRESOLVER-437] Resolver should not override given HTTP transport default use of expect-continue handshake

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -261,19 +261,13 @@ public final class ConfigurationProperties {
 
     /**
      * Boolean flag should the HTTP transport use expect-continue handshake for PUT requests. Not all transport support
-     * this option. This option may be needed for some broken HTTP servers.
+     * this option. This option may be needed for some broken HTTP servers. Default value corresponds to given
+     * transport default one (resolver does not override those), but if configuration IS given, it will replace
+     * given transport own default value.
      *
-     * @see #DEFAULT_HTTP_EXPECT_CONTINUE
      * @since 1.9.17
      */
     public static final String HTTP_EXPECT_CONTINUE = PREFIX_CONNECTOR + "http.expectContinue";
-
-    /**
-     * Default value if {@link #HTTP_EXPECT_CONTINUE} is not set: {@code true}.
-     *
-     * @since 1.9.17
-     */
-    public static final boolean DEFAULT_HTTP_EXPECT_CONTINUE = true;
 
     /**
      * The mode that sets HTTPS transport "security mode": to ignore any SSL errors (certificate validity checks,

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -323,13 +323,13 @@ final class HttpTransporter extends AbstractTransporter {
             builder.useSystemProperties();
         }
 
-        final boolean expectContinue = ConfigUtils.getBoolean(
+        final String expectContinue = ConfigUtils.getString(
                 session,
-                ConfigurationProperties.DEFAULT_HTTP_EXPECT_CONTINUE,
+                null,
                 ConfigurationProperties.HTTP_EXPECT_CONTINUE + "." + repository.getId(),
                 ConfigurationProperties.HTTP_EXPECT_CONTINUE);
-        if (expectContinue != ConfigurationProperties.DEFAULT_HTTP_EXPECT_CONTINUE) {
-            state.setExpectContinue(expectContinue);
+        if (expectContinue != null) {
+            state.setExpectContinue(Boolean.parseBoolean(expectContinue));
         }
 
         final boolean reuseConnections = ConfigUtils.getBoolean(

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -38,7 +38,7 @@ Option | Type | Description | Default Value | Supports Repo ID Suffix
 `aether.connector.http.cacheState` | boolean | Flag indicating whether a memory-based cache is used for user tokens, connection managers, expect continue requests and authentication schemes. | `true` | no
 `aether.connector.http.connectionMaxTtl` | int | Total time to live in seconds for an HTTP connection, after that time, the connection will be dropped (no matter for how long it was idle). | `300` | yes
 `aether.connector.http.credentialEncoding` | String | The encoding/charset to use when exchanging credentials with HTTP servers. | `"ISO-8859-1"` | yes
-`aether.connector.http.expectContinue` | boolean | Whether to use expect/continue handshake during PUTs. Some broken HTTP servers needs this disabled. | `true` | yes
+`aether.connector.http.expectContinue` | boolean | Whether to use expect/continue handshake during PUTs. Some broken HTTP servers needs this disabled. Default value depends on given transport default value. | Default value depends on HTTP transport being in use. | yes
 `aether.connector.http.headers` | `Map<String, String>` | The request headers to use for HTTP-based repository connectors. The headers are specified using a map of strings mapping a header name to its value. The repository-specific headers map is supposed to be complete, i.e. is not merged with the general headers map. | - | yes
 `aether.connector.http.maxConnectionsPerRoute` | int | The maximum concurrent connections per route HTTP client is allowed to use. | `50` | yes
 `aether.connector.http.preemptiveAuth` | boolean | Should HTTP client use preemptive-authentication for all HTTP verbs (works only w/ BASIC). By default is disabled, as it is considered less secure. | `false` | yes


### PR DESCRIPTION
Backport of MRESOLVER-437 to 1.9.x branch (only relevant parts): 
https://github.com/apache/maven-resolver/commit/a70ddef13490a4289e4a72327217218e688e4070

---

https://issues.apache.org/jira/browse/MRESOLVER-437