### PR TITLE
[MRESOLVER-491] Resolver should not have any "predefined" scope

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
@@ -19,15 +19,7 @@
 package org.eclipse.aether.internal.impl.collect;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -387,7 +379,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         Dependency dependency = newDep("managed:aid:ext:ver");
         CollectRequest request = new CollectRequest(dependency, singletonList(repository));
 
-        session.setDependencyManager(new ClassicDependencyManager());
+        session.setDependencyManager(new ClassicDependencyManager(s -> Objects.equals(s, "system")));
 
         CollectResult result = collector.collectDependencies(session, request);
 
@@ -462,7 +454,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_TransitiveDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager());
+        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
@@ -479,7 +471,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new TransitiveDependencyManager());
+        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }
@@ -488,7 +480,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_DefaultDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new DefaultDependencyManager());
+        session.setDependencyManager(new DefaultDependencyManager(s -> Objects.equals(s, "system")));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
@@ -506,7 +498,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:managed-by-dominant-request"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new DefaultDependencyManager());
+        session.setDependencyManager(new DefaultDependencyManager(s -> Objects.equals(s, "system")));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
@@ -379,7 +379,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         Dependency dependency = newDep("managed:aid:ext:ver");
         CollectRequest request = new CollectRequest(dependency, singletonList(repository));
 
-        session.setDependencyManager(new ClassicDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new ClassicDependencyManager("system"::equals));
 
         CollectResult result = collector.collectDependencies(session, request);
 
@@ -454,7 +454,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_TransitiveDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
@@ -471,7 +471,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }
@@ -480,7 +480,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_DefaultDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new DefaultDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new DefaultDependencyManager("system"::equals));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
@@ -498,7 +498,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:managed-by-dominant-request"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new DefaultDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new DefaultDependencyManager("system"::equals));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
@@ -47,6 +47,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.manager.DefaultDependencyManager;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
@@ -68,6 +69,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Common tests for various {@link DependencyCollectorDelegate} implementations.
  */
 public abstract class DependencyCollectorDelegateTestSupport {
+
+    protected static final SystemScopePredicate SYSTEM_PREDICATE = "system"::equals;
 
     protected DefaultRepositorySystemSession session;
 
@@ -379,7 +382,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         Dependency dependency = newDep("managed:aid:ext:ver");
         CollectRequest request = new CollectRequest(dependency, singletonList(repository));
 
-        session.setDependencyManager(new ClassicDependencyManager("system"::equals));
+        session.setDependencyManager(new ClassicDependencyManager(SYSTEM_PREDICATE));
 
         CollectResult result = collector.collectDependencies(session, request);
 
@@ -454,7 +457,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_TransitiveDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
+        session.setDependencyManager(new TransitiveDependencyManager(SYSTEM_PREDICATE));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
@@ -471,7 +474,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:must-retain-core-management"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
+        session.setDependencyManager(new TransitiveDependencyManager(SYSTEM_PREDICATE));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }
@@ -480,7 +483,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
     void testDependencyManagement_DefaultDependencyManager() throws DependencyCollectionException, IOException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new DefaultDependencyManager("system"::equals));
+        session.setDependencyManager(new DefaultDependencyManager(SYSTEM_PREDICATE));
         final Dependency root = newDep("gid:root:ext:ver", "compile");
         CollectRequest request = new CollectRequest(root, singletonList(repository));
         request.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
@@ -498,7 +501,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         rootArtifactRequest.addManagedDependency(newDep("gid:root:ext:must-not-manage-root"));
         rootArtifactRequest.addManagedDependency(newDep("gid:direct:ext:managed-by-dominant-request"));
         rootArtifactRequest.addManagedDependency(newDep("gid:transitive-1:ext:managed-by-root"));
-        session.setDependencyManager(new DefaultDependencyManager("system"::equals));
+        session.setDependencyManager(new DefaultDependencyManager(SYSTEM_PREDICATE));
         result = collector.collectDependencies(session, rootArtifactRequest);
         assertEqualSubtree(expectedTree, toDependencyResult(result.getRoot(), "compile", null));
     }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
@@ -18,10 +18,7 @@
  */
 package org.eclipse.aether.internal.impl.collect.bf;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
@@ -72,7 +69,7 @@ public class BfWithSkipperDependencyCollectorTest extends DependencyCollectorDel
     void testSkipperWithDifferentExclusion() throws DependencyCollectionException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager());
+        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
 
         ExclusionDependencySelector exclSel1 = new ExclusionDependencySelector();
         session.setDependencySelector(exclSel1);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
@@ -69,7 +69,7 @@ public class BfWithSkipperDependencyCollectorTest extends DependencyCollectorDel
     void testSkipperWithDifferentExclusion() throws DependencyCollectionException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
+        session.setDependencyManager(new TransitiveDependencyManager(SYSTEM_PREDICATE));
 
         ExclusionDependencySelector exclSel1 = new ExclusionDependencySelector();
         session.setDependencySelector(exclSel1);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/bf/BfWithSkipperDependencyCollectorTest.java
@@ -69,7 +69,7 @@ public class BfWithSkipperDependencyCollectorTest extends DependencyCollectorDel
     void testSkipperWithDifferentExclusion() throws DependencyCollectionException {
         collector = setupCollector(newReader("managed/"));
         parser = new DependencyGraphParser("artifact-descriptions/managed/");
-        session.setDependencyManager(new TransitiveDependencyManager(s -> Objects.equals(s, "system")));
+        session.setDependencyManager(new TransitiveDependencyManager("system"::equals));
 
         ExclusionDependencySelector exclSel1 = new ExclusionDependencySelector();
         session.setDependencySelector(exclSel1);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DependencyScopes.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DependencyScopes.java
@@ -28,7 +28,9 @@ package org.eclipse.aether.util.artifact;
  *
  * @see org.eclipse.aether.graph.Dependency#getScope()
  * @since 2.0.0
+ * @deprecated Consumer project is defining scopes.
  */
+@Deprecated
 public final class DependencyScopes {
 
     /**

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/SystemScopePredicate.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/SystemScopePredicate.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.graph;
+
+import java.util.function.Predicate;
+
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+
+/**
+ * In Resolver 1.x line, the "system" scope represented artifacts, that in 2.x resolver are now delegate to consumer
+ * application. Class or component that wants to test for this special dependency scope should use this inteface,
+ * with implementation provided by consumer application.
+ * <p>
+ * Special scope that tells resolver that dependency is not to be found in any regular repository, so it should not
+ * even try to resolve the artifact from them. Dependency in this scope does not have artifact descriptor either.
+ * Artifacts in this scope should have the "local path" property set, pointing to a file on local system, where the
+ * backing file should reside. Resolution of artifacts in this scope fails, if backing file does not exist
+ * (no property set, or property contains invalid path, or the path points to a non-existent file).
+ *
+ * @see org.eclipse.aether.artifact.ArtifactProperties#LOCAL_PATH
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface SystemScopePredicate extends Predicate<String> {
+    default boolean test(Dependency dependency) {
+        return test(dependency.getScope());
+    }
+
+    default boolean test(DependencyNode dependencyNode) {
+        return dependencyNode.getDependency() != null && test(dependencyNode.getDependency());
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -18,12 +18,8 @@
  */
 package org.eclipse.aether.util.graph.manager;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Predicate;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
@@ -32,7 +28,6 @@ import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.Exclusion;
-import org.eclipse.aether.util.artifact.DependencyScopes;
 
 import static java.util.Objects.requireNonNull;
 
@@ -59,12 +54,11 @@ public abstract class AbstractDependencyManager implements DependencyManager {
 
     protected final Map<Object, Collection<Exclusion>> managedExclusions;
 
+    protected final Predicate<String> systemScopePredicate;
+
     private final int hashCode;
 
-    /**
-     * Creates a new dependency manager without any management information.
-     */
-    protected AbstractDependencyManager(int deriveUntil, int applyFrom) {
+    protected AbstractDependencyManager(int deriveUntil, int applyFrom, Predicate<String> systemScopePredicate) {
         this(
                 0,
                 deriveUntil,
@@ -73,7 +67,8 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                systemScopePredicate);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -85,15 +80,17 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             Map<Object, String> managedScopes,
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
-            Map<Object, Collection<Exclusion>> managedExclusions) {
+            Map<Object, Collection<Exclusion>> managedExclusions,
+            Predicate<String> systemScopePredicate) {
         this.depth = depth;
         this.deriveUntil = deriveUntil;
         this.applyFrom = applyFrom;
-        this.managedVersions = managedVersions;
-        this.managedScopes = managedScopes;
-        this.managedOptionals = managedOptionals;
-        this.managedLocalPaths = managedLocalPaths;
-        this.managedExclusions = managedExclusions;
+        this.managedVersions = requireNonNull(managedVersions);
+        this.managedScopes = requireNonNull(managedScopes);
+        this.managedOptionals = requireNonNull(managedOptionals);
+        this.managedLocalPaths = requireNonNull(managedLocalPaths);
+        this.managedExclusions = requireNonNull(managedExclusions);
+        this.systemScopePredicate = requireNonNull(systemScopePredicate);
 
         this.hashCode = Objects.hash(
                 depth,
@@ -195,7 +192,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
                 management.setScope(scope);
 
-                if (!DependencyScopes.SYSTEM.equals(scope)
+                if (!systemScopePredicate.test(scope)
                         && dependency.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
                     Map<String, String> properties =
                             new HashMap<>(dependency.getArtifact().getProperties());
@@ -204,8 +201,8 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
             }
 
-            if ((DependencyScopes.SYSTEM.equals(scope))
-                    || (scope == null && DependencyScopes.SYSTEM.equals(dependency.getScope()))) {
+            if ((systemScopePredicate.test(scope))
+                    || (scope == null && systemScopePredicate.test(dependency.getScope()))) {
                 String localPath = managedLocalPaths.get(key);
                 if (localPath != null) {
                     if (management == null) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -37,6 +37,13 @@ import static java.util.Objects.requireNonNull;
  * @since 2.0.0
  */
 public abstract class AbstractDependencyManager implements DependencyManager {
+    /**
+     * This predicate is here ONLY to support deprecated constructors.
+     *
+     * @deprecated To be removed when deprecated constructors are removed.
+     */
+    @Deprecated
+    protected static final Predicate<String> SYSTEM_PREDICATE = s -> Objects.equals(s, "system");
 
     protected final int depth;
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -19,7 +19,6 @@
 package org.eclipse.aether.util.graph.manager;
 
 import java.util.*;
-import java.util.function.Predicate;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
@@ -28,6 +27,7 @@ import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +43,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
      * @deprecated To be removed when deprecated constructors are removed.
      */
     @Deprecated
-    protected static final Predicate<String> SYSTEM_PREDICATE = s -> Objects.equals(s, "system");
+    protected static final SystemScopePredicate SYSTEM_PREDICATE = "system"::equals;
 
     protected final int depth;
 
@@ -61,11 +61,11 @@ public abstract class AbstractDependencyManager implements DependencyManager {
 
     protected final Map<Object, Collection<Exclusion>> managedExclusions;
 
-    protected final Predicate<String> systemScopePredicate;
+    protected final SystemScopePredicate systemScopePredicate;
 
     private final int hashCode;
 
-    protected AbstractDependencyManager(int deriveUntil, int applyFrom, Predicate<String> systemScopePredicate) {
+    protected AbstractDependencyManager(int deriveUntil, int applyFrom, SystemScopePredicate systemScopePredicate) {
         this(
                 0,
                 deriveUntil,
@@ -88,7 +88,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
             Map<Object, Collection<Exclusion>> managedExclusions,
-            Predicate<String> systemScopePredicate) {
+            SystemScopePredicate systemScopePredicate) {
         this.depth = depth;
         this.deriveUntil = deriveUntil;
         this.applyFrom = applyFrom;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -40,7 +40,7 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
      */
     @Deprecated
     public ClassicDependencyManager() {
-        this(s -> Objects.equals(s, "system"));
+        this(SYSTEM_PREDICATE);
     }
 
     public ClassicDependencyManager(Predicate<String> systemScopePredicate) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -20,7 +20,6 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -20,11 +20,11 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 
 /**
  * A dependency manager that mimics the way Maven 2.x works. This manager was used throughout all Maven 3.x versions.
@@ -42,7 +42,7 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
         this(SYSTEM_PREDICATE);
     }
 
-    public ClassicDependencyManager(Predicate<String> systemScopePredicate) {
+    public ClassicDependencyManager(SystemScopePredicate systemScopePredicate) {
         this(false, systemScopePredicate);
     }
 
@@ -55,7 +55,7 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
      *
      * @since 2.0.0
      */
-    public ClassicDependencyManager(boolean transitive, Predicate<String> systemScopePredicate) {
+    public ClassicDependencyManager(boolean transitive, SystemScopePredicate systemScopePredicate) {
         super(transitive ? Integer.MAX_VALUE : 2, 2, systemScopePredicate);
     }
 
@@ -69,7 +69,7 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
             Map<Object, Collection<Exclusion>> managedExclusions,
-            Predicate<String> systemScopePredicate) {
+            SystemScopePredicate systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -20,6 +20,8 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencyManager;
@@ -33,9 +35,16 @@ import org.eclipse.aether.graph.Exclusion;
 public final class ClassicDependencyManager extends AbstractDependencyManager {
     /**
      * Creates a new dependency manager without any management information.
+     *
+     * @deprecated Use constructor that provides consumer application specific predicate.
      */
+    @Deprecated
     public ClassicDependencyManager() {
-        this(false);
+        this(s -> Objects.equals(s, "system"));
+    }
+
+    public ClassicDependencyManager(Predicate<String> systemScopePredicate) {
+        this(false, systemScopePredicate);
     }
 
     /**
@@ -47,8 +56,8 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
      *
      * @since 2.0.0
      */
-    public ClassicDependencyManager(boolean transitive) {
-        super(transitive ? Integer.MAX_VALUE : 2, 2);
+    public ClassicDependencyManager(boolean transitive, Predicate<String> systemScopePredicate) {
+        super(transitive ? Integer.MAX_VALUE : 2, 2, systemScopePredicate);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -60,7 +69,8 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
             Map<Object, String> managedScopes,
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
-            Map<Object, Collection<Exclusion>> managedExclusions) {
+            Map<Object, Collection<Exclusion>> managedExclusions,
+            Predicate<String> systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,
@@ -69,7 +79,8 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 
     @Override
@@ -98,6 +109,7 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -20,6 +20,8 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Exclusion;
@@ -39,9 +41,16 @@ import org.eclipse.aether.graph.Exclusion;
 public final class DefaultDependencyManager extends AbstractDependencyManager {
     /**
      * Creates a new dependency manager without any management information.
+     *
+     * @deprecated Use constructor that provides consumer application specific predicate.
      */
+    @Deprecated
     public DefaultDependencyManager() {
-        super(Integer.MAX_VALUE, 0);
+        this(s -> Objects.equals(s, "system"));
+    }
+
+    public DefaultDependencyManager(Predicate<String> systemScopePredicate) {
+        super(Integer.MAX_VALUE, 0, systemScopePredicate);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -53,7 +62,8 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
             Map<Object, String> managedScopes,
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
-            Map<Object, Collection<Exclusion>> managedExclusions) {
+            Map<Object, Collection<Exclusion>> managedExclusions,
+            Predicate<String> systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,
@@ -62,7 +72,8 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 
     @Override
@@ -80,6 +91,7 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -20,10 +20,10 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 
 /**
  * A dependency manager managing dependencies on all levels supporting transitive dependency management.
@@ -48,7 +48,7 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
         this(SYSTEM_PREDICATE);
     }
 
-    public DefaultDependencyManager(Predicate<String> systemScopePredicate) {
+    public DefaultDependencyManager(SystemScopePredicate systemScopePredicate) {
         super(Integer.MAX_VALUE, 0, systemScopePredicate);
     }
 
@@ -62,7 +62,7 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
             Map<Object, Collection<Exclusion>> managedExclusions,
-            Predicate<String> systemScopePredicate) {
+            SystemScopePredicate systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -46,7 +46,7 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
      */
     @Deprecated
     public DefaultDependencyManager() {
-        this(s -> Objects.equals(s, "system"));
+        this(SYSTEM_PREDICATE);
     }
 
     public DefaultDependencyManager(Predicate<String> systemScopePredicate) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -20,7 +20,6 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -43,7 +43,7 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
      */
     @Deprecated
     public TransitiveDependencyManager() {
-        this(s -> Objects.equals(s, "system"));
+        this(SYSTEM_PREDICATE);
     }
 
     public TransitiveDependencyManager(Predicate<String> systemScopePredicate) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -20,6 +20,8 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Exclusion;
@@ -36,9 +38,16 @@ import org.eclipse.aether.graph.Exclusion;
 public final class TransitiveDependencyManager extends AbstractDependencyManager {
     /**
      * Creates a new dependency manager without any management information.
+     *
+     * @deprecated Use constructor that provides consumer application specific predicate.
      */
+    @Deprecated
     public TransitiveDependencyManager() {
-        super(Integer.MAX_VALUE, 2);
+        this(s -> Objects.equals(s, "system"));
+    }
+
+    public TransitiveDependencyManager(Predicate<String> systemScopePredicate) {
+        super(Integer.MAX_VALUE, 2, systemScopePredicate);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -50,7 +59,8 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
             Map<Object, String> managedScopes,
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
-            Map<Object, Collection<Exclusion>> managedExclusions) {
+            Map<Object, Collection<Exclusion>> managedExclusions,
+            Predicate<String> systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,
@@ -59,7 +69,8 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 
     @Override
@@ -77,6 +88,7 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
                 managedScopes,
                 managedOptionals,
                 managedLocalPaths,
-                managedExclusions);
+                managedExclusions,
+                systemScopePredicate);
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -20,10 +20,10 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Exclusion;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 
 /**
  * A dependency manager managing transitive dependencies supporting transitive dependency management.
@@ -45,7 +45,7 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
         this(SYSTEM_PREDICATE);
     }
 
-    public TransitiveDependencyManager(Predicate<String> systemScopePredicate) {
+    public TransitiveDependencyManager(SystemScopePredicate systemScopePredicate) {
         super(Integer.MAX_VALUE, 2, systemScopePredicate);
     }
 
@@ -59,7 +59,7 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
             Map<Object, Boolean> managedOptionals,
             Map<Object, String> managedLocalPaths,
             Map<Object, Collection<Exclusion>> managedExclusions,
-            Predicate<String> systemScopePredicate) {
+            SystemScopePredicate systemScopePredicate) {
         super(
                 depth,
                 deriveUntil,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -20,7 +20,6 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.eclipse.aether.collection.DependencyManager;

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -20,8 +20,6 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Objects;
-import java.util.function.Predicate;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -32,6 +30,7 @@ import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.util.graph.SystemScopePredicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DependencyManagerTest {
 
-    private final Predicate<String> systemScopePredicate = s -> Objects.equals(s, "system");
+    private final SystemScopePredicate systemScopePredicate = "system"::equals;
 
     private final Artifact A1 = new DefaultArtifact("test", "a", "", "1");
 

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -20,6 +20,8 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -39,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * UT for {@link DependencyManager} implementations.
  */
 public class DependencyManagerTest {
+
+    private final Predicate<String> systemScopePredicate = s -> Objects.equals(s, "system");
 
     private final Artifact A1 = new DefaultArtifact("test", "a", "", "1");
 
@@ -73,7 +77,7 @@ public class DependencyManagerTest {
 
     @Test
     void testClassic() {
-        DependencyManager manager = new ClassicDependencyManager();
+        DependencyManager manager = new ClassicDependencyManager(systemScopePredicate);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -132,7 +136,7 @@ public class DependencyManagerTest {
 
     @Test
     void testClassicTransitive() {
-        DependencyManager manager = new ClassicDependencyManager(true);
+        DependencyManager manager = new ClassicDependencyManager(true, systemScopePredicate);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -192,7 +196,7 @@ public class DependencyManagerTest {
 
     @Test
     void testTransitive() {
-        DependencyManager manager = new TransitiveDependencyManager();
+        DependencyManager manager = new TransitiveDependencyManager(systemScopePredicate);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -252,7 +256,7 @@ public class DependencyManagerTest {
 
     @Test
     void testDefault() {
-        DependencyManager manager = new DefaultDependencyManager();
+        DependencyManager manager = new DefaultDependencyManager(systemScopePredicate);
         DependencyManagement mngt;
 
         // depth=1: all applied

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -41,7 +41,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DependencyManagerTest {
 
-    private final SystemScopePredicate systemScopePredicate = "system"::equals;
+    @SuppressWarnings("deprecation")
+    private static final SystemScopePredicate SYSTEM_PREDICATE = AbstractDependencyManager.SYSTEM_PREDICATE;
 
     private final Artifact A1 = new DefaultArtifact("test", "a", "", "1");
 
@@ -76,7 +77,7 @@ public class DependencyManagerTest {
 
     @Test
     void testClassic() {
-        DependencyManager manager = new ClassicDependencyManager(systemScopePredicate);
+        DependencyManager manager = new ClassicDependencyManager(SYSTEM_PREDICATE);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -135,7 +136,7 @@ public class DependencyManagerTest {
 
     @Test
     void testClassicTransitive() {
-        DependencyManager manager = new ClassicDependencyManager(true, systemScopePredicate);
+        DependencyManager manager = new ClassicDependencyManager(true, SYSTEM_PREDICATE);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -195,7 +196,7 @@ public class DependencyManagerTest {
 
     @Test
     void testTransitive() {
-        DependencyManager manager = new TransitiveDependencyManager(systemScopePredicate);
+        DependencyManager manager = new TransitiveDependencyManager(SYSTEM_PREDICATE);
         DependencyManagement mngt;
 
         // depth=1: only exclusion applied, nothing more
@@ -255,7 +256,7 @@ public class DependencyManagerTest {
 
     @Test
     void testDefault() {
-        DependencyManager manager = new DefaultDependencyManager(systemScopePredicate);
+        DependencyManager manager = new DefaultDependencyManager(SYSTEM_PREDICATE);
         DependencyManagement mngt;
 
         // depth=1: all applied


### PR DESCRIPTION
It is duty of consumer application to define those. Also, no need for SPI either, as essentialy ONLY the dependency managers were using the "system" scope definition so far.

Now, client code, that instantianates these anyway are able to pass in predicate.

Note: as util is japicmp checked, the def ctors MUST stay, but are deprecated.

---

https://issues.apache.org/jira/browse/MRESOLVER-491