### PR TITLE
[MRESOLVER-440] Addendum

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-http</artifactId>
+      <artifactId>maven-resolver-transport-apache</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/supplier/SupplierRepositorySystemFactory.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/supplier/SupplierRepositorySystemFactory.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
-import org.eclipse.aether.transport.http.ChecksumExtractor;
 import org.eclipse.aether.transport.jdk.JdkTransporterFactory;
 import org.eclipse.aether.transport.jetty.JettyTransporterFactory;
 
@@ -34,9 +33,8 @@ public class SupplierRepositorySystemFactory {
     public static RepositorySystem newRepositorySystem() {
         return new RepositorySystemSupplier() {
             @Override
-            protected Map<String, TransporterFactory> getTransporterFactories(
-                    Map<String, ChecksumExtractor> extractors) {
-                Map<String, TransporterFactory> result = super.getTransporterFactories(extractors);
+            protected Map<String, TransporterFactory> getTransporterFactories() {
+                Map<String, TransporterFactory> result = super.getTransporterFactories();
                 result.put(JdkTransporterFactory.NAME, new JdkTransporterFactory());
                 result.put(JettyTransporterFactory.NAME, new JettyTransporterFactory());
                 return result;

--- a/maven-resolver-supplier/pom.xml
+++ b/maven-resolver-supplier/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-http</artifactId>
+      <artifactId>maven-resolver-transport-apache</artifactId>
     </dependency>
 
     <dependency>

--- a/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -120,11 +120,8 @@ import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.spi.resolution.ArtifactResolverPostProcessor;
 import org.eclipse.aether.spi.synccontext.SyncContextFactory;
+import org.eclipse.aether.transport.apache.ApacheTransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
-import org.eclipse.aether.transport.http.ChecksumExtractor;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
-import org.eclipse.aether.transport.http.Nexus2ChecksumExtractor;
-import org.eclipse.aether.transport.http.XChecksumChecksumExtractor;
 import org.eclipse.aether.util.version.GenericVersionScheme;
 import org.eclipse.aether.version.VersionScheme;
 
@@ -300,17 +297,10 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return result;
     }
 
-    protected Map<String, ChecksumExtractor> getChecksumExtractors() {
-        HashMap<String, ChecksumExtractor> result = new HashMap<>();
-        result.put(Nexus2ChecksumExtractor.NAME, new Nexus2ChecksumExtractor());
-        result.put(XChecksumChecksumExtractor.NAME, new XChecksumChecksumExtractor());
-        return result;
-    }
-
-    protected Map<String, TransporterFactory> getTransporterFactories(Map<String, ChecksumExtractor> extractors) {
+    protected Map<String, TransporterFactory> getTransporterFactories() {
         HashMap<String, TransporterFactory> result = new HashMap<>();
         result.put(FileTransporterFactory.NAME, new FileTransporterFactory());
-        result.put(HttpTransporterFactory.NAME, new HttpTransporterFactory(extractors));
+        result.put(ApacheTransporterFactory.NAME, new ApacheTransporterFactory());
         return result;
     }
 
@@ -555,8 +545,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         Map<String, ProvidedChecksumsSource> providedChecksumsSources =
                 getProvidedChecksumsSources(trustedChecksumsSources);
 
-        Map<String, ChecksumExtractor> checksumExtractors = getChecksumExtractors();
-        Map<String, TransporterFactory> transporterFactories = getTransporterFactories(checksumExtractors);
+        Map<String, TransporterFactory> transporterFactories = getTransporterFactories();
         TransporterProvider transporterProvider = getTransporterProvider(transporterFactories);
 
         BasicRepositoryConnectorFactory basic = getBasicRepositoryConnectorFactory(

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-http</artifactId>
+        <artifactId>maven-resolver-transport-apache</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Seems the "atypical" modules like supplier and
demo snippets were completely omitted from the
transport rename, and were still using renamed
transport-http instead the new transport-apache.

---

https://issues.apache.org/jira/browse/MRESOLVER-440