### PR TITLE
[MRESOLVER-472] Update Jetty 10.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <guiceVersion>6.0.0</guiceVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <!-- Used by Jetty Transport (client) and Test HTTP (server) -->
-    <jettyVersion>10.0.18</jettyVersion>
+    <jettyVersion>10.0.19</jettyVersion>
     <!-- used by supplier and demo only -->
     <mavenVersion>4.0.0-alpha-12</mavenVersion>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>


### PR DESCRIPTION
Client used for "jetty" transport, and Server used in HTTP tests.

Release notes:
https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.19

---

https://issues.apache.org/jira/browse/MRESOLVER-472