### PR TITLE
Rename the new Scopes class

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DependencyScopes.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DependencyScopes.java
@@ -29,7 +29,7 @@ package org.eclipse.aether.util.artifact;
  * @see org.eclipse.aether.graph.Dependency#getScope()
  * @since 2.0.0
  */
-public final class Scopes {
+public final class DependencyScopes {
 
     /**
      * Special scope that tells resolver that dependency is not to be found in any regular repository, so it should not
@@ -42,7 +42,7 @@ public final class Scopes {
      */
     public static final String SYSTEM = "system";
 
-    private Scopes() {
+    private DependencyScopes() {
         // hide constructor
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/JavaScopes.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/JavaScopes.java
@@ -24,7 +24,7 @@ package org.eclipse.aether.util.artifact;
  * @see org.eclipse.aether.graph.Dependency#getScope()
  *
  * @deprecated Definition and semantics of the scopes should be defined by consumer project. Resolver out-of-the-box
- * supported scopes are defined in {@link Scopes} class. Resolver is oblivious about any other scopes and their
+ * supported scopes are defined in {@link DependencyScopes} class. Resolver is oblivious about any other scopes and their
  * semantics.
  */
 @Deprecated
@@ -34,7 +34,7 @@ public final class JavaScopes {
 
     public static final String PROVIDED = "provided";
 
-    public static final String SYSTEM = Scopes.SYSTEM;
+    public static final String SYSTEM = DependencyScopes.SYSTEM;
 
     public static final String RUNTIME = "runtime";
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -32,7 +32,7 @@ import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.Exclusion;
-import org.eclipse.aether.util.artifact.Scopes;
+import org.eclipse.aether.util.artifact.DependencyScopes;
 
 import static java.util.Objects.requireNonNull;
 
@@ -195,7 +195,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
                 management.setScope(scope);
 
-                if (!Scopes.SYSTEM.equals(scope)
+                if (!DependencyScopes.SYSTEM.equals(scope)
                         && dependency.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
                     Map<String, String> properties =
                             new HashMap<>(dependency.getArtifact().getProperties());
@@ -204,7 +204,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
             }
 
-            if ((Scopes.SYSTEM.equals(scope)) || (scope == null && Scopes.SYSTEM.equals(dependency.getScope()))) {
+            if ((DependencyScopes.SYSTEM.equals(scope)) || (scope == null && DependencyScopes.SYSTEM.equals(dependency.getScope()))) {
                 String localPath = managedLocalPaths.get(key);
                 if (localPath != null) {
                     if (management == null) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner.java
@@ -23,6 +23,7 @@ import org.eclipse.aether.collection.DependencyGraphTransformationContext;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.artifact.DependencyScopes;
 import org.eclipse.aether.util.artifact.JavaScopes;
 
 import static java.util.Objects.requireNonNull;
@@ -35,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  * @see DependencyNode#getRequestContext()
  *
  * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
- * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * in {@link DependencyScopes} class, moreover it has no knowledge about scope transformation
  * of dependencies to build path scopes.
  */
 @Deprecated

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeDeriver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeDeriver.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.util.graph.transformer;
 
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.util.artifact.DependencyScopes;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeContext;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeDeriver;
@@ -27,7 +28,7 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeDeriver;
  * A scope deriver for use with {@link ConflictResolver} that supports the scopes from {@link JavaScopes}.
  *
  * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
- * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * in {@link DependencyScopes} class, moreover it has no knowledge about scope transformation
  * of dependencies to build path scopes.
  */
 @Deprecated

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeSelector.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/JavaScopeSelector.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.aether.RepositoryException;
+import org.eclipse.aether.util.artifact.DependencyScopes;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.ConflictContext;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver.ConflictItem;
@@ -34,7 +35,7 @@ import org.eclipse.aether.util.graph.transformer.ConflictResolver.ScopeSelector;
  * "runtime" which is wider than "test". If however a direct dependency is involved, its scope is selected.
  *
  * @deprecated This class belongs to consumer project. Resolver have no notion of scopes other than those defined
- * in {@link org.eclipse.aether.util.artifact.Scopes} class, moreover it has no knowledge about scope transformation
+ * in {@link DependencyScopes} class, moreover it has no knowledge about scope transformation
  * of dependencies to build path scopes.
  */
 @Deprecated


### PR DESCRIPTION
The class name is too generic and too wide
(scope of what?).

IMHO `DependencyScopes` covers much better
the intent here.