### PR TITLE
Update UTs regarding deprecations

### DIFF
--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
@@ -25,12 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 public class DefaultRepositoryCacheTest {
 
     private final DefaultRepositoryCache cache = new DefaultRepositoryCache();
 
-    private final RepositorySystemSession session = new DefaultRepositorySystemSession();
+    private final RepositorySystemSession session = mock(RepositorySystemSession.class);
 
     private Object get(Object key) {
         return cache.get(session, key);

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositorySystemSessionTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositorySystemSessionTest.java
@@ -35,9 +35,13 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DefaultRepositorySystemSessionTest {
 
+    private DefaultRepositorySystemSession newSession() {
+        return new DefaultRepositorySystemSession();
+    }
+
     @Test
     void testDefaultProxySelectorUsesExistingProxy() {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = newSession();
 
         RemoteRepository repo = new RemoteRepository.Builder("id", "default", "void").build();
         assertSame(null, session.getProxySelector().getProxy(repo));
@@ -49,7 +53,7 @@ public class DefaultRepositorySystemSessionTest {
 
     @Test
     void testDefaultAuthenticationSelectorUsesExistingAuth() {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = newSession();
 
         RemoteRepository repo = new RemoteRepository.Builder("id", "default", "void").build();
         assertSame(null, session.getAuthenticationSelector().getAuthentication(repo));
@@ -65,7 +69,7 @@ public class DefaultRepositorySystemSessionTest {
 
     @Test
     void testCopyConstructorCopiesPropertiesDeep() {
-        DefaultRepositorySystemSession session1 = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session1 = newSession();
         session1.setUserProperties(System.getProperties());
         session1.setSystemProperties(System.getProperties());
         session1.setConfigProperties(System.getProperties());
@@ -82,7 +86,7 @@ public class DefaultRepositorySystemSessionTest {
 
     @Test
     void testReadOnlyProperties() {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = newSession();
 
         try {
             session.getUserProperties().put("key", "test");

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/repository/AuthenticationContextTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/repository/AuthenticationContextTest.java
@@ -21,16 +21,16 @@ package org.eclipse.aether.repository;
 import java.io.File;
 import java.util.Map;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 public class AuthenticationContextTest {
 
     private RepositorySystemSession newSession() {
-        return new DefaultRepositorySystemSession();
+        return mock(RepositorySystemSession.class);
     }
 
     private RemoteRepository newRepo(Authentication auth, Proxy proxy) {

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/repository/AuthenticationDigestTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/repository/AuthenticationDigestTest.java
@@ -20,16 +20,16 @@ package org.eclipse.aether.repository;
 
 import java.util.Map;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 public class AuthenticationDigestTest {
 
     private RepositorySystemSession newSession() {
-        return new DefaultRepositorySystemSession();
+        return mock(RepositorySystemSession.class);
     }
 
     private RemoteRepository newRepo(Authentication auth, Proxy proxy) {

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/transfer/TransferEventTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/transfer/TransferEventTest.java
@@ -20,19 +20,19 @@ package org.eclipse.aether.transfer;
 
 import java.nio.ByteBuffer;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 /**
  */
 public class TransferEventTest {
 
-    private static TransferResource res = new TransferResource("none", "file://nil", "void", null, null);
+    private static final TransferResource res = new TransferResource("none", "file://nil", "void", null, null);
 
-    private static RepositorySystemSession session = new DefaultRepositorySystemSession();
+    private static final RepositorySystemSession session = mock(RepositorySystemSession.class);
 
     @Test
     void testByteArrayConversion() {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultOfflineControllerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultOfflineControllerTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.transfer.RepositoryOfflineException;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +33,7 @@ public class DefaultOfflineControllerTest {
     private DefaultOfflineController controller;
 
     private RepositorySystemSession newSession(boolean offline, String protocols, String hosts) {
-        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession();
+        DefaultRepositorySystemSession session = TestUtils.newSession();
         session.setOffline(offline);
         session.setConfigProperty(DefaultOfflineController.CONFIG_PROP_OFFLINE_PROTOCOLS, protocols);
         session.setConfigProperty(DefaultOfflineController.CONFIG_PROP_OFFLINE_HOSTS, hosts);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DataPoolTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DataPoolTest.java
@@ -20,9 +20,9 @@ package org.eclipse.aether.internal.impl.collect;
 
 import java.util.Collections;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class DataPoolTest {
 
     private DataPool newDataPool() {
-        return new DataPool(new DefaultRepositorySystemSession());
+        return new DataPool(TestUtils.newSession());
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContextTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContextTest.java
@@ -23,9 +23,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.internal.test.util.TestVersion;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
@@ -40,7 +40,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void iteratorOneItem() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -52,7 +52,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void getCountOneItem() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -62,7 +62,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void getOneItem() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -72,7 +72,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void iteratorDelete() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -86,7 +86,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void nextBeyondEnd() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -98,7 +98,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void removeOneOfOne() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, result);
@@ -112,7 +112,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void removeOneOfTwo() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         result.addVersion(new TestVersion("2.0"));
@@ -127,7 +127,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void removeOneOfThree() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
         result.addVersion(new TestVersion("1.0"));
         result.addVersion(new TestVersion("2.0"));
@@ -143,7 +143,7 @@ public class DefaultVersionFilterContextTest {
 
     @Test
     void setTwice() {
-        DefaultVersionFilterContext context = new DefaultVersionFilterContext(new DefaultRepositorySystemSession());
+        DefaultVersionFilterContext context = new DefaultVersionFilterContext(TestUtils.newSession());
         VersionRangeResult fooResult = new VersionRangeResult(new VersionRangeRequest());
         fooResult.addVersion(new TestVersion("1.0"));
         context.set(FOO_DEPENDENCY, fooResult);

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/AbstractDependencyGraphTransformerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/AbstractDependencyGraphTransformerTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractDependencyGraphTransformerTest {
     void setUp() {
         transformer = newTransformer();
         parser = newParser();
-        session = new DefaultRepositorySystemSession();
+        session = TestUtils.newSession();
     }
 
     @AfterEach

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/ComponentAuthenticationTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/ComponentAuthenticationTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.aether.util.repository;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.AuthenticationDigest;
@@ -33,7 +33,7 @@ public class ComponentAuthenticationTest {
     private static class Component {}
 
     private RepositorySystemSession newSession() {
-        return new DefaultRepositorySystemSession();
+        return TestUtils.newSession();
     }
 
     private RemoteRepository newRepo(Authentication auth) {

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/SecretAuthenticationTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/SecretAuthenticationTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.aether.util.repository;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.AuthenticationDigest;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SecretAuthenticationTest {
 
     private RepositorySystemSession newSession() {
-        return new DefaultRepositorySystemSession();
+        return TestUtils.newSession();
     }
 
     private RemoteRepository newRepo(Authentication auth) {
@@ -58,9 +58,10 @@ public class SecretAuthenticationTest {
     @Test
     void testFill() {
         Authentication auth = new SecretAuthentication("key", "value");
-        AuthenticationContext context = newContext(auth);
-        assertNull(context.get("another-key"));
-        assertEquals("value", context.get("key"));
+        try (AuthenticationContext context = newContext(auth)) {
+            assertNull(context.get("another-key"));
+            assertEquals("value", context.get("key"));
+        }
     }
 
     @Test

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/StringAuthenticationTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/StringAuthenticationTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.aether.util.repository;
 
-import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.AuthenticationDigest;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class StringAuthenticationTest {
 
     private RepositorySystemSession newSession() {
-        return new DefaultRepositorySystemSession();
+        return TestUtils.newSession();
     }
 
     private RemoteRepository newRepo(Authentication auth) {
@@ -51,9 +51,10 @@ public class StringAuthenticationTest {
     @Test
     void testFill() {
         Authentication auth = new StringAuthentication("key", "value");
-        AuthenticationContext context = newContext(auth);
-        assertNull(context.get("another-key"));
-        assertEquals("value", context.get("key"));
+        try (AuthenticationContext context = newContext(auth)) {
+            assertNull(context.get("another-key"));
+            assertEquals("value", context.get("key"));
+        }
     }
 
     @Test


### PR DESCRIPTION
With latest changes there were some deprecations, most notably the default ctor of DRSS. Due that the build started emitting quite some warning messages during build.

This is now lowered to 2 warnings for whole build. There is no issue for this, as these changes are all happening in UTs.