### PR TITLE
[MRESOLVER-321] Make collection and visiting interruptable

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -286,7 +286,7 @@ public final class DefaultDependencyNode implements DependencyNode {
     }
 
     public boolean accept(DependencyVisitor visitor) {
-        if (Thread.interrupted()) {
+        if (Thread.currentThread().isInterrupted()) {
             throw new RuntimeException("Thread interrupted");
         }
         if (visitor.visitEnter(this)) {

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -287,7 +287,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     public boolean accept(DependencyVisitor visitor) {
         if (Thread.currentThread().isInterrupted()) {
-            throw new RuntimeException("Thread interrupted");
+            throw new RuntimeException(new InterruptedException("Thread interrupted"));
         }
         if (visitor.visitEnter(this)) {
             for (DependencyNode child : children) {

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -286,6 +286,9 @@ public final class DefaultDependencyNode implements DependencyNode {
     }
 
     public boolean accept(DependencyVisitor visitor) {
+        if (Thread.interrupted()) {
+            throw new RuntimeException("Thread interrupted");
+        }
         if (visitor.visitEnter(this)) {
             for (DependencyNode child : children) {
                 if (!child.accept(visitor)) {

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.graph;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ */
+public class DefaultDependencyNodeTest {
+    @Test
+    void testVisitorInterrupt() throws Exception {
+        DefaultDependencyNode node =
+                new DefaultDependencyNode(new Dependency(new DefaultArtifact("gid:aid:ver"), "compile"));
+        // we just use dummy visitor, as it is not visiting that matters
+        DependencyVisitor visitor = new DependencyVisitor() {
+            @Override
+            public boolean visitEnter(DependencyNode node) {
+                return true;
+            }
+
+            @Override
+            public boolean visitLeave(DependencyNode node) {
+                return true;
+            }
+        };
+        AtomicReference<Object> thrown = new AtomicReference<>(null);
+        Thread t = new Thread(() -> {
+            Thread.currentThread().interrupt();
+            try {
+                node.accept(visitor);
+                fail("Should fail");
+            } catch (Exception e) {
+                thrown.set(e);
+            }
+        });
+        t.start();
+        t.join();
+
+        assertTrue(thrown.get() instanceof RuntimeException, String.valueOf(thrown.get()));
+    }
+}

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
@@ -45,7 +45,7 @@ public class DefaultDependencyNodeTest {
                 return true;
             }
         };
-        AtomicReference<Object> thrown = new AtomicReference<>(null);
+        AtomicReference<Exception> thrown = new AtomicReference<>(null);
         Thread t = new Thread(() -> {
             Thread.currentThread().interrupt();
             try {
@@ -59,9 +59,7 @@ public class DefaultDependencyNodeTest {
         t.join();
 
         assertTrue(thrown.get() instanceof RuntimeException, String.valueOf(thrown.get()));
-        assertTrue(
-                ((RuntimeException) thrown.get()).getCause() instanceof InterruptedException,
-                String.valueOf(thrown.get()));
+        assertTrue(thrown.get().getCause() instanceof InterruptedException, String.valueOf(thrown.get()));
         assertTrue(t.isInterrupted());
     }
 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
@@ -59,5 +59,6 @@ public class DefaultDependencyNodeTest {
         t.join();
 
         assertTrue(thrown.get() instanceof RuntimeException, String.valueOf(thrown.get()));
+        assertTrue(t.isInterrupted());
     }
 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
@@ -59,6 +59,7 @@ public class DefaultDependencyNodeTest {
         t.join();
 
         assertTrue(thrown.get() instanceof RuntimeException, String.valueOf(thrown.get()));
+        assertTrue(( (RuntimeException) thrown.get() ).getCause() instanceof InterruptedException, String.valueOf(thrown.get()));
         assertTrue(t.isInterrupted());
     }
 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/graph/DefaultDependencyNodeTest.java
@@ -59,7 +59,9 @@ public class DefaultDependencyNodeTest {
         t.join();
 
         assertTrue(thrown.get() instanceof RuntimeException, String.valueOf(thrown.get()));
-        assertTrue(( (RuntimeException) thrown.get() ).getCause() instanceof InterruptedException, String.valueOf(thrown.get()));
+        assertTrue(
+                ((RuntimeException) thrown.get()).getCause() instanceof InterruptedException,
+                String.valueOf(thrown.get()));
         assertTrue(t.isInterrupted());
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -281,7 +281,8 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
             List<RemoteRepository> repositories,
             List<Dependency> dependencies,
             List<Dependency> managedDependencies,
-            Results results);
+            Results results)
+            throws DependencyCollectionException;
 
     protected RepositorySystemSession optimizeSession(RepositorySystemSession session) {
         DefaultRepositorySystemSession optimized = new DefaultRepositorySystemSession(session);
@@ -459,6 +460,10 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
             maxExceptions = ConfigUtils.getInteger(session, DEFAULT_MAX_EXCEPTIONS, CONFIG_PROP_MAX_EXCEPTIONS);
 
             maxCycles = ConfigUtils.getInteger(session, DEFAULT_MAX_CYCLES, CONFIG_PROP_MAX_CYCLES);
+        }
+
+        public CollectResult getResult() {
+            return result;
         }
 
         public String getErrorPath() {


### PR DESCRIPTION
Currently the two collector implementations are not interrupt-able, do not sense interruption directly, only by some side-effect like IO. Moreover, the BF new collector may enter a "busy loop" as we seen (it was due bug, but nothing prevents us to have more bugs). Make main loop in both collector detect thread interruption and use global (per-collection) Args to carry state of the, interruption effectively the whole ST or MT collection.

Same stands for dependency visitor: it may also enter busy loop in case of cycles, hence, it should be made also  interrupt-able. Visitor OTOH should not reset the interrupted flag, it should just stop when it is set, and let the flag be handled at higher level (for example in collector).

---

https://issues.apache.org/jira/browse/MRESOLVER-321