### PR TITLE
[MRESOLVER-447] Expose flatten method w/ filter

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
@@ -29,6 +29,7 @@ import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeployResult;
 import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallResult;
@@ -157,6 +158,19 @@ public interface RepositorySystem extends Closeable {
      * @since 2.0.0
      */
     List<DependencyNode> flattenDependencyNodes(RepositorySystemSession session, DependencyNode root);
+
+    /**
+     * Flattens the provided graph as {@link DependencyNode} into a {@link List}{@code <DependencyNode>} according to session
+     * configuration.
+     *
+     * @param session The repository session, must not be {@code null}.
+     * @param root The dependency node root of the graph, must not be {@code null}.
+     * @param filter The filter to apply, may be {@code null}.
+     * @return The flattened list of dependency nodes, never {@code null}.
+     * @since 2.0.0
+     */
+    List<DependencyNode> flattenDependencyNodes(
+            RepositorySystemSession session, DependencyNode root, DependencyFilter filter);
 
     /**
      * Resolves the path for an artifact. The artifact will be downloaded to the local repository if necessary. An

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystem.java
@@ -154,17 +154,6 @@ public interface RepositorySystem extends Closeable {
      *
      * @param session The repository session, must not be {@code null}.
      * @param root The dependency node root of the graph, must not be {@code null}.
-     * @return The flattened list of dependency nodes, never {@code null}.
-     * @since 2.0.0
-     */
-    List<DependencyNode> flattenDependencyNodes(RepositorySystemSession session, DependencyNode root);
-
-    /**
-     * Flattens the provided graph as {@link DependencyNode} into a {@link List}{@code <DependencyNode>} according to session
-     * configuration.
-     *
-     * @param session The repository session, must not be {@code null}.
-     * @param root The dependency node root of the graph, must not be {@code null}.
      * @param filter The filter to apply, may be {@code null}.
      * @return The flattened list of dependency nodes, never {@code null}.
      * @since 2.0.0

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
@@ -297,14 +297,6 @@ public class DefaultRepositorySystem implements RepositorySystem {
     }
 
     @Override
-    public List<DependencyNode> flattenDependencyNodes(RepositorySystemSession session, DependencyNode root) {
-        validateSession(session);
-        requireNonNull(root, "root cannot be null");
-
-        return doFlattenDependencyNodes(session, root, null);
-    }
-
-    @Override
     public List<DependencyNode> flattenDependencyNodes(
             RepositorySystemSession session, DependencyNode root, DependencyFilter dependencyFilter) {
         validateSession(session);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
@@ -260,13 +260,8 @@ public class DefaultRepositorySystem implements RepositorySystem {
             throw new NullPointerException("dependency node and collect request cannot be null");
         }
 
-        final ArrayList<DependencyNode> dependencyNodes = new ArrayList<>();
-        DependencyVisitor builder = getDependencyVisitor(session, dependencyNodes::add);
-        DependencyFilter filter = request.getFilter();
-        DependencyVisitor visitor = (filter != null) ? new FilteringDependencyVisitor(builder, filter) : builder;
-        if (result.getRoot() != null) {
-            result.getRoot().accept(visitor);
-        }
+        final List<DependencyNode> dependencyNodes =
+                doFlattenDependencyNodes(session, result.getRoot(), request.getFilter());
 
         final List<ArtifactRequest> requests = dependencyNodes.stream()
                 .map(n -> {
@@ -306,8 +301,27 @@ public class DefaultRepositorySystem implements RepositorySystem {
         validateSession(session);
         requireNonNull(root, "root cannot be null");
 
+        return doFlattenDependencyNodes(session, root, null);
+    }
+
+    @Override
+    public List<DependencyNode> flattenDependencyNodes(
+            RepositorySystemSession session, DependencyNode root, DependencyFilter dependencyFilter) {
+        validateSession(session);
+        requireNonNull(root, "root cannot be null");
+
+        return doFlattenDependencyNodes(session, root, dependencyFilter);
+    }
+
+    private List<DependencyNode> doFlattenDependencyNodes(
+            RepositorySystemSession session, DependencyNode root, DependencyFilter dependencyFilter) {
         final ArrayList<DependencyNode> dependencyNodes = new ArrayList<>();
-        root.accept(getDependencyVisitor(session, dependencyNodes::add));
+        if (root != null) {
+            DependencyVisitor builder = getDependencyVisitor(session, dependencyNodes::add);
+            DependencyVisitor visitor =
+                    (dependencyFilter != null) ? new FilteringDependencyVisitor(builder, dependencyFilter) : builder;
+            root.accept(visitor);
+        }
         return dependencyNodes;
     }
 


### PR DESCRIPTION
As this now exposes full "third step" in resolveDependencies, so client code can reuse and have all of it.

---

https://issues.apache.org/jira/browse/MRESOLVER-447