### PR TITLE
[MRESOLVER-471] Resolver should be oblivious about scopes.

### DIFF
--- a/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -56,7 +56,13 @@ import static java.util.Objects.requireNonNull;
  * Extend this class and override methods to customize, if needed.
  *
  * @since 2.0.0
+ *
+ * @deprecated (To be removed as it was introduced in 2.0.0-alpha-2!) This class is wrong, as it uses Resolver 1.x
+ * bits that do interpret dependency scopes. The proper session supplier should be provided by consumer project
+ * (Maven) that also defines the dependency scopes and their meaning and semantics, as session need to be equipped
+ * with these bits. Session is very much dependent on the consumer project.
  */
+@Deprecated
 public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected final RepositorySystem repositorySystem;
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/JavaScopes.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/JavaScopes.java
@@ -22,14 +22,19 @@ package org.eclipse.aether.util.artifact;
  * The dependency scopes used for Java dependencies.
  *
  * @see org.eclipse.aether.graph.Dependency#getScope()
+ *
+ * @deprecated Definition and semantics of the scopes should be defined by consumer project. Resolver out-of-the-box
+ * supported scopes are defined in {@link Scopes} class. Resolver is oblivious about any other scopes and their
+ * semantics.
  */
+@Deprecated
 public final class JavaScopes {
 
     public static final String COMPILE = "compile";
 
     public static final String PROVIDED = "provided";
 
-    public static final String SYSTEM = "system";
+    public static final String SYSTEM = Scopes.SYSTEM;
 
     public static final String RUNTIME = "runtime";
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/Scopes.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/Scopes.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.artifact;
+
+/**
+ * The dependency scopes that Resolver supports out of the box. The full set of scopes should be defined by
+ * consumer project.
+ * <p>
+ * By definition, scopes for Resolver are just labels, checked for equality. Resolver will not interpret, alter or
+ * modify any scope "label" that is not present in this class. It is left to consumer projects to define and
+ * interpret those.
+ *
+ * @see org.eclipse.aether.graph.Dependency#getScope()
+ * @since 2.0.0
+ */
+public final class Scopes {
+
+    /**
+     * Special scope that tells resolver that dependency is not to be found in any regular repository, so it should not
+     * even try to resolve the artifact from them. Dependency in this scope does not have artifact descriptor either.
+     * Artifacts in this scope should have the "local path" property set, pointing to a file on local system, where the
+     * backing file should reside. Resolution of artifacts in this scope fails, if backing file does not exist
+     * (no property set, or property contains invalid path, or the path points to a non-existent file).
+     *
+     * @see org.eclipse.aether.artifact.ArtifactProperties#LOCAL_PATH
+     */
+    public static final String SYSTEM = "system";
+
+    private Scopes() {
+        // hide constructor
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
@@ -112,7 +112,12 @@ public final class DependencyFilterUtils {
      * @param classpathTypes The classpath types, may be {@code null} or empty to match no dependency.
      * @return The new filter, never {@code null}.
      * @see JavaScopes
+     *
+     * @deprecated Resolver is oblivious about "scopes", it is consumer project which needs to lay these down and
+     * also assign proper semantics. Moreover, Resolver is oblivious about notions of "classpath", "modulepath", and
+     * any other similar uses. These should be handled by consumer project.
      */
+    @Deprecated
     public static DependencyFilter classpathFilter(String... classpathTypes) {
         return classpathFilter((classpathTypes != null) ? Arrays.asList(classpathTypes) : null);
     }
@@ -124,7 +129,12 @@ public final class DependencyFilterUtils {
      * @param classpathTypes The classpath types, may be {@code null} or empty to match no dependency.
      * @return The new filter, never {@code null}.
      * @see JavaScopes
+     *
+     * @deprecated Resolver is oblivious about "scopes", it is consumer project which needs to lay these down and
+     * also assign proper semantics. Moreover, Resolver is oblivious about notions of "classpath", "modulepath", and
+     * any other similar uses. These should be handled by consumer project.
      */
+    @Deprecated
     public static DependencyFilter classpathFilter(Collection<String> classpathTypes) {
         Collection<String> types = new HashSet<>();
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -32,7 +32,7 @@ import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.Exclusion;
-import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.artifact.Scopes;
 
 import static java.util.Objects.requireNonNull;
 
@@ -195,7 +195,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
                 management.setScope(scope);
 
-                if (!JavaScopes.SYSTEM.equals(scope)
+                if (!Scopes.SYSTEM.equals(scope)
                         && dependency.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
                     Map<String, String> properties =
                             new HashMap<>(dependency.getArtifact().getProperties());
@@ -204,8 +204,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
             }
 
-            if ((JavaScopes.SYSTEM.equals(scope))
-                    || (scope == null && JavaScopes.SYSTEM.equals(dependency.getScope()))) {
+            if ((Scopes.SYSTEM.equals(scope)) || (scope == null && Scopes.SYSTEM.equals(dependency.getScope()))) {
                 String localPath = managedLocalPaths.get(key);
                 if (localPath != null) {
                     if (management == null) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
@@ -29,11 +29,16 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A dependency graph transformer that refines the request context for nodes that belong to the "project" context by
- * appending the classpath type to which the node belongs. For instance, a compile-time project dependency will be
+ * appending the buildpath type to which the node belongs. For instance, a compile-time project dependency will be
  * assigned the request context "project/compile".
  *
  * @see DependencyNode#getRequestContext()
+ * 
+ * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
+ * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * of dependencies to build path scopes.
  */
+@Deprecated
 public final class JavaDependencyContextRefiner implements DependencyGraphTransformer {
 
     public DependencyNode transformGraph(DependencyNode node, DependencyGraphTransformationContext context)
@@ -43,7 +48,7 @@ public final class JavaDependencyContextRefiner implements DependencyGraphTransf
         String ctx = node.getRequestContext();
 
         if ("project".equals(ctx)) {
-            String scope = getClasspathScope(node);
+            String scope = getBuildpathScope(node);
             if (scope != null) {
                 ctx += '/' + scope;
                 node.setRequestContext(ctx);
@@ -57,7 +62,7 @@ public final class JavaDependencyContextRefiner implements DependencyGraphTransf
         return node;
     }
 
-    private String getClasspathScope(DependencyNode node) {
+    private String getBuildpathScope(DependencyNode node) {
         Dependency dependency = node.getDependency();
         if (dependency == null) {
             return null;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * assigned the request context "project/compile".
  *
  * @see DependencyNode#getRequestContext()
- * 
+ *
  * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
  * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
  * of dependencies to build path scopes.

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeDeriver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeDeriver.java
@@ -25,7 +25,12 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeDeriver;
 
 /**
  * A scope deriver for use with {@link ConflictResolver} that supports the scopes from {@link JavaScopes}.
+ *
+ * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
+ * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * of dependencies to build path scopes.
  */
+@Deprecated
 public final class JavaScopeDeriver extends ScopeDeriver {
 
     /**

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeSelector.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeSelector.java
@@ -32,7 +32,12 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeSelector;
  * A scope selector for use with {@link ConflictResolver} that supports the scopes from {@link JavaScopes}. In general,
  * this selector picks the widest scope present among conflicting dependencies where e.g. "compile" is wider than
  * "runtime" which is wider than "test". If however a direct dependency is involved, its scope is selected.
+ *
+ * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
+ * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * of dependencies to build path scopes.
  */
+@Deprecated
 public final class JavaScopeSelector extends ScopeSelector {
 
     /**


### PR DESCRIPTION
In Resolver 1.x it defined scopes (that were redefined by consumer project Maven), leading to duplication and possible digression if Maven was about to support new dependency scopes. Moreover, Resolver 1.x also contained (based on these scopes) logic, "scope refinement", "scope derive to buildpath scope" and so on. All these logic just like the definition of scopes belong to consumer project: Maven.

Resolver really cares about only one scope: "system", as dependencies in this scope should be handled very differently than others (have no POMs and just file presence should be checked on resolving them).

---

https://issues.apache.org/jira/browse/MRESOLVER-471