### PR TITLE
[MRESOLVER-465] Make room for alternate version scheme

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionConstraint.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionConstraint.java
@@ -28,6 +28,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A constraint on versions for a dependency.
+ * <p>
+ * Despite its name, this class is generic in a sense it works with any {@link Version}.
  */
 final class GenericVersionConstraint implements VersionConstraint {
 
@@ -88,9 +90,9 @@ final class GenericVersionConstraint implements VersionConstraint {
             return false;
         }
 
-        GenericVersionConstraint that = (GenericVersionConstraint) obj;
+        VersionConstraint that = (VersionConstraint) obj;
 
-        return Objects.equals(range, that.range) && Objects.equals(version, that.getVersion());
+        return Objects.equals(range, that.getRange()) && Objects.equals(version, that.getVersion());
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionRange.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionRange.java
@@ -23,13 +23,17 @@ import java.util.Objects;
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionRange;
+import org.eclipse.aether.version.VersionScheme;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * A version range inspired by mathematical range syntax. For example, "[1.0,2.0)", "[1.0,)" or "[1.0]".
+ * <p>
+ * Despite its name, this class is generic in a sense it works with any {@link Version}
  */
 final class GenericVersionRange implements VersionRange {
+    private final VersionScheme versionScheme;
 
     private final Bound lowerBound;
 
@@ -41,7 +45,8 @@ final class GenericVersionRange implements VersionRange {
      * @param range The range specification to parse, must not be {@code null}.
      * @throws InvalidVersionSpecificationException If the range could not be parsed.
      */
-    GenericVersionRange(String range) throws InvalidVersionSpecificationException {
+    GenericVersionRange(VersionScheme versionScheme, String range) throws InvalidVersionSpecificationException {
+        this.versionScheme = requireNonNull(versionScheme, "versionScheme cannot be null");
         String process = requireNonNull(range, "version range cannot be null");
 
         boolean lowerBoundInclusive, upperBoundInclusive;
@@ -110,8 +115,8 @@ final class GenericVersionRange implements VersionRange {
         this.upperBound = (upperBound != null) ? new Bound(upperBound, upperBoundInclusive) : null;
     }
 
-    private Version parse(String version) {
-        return new GenericVersion(version);
+    private Version parse(String version) throws InvalidVersionSpecificationException {
+        return versionScheme.parseVersion(version);
     }
 
     @Override
@@ -159,9 +164,9 @@ final class GenericVersionRange implements VersionRange {
             return false;
         }
 
-        GenericVersionRange that = (GenericVersionRange) obj;
+        VersionRange that = (VersionRange) obj;
 
-        return Objects.equals(upperBound, that.upperBound) && Objects.equals(lowerBound, that.lowerBound);
+        return Objects.equals(upperBound, that.getUpperBound()) && Objects.equals(lowerBound, that.getLowerBound());
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
@@ -51,16 +51,14 @@ public final class GenericVersionScheme extends VersionSchemeSupport {
         return new GenericVersion(version);
     }
 
-    // CHECKSTYLE_OFF: LineLength
     /**
      * A handy main method that behaves similarly like maven-artifact ComparableVersion is, to make possible test
      * and possibly compare differences between the two.
      * <p>
      * To check how "1.2.7" compares to "1.2-SNAPSHOT", for example, you can issue
-     * <pre>java -cp ${maven.repo.local}/org/apache/maven/resolver/maven-resolver-api/${resolver.version}/maven-resolver-api-${resolver.version}.jar:${maven.repo.local}/org/apache/maven/resolver/maven-resolver-util/${resolver.version}/maven-resolver-util-${resolver.version}.jar org.eclipse.aether.util.version.GenericVersionScheme "1.2.7" "1.2-SNAPSHOT"</pre>
+     * <pre>jbang --main=org.eclipse.aether.util.version.GenericVersionScheme org.apache.maven.resolver:maven-resolver-util:1.9.18 "1.2.7" "1.2-SNAPSHOT"</pre>
      * command to command line, output is very similar to that of ComparableVersion on purpose.
      */
-    // CHECKSTYLE_ON: LineLength
     public static void main(String... args) {
         System.out.println(
                 "Display parameters as parsed by Maven Resolver 'generic' scheme (in canonical form and as a list of tokens)"

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
@@ -18,13 +18,7 @@
  */
 package org.eclipse.aether.util.version;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.eclipse.aether.version.VersionScheme;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * A version scheme using a generic version syntax and common sense sorting.
@@ -51,80 +45,10 @@ import static java.util.Objects.requireNonNull;
  * respectively, until the kind mismatch is resolved, e.g. "1-alpha" = "1.0.0-alpha" &lt; "1.0.1-ga" = "1.0.1".
  * </p>
  */
-public final class GenericVersionScheme implements VersionScheme {
-
-    /**
-     * Creates a new instance of the version scheme for parsing versions.
-     */
-    public GenericVersionScheme() {}
-
+public final class GenericVersionScheme extends VersionSchemeSupport {
     @Override
     public GenericVersion parseVersion(final String version) throws InvalidVersionSpecificationException {
         return new GenericVersion(version);
-    }
-
-    @Override
-    public GenericVersionRange parseVersionRange(final String range) throws InvalidVersionSpecificationException {
-        return new GenericVersionRange(range);
-    }
-
-    @Override
-    public GenericVersionConstraint parseVersionConstraint(final String constraint)
-            throws InvalidVersionSpecificationException {
-        String process = requireNonNull(constraint, "constraint cannot be null");
-
-        Collection<GenericVersionRange> ranges = new ArrayList<>();
-
-        while (process.startsWith("[") || process.startsWith("(")) {
-            int index1 = process.indexOf(')');
-            int index2 = process.indexOf(']');
-
-            int index = index2;
-            if (index2 < 0 || (index1 >= 0 && index1 < index2)) {
-                index = index1;
-            }
-
-            if (index < 0) {
-                throw new InvalidVersionSpecificationException(constraint, "Unbounded version range " + constraint);
-            }
-
-            GenericVersionRange range = parseVersionRange(process.substring(0, index + 1));
-            ranges.add(range);
-
-            process = process.substring(index + 1).trim();
-
-            if (process.startsWith(",")) {
-                process = process.substring(1).trim();
-            }
-        }
-
-        if (!process.isEmpty() && !ranges.isEmpty()) {
-            throw new InvalidVersionSpecificationException(
-                    constraint, "Invalid version range " + constraint + ", expected [ or ( but got " + process);
-        }
-
-        GenericVersionConstraint result;
-        if (ranges.isEmpty()) {
-            result = new GenericVersionConstraint(parseVersion(constraint));
-        } else {
-            result = new GenericVersionConstraint(UnionVersionRange.from(ranges));
-        }
-
-        return result;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-
-        return obj != null && getClass().equals(obj.getClass());
-    }
-
-    @Override
-    public int hashCode() {
-        return getClass().hashCode();
     }
 
     // CHECKSTYLE_OFF: LineLength
@@ -138,8 +62,9 @@ public final class GenericVersionScheme implements VersionScheme {
      */
     // CHECKSTYLE_ON: LineLength
     public static void main(String... args) {
-        System.out.println("Display parameters as parsed by Maven Resolver (in canonical form and as a list of tokens)"
-                + " and comparison result:");
+        System.out.println(
+                "Display parameters as parsed by Maven Resolver 'generic' scheme (in canonical form and as a list of tokens)"
+                        + " and comparison result:");
         if (args.length == 0) {
             return;
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.version;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.VersionRange;
+import org.eclipse.aether.version.VersionScheme;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A version scheme support class. A new implementation should extend this class and would receive full support for
+ * ranges and constraints. The new implementation should implement {@link org.eclipse.aether.version.Version} and
+ * the one missing method in this class, the {@link #parseVersion(String)}.
+ *
+ * @since 2.0.0
+ */
+public abstract class VersionSchemeSupport implements VersionScheme {
+    @Override
+    public GenericVersionRange parseVersionRange(final String range) throws InvalidVersionSpecificationException {
+        return new GenericVersionRange(this, range);
+    }
+
+    @Override
+    public GenericVersionConstraint parseVersionConstraint(final String constraint)
+            throws InvalidVersionSpecificationException {
+        String process = requireNonNull(constraint, "constraint cannot be null");
+
+        Collection<VersionRange> ranges = new ArrayList<>();
+
+        while (process.startsWith("[") || process.startsWith("(")) {
+            int index1 = process.indexOf(')');
+            int index2 = process.indexOf(']');
+
+            int index = index2;
+            if (index2 < 0 || (index1 >= 0 && index1 < index2)) {
+                index = index1;
+            }
+
+            if (index < 0) {
+                throw new InvalidVersionSpecificationException(constraint, "Unbounded version range " + constraint);
+            }
+
+            VersionRange range = parseVersionRange(process.substring(0, index + 1));
+            ranges.add(range);
+
+            process = process.substring(index + 1).trim();
+
+            if (process.startsWith(",")) {
+                process = process.substring(1).trim();
+            }
+        }
+
+        if (!process.isEmpty() && !ranges.isEmpty()) {
+            throw new InvalidVersionSpecificationException(
+                    constraint, "Invalid version range " + constraint + ", expected [ or ( but got " + process);
+        }
+
+        GenericVersionConstraint result;
+        if (ranges.isEmpty()) {
+            result = new GenericVersionConstraint(parseVersion(constraint));
+        } else {
+            result = new GenericVersionConstraint(UnionVersionRange.from(ranges));
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        return obj != null && getClass().equals(obj.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
@@ -84,18 +84,4 @@ abstract class VersionSchemeSupport implements VersionScheme {
 
         return result;
     }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-
-        return obj != null && getClass().equals(obj.getClass());
-    }
-
-    @Override
-    public int hashCode() {
-        return getClass().hashCode();
-    }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/VersionSchemeSupport.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 2.0.0
  */
-public abstract class VersionSchemeSupport implements VersionScheme {
+abstract class VersionSchemeSupport implements VersionScheme {
     @Override
     public GenericVersionRange parseVersionRange(final String range) throws InvalidVersionSpecificationException {
         return new GenericVersionRange(this, range);

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionRangeTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionRangeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GenericVersionRangeTest {
+    private final GenericVersionScheme versionScheme = new GenericVersionScheme();
 
     private Version newVersion(String version) {
         return new GenericVersion(version);
@@ -33,7 +34,7 @@ public class GenericVersionRangeTest {
 
     private VersionRange parseValid(String range) {
         try {
-            return new GenericVersionRange(range);
+            return new GenericVersionRange(versionScheme, range);
         } catch (InvalidVersionSpecificationException e) {
             throw new AssertionError(range + " should be valid but failed to parse due to: " + e.getMessage(), e);
         }
@@ -41,7 +42,7 @@ public class GenericVersionRangeTest {
 
     private void parseInvalid(String range) {
         try {
-            new GenericVersionRange(range);
+            new GenericVersionRange(versionScheme, range);
             fail(range + " should be invalid");
         } catch (InvalidVersionSpecificationException e) {
             assertTrue(true);


### PR DESCRIPTION
Since eons Resolver had the "generic" scheme implementing the `Version`, `VersionRange` and `VersionConstraint` API interfaces.

Interesting fact: `GenericVersionRange` and `GenericVersionConstraint` are NOT tied in any way to `GenericVersion` implementation, they are happy with plain `Version` interface as well, they are truly "generic".

This means, that a scheme needs really only to provide `Version` implementation (currently in form of `GenericVersion`) and a "factory" for it (currently in a form of `GenericVersionScheme`).

Refactor a bit, and make room for alternate Version implementations.

Fact: the change can be done in source and binary compatible way, and is enforced by japicmp.

---

https://issues.apache.org/jira/browse/MRESOLVER-465