### PR TITLE
[MRESOLVER-443] Integrate tool into build

### DIFF
--- a/maven-resolver-tools/pom.xml
+++ b/maven-resolver-tools/pom.xml
@@ -73,4 +73,30 @@
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>render-configuration</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
+              <arguments>
+                <argument>${basedir}/..</argument>
+                <argument>${basedir}/../src/site/markdown/configuration.md</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-tools/pom.xml
+++ b/maven-resolver-tools/pom.xml
@@ -82,7 +82,7 @@
         <version>3.1.0</version>
         <executions>
           <execution>
-            <id>render-configuration</id>
+            <id>render-configuration-page</id>
             <goals>
               <goal>java</goal>
             </goals>


### PR DESCRIPTION
Simply invoke it as very last step of build to generate the documentation. Ideally, this will produce _same output_ hence there will be no side effect (no local change). But in case page is outdated (needs update) the local checkout becomes dirty and would prevent release for example.

This is not "final" solution, but would work IMHO. Current issue with tool is that:
* it must have access to up-to-date class files (to javap them), hence it runs as last module of multi module build
* it must process WHOLE project, so to say "aggregate" output, it cannot run per module

---

https://issues.apache.org/jira/browse/MRESOLVER-443