### PR TITLE
Paths everywhere

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositoryEvent.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositoryEvent.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -149,7 +150,7 @@ public final class RepositoryEvent {
 
     private final ArtifactRepository repository;
 
-    private final File file;
+    private final Path path;
 
     private final List<Exception> exceptions;
 
@@ -161,7 +162,7 @@ public final class RepositoryEvent {
         artifact = builder.artifact;
         metadata = builder.metadata;
         repository = builder.repository;
-        file = builder.file;
+        path = builder.path;
         exceptions = builder.exceptions;
         trace = builder.trace;
     }
@@ -206,9 +207,21 @@ public final class RepositoryEvent {
      * Gets the file involved in the event (if any).
      *
      * @return The involved file or {@code null} if none.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the file involved in the event (if any).
+     *
+     * @return The involved file or {@code null} if none.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -260,8 +273,8 @@ public final class RepositoryEvent {
         if (getMetadata() != null) {
             buffer.append(" ").append(getMetadata());
         }
-        if (getFile() != null) {
-            buffer.append(" (").append(getFile()).append(")");
+        if (getPath() != null) {
+            buffer.append(" (").append(getPath()).append(")");
         }
         if (getRepository() != null) {
             buffer.append(" @ ").append(getRepository());
@@ -284,7 +297,7 @@ public final class RepositoryEvent {
 
         ArtifactRepository repository;
 
-        File file;
+        Path path;
 
         List<Exception> exceptions = Collections.emptyList();
 
@@ -339,9 +352,22 @@ public final class RepositoryEvent {
          *
          * @param file The involved file, may be {@code null}.
          * @return This event builder for chaining, never {@code null}.
+         * @deprecated Use {@link #setPath(Path)} instead.
          */
+        @Deprecated
         public Builder setFile(File file) {
-            this.file = file;
+            return setPath(file != null ? file.toPath() : null);
+        }
+
+        /**
+         * Sets the file involved in the event.
+         *
+         * @param path The involved file, may be {@code null}.
+         * @return This event builder for chaining, never {@code null}.
+         * @since 2.0.0
+         */
+        public Builder setPath(Path path) {
+            this.path = path;
             return this;
         }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -19,8 +19,8 @@
 package org.eclipse.aether;
 
 import java.io.Closeable;
-import java.io.File;
-import java.util.List;
+import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -398,6 +398,14 @@ public interface RepositorySystemSession {
         SessionBuilder setSystemScopeHandler(SystemScopeHandler systemScopeHandler);
 
         /**
+         * Adds on session ended handler to be immediately registered when this builder creates session.
+         *
+         * @param handler The on session ended handler, may not be {@code null}.
+         * @return The session for chaining, never {@code null}.
+         */
+        SessionBuilder addOnSessionEndedHandler(Runnable handler);
+
+        /**
          * Sets the custom session data supplier associated with this session.
          * Note: The supplier will be used for every built session out of this builder instance, so if supplier supplies
          * <em>same instance</em> the built sessions will share these instances as well!
@@ -419,25 +427,25 @@ public interface RepositorySystemSession {
 
         /**
          * Shortcut method to set up local repository manager directly onto builder. There must be at least one non-null
-         * {@link File} passed in this method. In case multiple files, session builder will use chained local repository
+         * {@link Path} passed in this method. In case multiple files, session builder will use chained local repository
          * manager.
          *
          * @param baseDirectories The local repository base directories.
          * @return This session for chaining, never {@code null}.
          * @see #withLocalRepositories(LocalRepository...)
          */
-        SessionBuilder withLocalRepositoryBaseDirectories(File... baseDirectories);
+        SessionBuilder withLocalRepositoryBaseDirectories(Path... baseDirectories);
 
         /**
          * Shortcut method to set up local repository manager directly onto builder. There must be at least one non-null
-         * {@link File} present in passed in list. In case multiple files, session builder will use chained local
+         * {@link Path} present in passed in list. In case multiple files, session builder will use chained local
          * repository manager.
          *
          * @param baseDirectories The local repository base directories.
          * @return This session for chaining, never {@code null}.
-         * @see #withLocalRepositories(List)
+         * @see #withLocalRepositories(Collection)
          */
-        SessionBuilder withLocalRepositoryBaseDirectories(List<File> baseDirectories);
+        SessionBuilder withLocalRepositoryBaseDirectories(Collection<Path> baseDirectories);
 
         /**
          * Shortcut method to set up local repository manager directly onto builder. There must be at least one non-null
@@ -457,7 +465,39 @@ public interface RepositorySystemSession {
          * @param localRepositories The local repositories.
          * @return This session for chaining, never {@code null}.
          */
-        SessionBuilder withLocalRepositories(List<LocalRepository> localRepositories);
+        SessionBuilder withLocalRepositories(Collection<LocalRepository> localRepositories);
+
+        /**
+         * Adds the listeners to be notified of actions in the repository system.
+         *
+         * @param repositoryListeners The repository listeners, never {@code null}.
+         * @return This session for chaining, never {@code null}.
+         */
+        SessionBuilder withRepositoryListener(RepositoryListener... repositoryListeners);
+
+        /**
+         * Adds the listeners to be notified of actions in the repository system.
+         *
+         * @param repositoryListeners The repository listeners, never {@code null}.
+         * @return This session for chaining, never {@code null}.
+         */
+        SessionBuilder withRepositoryListener(Collection<RepositoryListener> repositoryListeners);
+
+        /**
+         * Adds the listener to be notified of uploads/downloads by the repository system.
+         *
+         * @param transferListeners The transfer listeners, never {@code null}.
+         * @return This session for chaining, never {@code null}.
+         */
+        SessionBuilder withTransferListener(TransferListener... transferListeners);
+
+        /**
+         * Adds the listener to be notified of uploads/downloads by the repository system.
+         *
+         * @param transferListeners The transfer listeners, never {@code null}.
+         * @return This session for chaining, never {@code null}.
+         */
+        SessionBuilder withTransferListener(Collection<TransferListener> transferListeners);
 
         /**
          * Shortcut method to shallow-copy passed in session into current builder.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/Artifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/Artifact.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.artifact;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -97,16 +98,38 @@ public interface Artifact {
      * callers must not assume any relationship between an artifact's filename and its coordinates.
      *
      * @return The file or {@code null} if the artifact isn't resolved.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     File getFile();
+
+    /**
+     * Gets the file of this artifact. Note that only resolved artifacts have a file associated with them. In general,
+     * callers must not assume any relationship between an artifact's filename and its coordinates.
+     *
+     * @return The file or {@code null} if the artifact isn't resolved.
+     * @since 2.0.0
+     */
+    Path getPath();
 
     /**
      * Sets the file of the artifact.
      *
      * @param file The file of the artifact, may be {@code null}
      * @return The new artifact, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     Artifact setFile(File file);
+
+    /**
+     * Sets the file of the artifact.
+     *
+     * @param path The file of the artifact, may be {@code null}
+     * @return The new artifact, never {@code null}.
+     * @since 2.0.0
+     */
+    Artifact setPath(Path path);
 
     /**
      * Gets the specified property.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.artifact;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +44,7 @@ public final class DefaultArtifact extends AbstractArtifact {
 
     private final String extension;
 
-    private final File file;
+    private final Path path;
 
     private final Map<String, String> properties;
 
@@ -116,7 +117,7 @@ public final class DefaultArtifact extends AbstractArtifact {
         extension = get(m.group(4), type == null ? "jar" : type.getExtension());
         classifier = get(m.group(6), type == null ? "" : type.getClassifier());
         this.version = emptify(m.group(7));
-        this.file = null;
+        this.path = null;
         this.properties = merge(properties, (type != null) ? type.getProperties() : null);
     }
 
@@ -205,7 +206,7 @@ public final class DefaultArtifact extends AbstractArtifact {
             this.extension = emptify(type.getExtension());
         }
         this.version = emptify(version);
-        this.file = null;
+        this.path = null;
         this.properties = merge(properties, (type != null) ? type.getProperties() : null);
     }
 
@@ -253,7 +254,36 @@ public final class DefaultArtifact extends AbstractArtifact {
         this.classifier = emptify(classifier);
         this.extension = emptify(extension);
         this.version = emptify(version);
-        this.file = file;
+        this.path = file != null ? file.toPath() : null;
+        this.properties = copyProperties(properties);
+    }
+
+    /**
+     * Creates a new artifact with the specified coordinates, properties and file. Passing {@code null} for any of the
+     * coordinates is equivalent to specifying an empty string.
+     *
+     * @param groupId The group identifier of the artifact, may be {@code null}.
+     * @param artifactId The artifact identifier of the artifact, may be {@code null}.
+     * @param classifier The classifier of the artifact, may be {@code null}.
+     * @param extension The file extension of the artifact, may be {@code null}.
+     * @param version The version of the artifact, may be {@code null}.
+     * @param properties The properties of the artifact, may be {@code null} if none.
+     * @param path The resolved file of the artifact, may be {@code null}.
+     */
+    public DefaultArtifact(
+            String groupId,
+            String artifactId,
+            String classifier,
+            String extension,
+            String version,
+            Map<String, String> properties,
+            Path path) {
+        this.groupId = emptify(groupId);
+        this.artifactId = emptify(artifactId);
+        this.classifier = emptify(classifier);
+        this.extension = emptify(extension);
+        this.version = emptify(version);
+        this.path = path;
         this.properties = copyProperties(properties);
     }
 
@@ -263,7 +293,7 @@ public final class DefaultArtifact extends AbstractArtifact {
             String classifier,
             String extension,
             String version,
-            File file,
+            Path path,
             Map<String, String> properties) {
         // NOTE: This constructor assumes immutability of the provided properties, for internal use only
         this.groupId = emptify(groupId);
@@ -271,7 +301,7 @@ public final class DefaultArtifact extends AbstractArtifact {
         this.classifier = emptify(classifier);
         this.extension = emptify(extension);
         this.version = emptify(version);
-        this.file = file;
+        this.path = path;
         this.properties = properties;
     }
 
@@ -299,8 +329,13 @@ public final class DefaultArtifact extends AbstractArtifact {
         return extension;
     }
 
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    public Path getPath() {
+        return path;
     }
 
     public Map<String, String> getProperties() {

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/AbstractMetadata.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/AbstractMetadata.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.metadata;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,27 +30,40 @@ import java.util.Objects;
  */
 public abstract class AbstractMetadata implements Metadata {
 
-    private Metadata newInstance(Map<String, String> properties, File file) {
+    private Metadata newInstance(Map<String, String> properties, Path path) {
         return new DefaultMetadata(
-                getGroupId(), getArtifactId(), getVersion(), getType(), getNature(), file, properties);
+                getGroupId(), getArtifactId(), getVersion(), getType(), getNature(), path, properties);
     }
 
+    @Deprecated
+    @Override
     public Metadata setFile(File file) {
         File current = getFile();
         if (Objects.equals(current, file)) {
             return this;
         }
-        return newInstance(getProperties(), file);
+        return newInstance(getProperties(), file != null ? file.toPath() : null);
     }
 
+    @Override
+    public Metadata setPath(Path path) {
+        Path current = getPath();
+        if (Objects.equals(current, path)) {
+            return this;
+        }
+        return newInstance(getProperties(), path);
+    }
+
+    @Override
     public Metadata setProperties(Map<String, String> properties) {
         Map<String, String> current = getProperties();
         if (current.equals(properties) || (properties == null && current.isEmpty())) {
             return this;
         }
-        return newInstance(copyProperties(properties), getFile());
+        return newInstance(copyProperties(properties), getPath());
     }
 
+    @Override
     public String getProperty(String key, String defaultValue) {
         String value = getProperties().get(key);
         return (value != null) ? value : defaultValue;
@@ -108,7 +122,7 @@ public abstract class AbstractMetadata implements Metadata {
                 && Objects.equals(getVersion(), that.getVersion())
                 && Objects.equals(getType(), that.getType())
                 && Objects.equals(getNature(), that.getNature())
-                && Objects.equals(getFile(), that.getFile())
+                && Objects.equals(getPath(), that.getPath())
                 && Objects.equals(getProperties(), that.getProperties());
     }
 
@@ -125,7 +139,7 @@ public abstract class AbstractMetadata implements Metadata {
         hash = hash * 31 + getType().hashCode();
         hash = hash * 31 + getNature().hashCode();
         hash = hash * 31 + getVersion().hashCode();
-        hash = hash * 31 + hash(getFile());
+        hash = hash * 31 + hash(getPath());
         return hash;
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/DefaultMetadata.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/DefaultMetadata.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.metadata;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -39,7 +40,7 @@ public final class DefaultMetadata extends AbstractMetadata {
 
     private final Nature nature;
 
-    private final File file;
+    private final Path path;
 
     private final Map<String, String> properties;
 
@@ -50,7 +51,7 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param nature The nature of the metadata, must not be {@code null}.
      */
     public DefaultMetadata(String type, Nature nature) {
-        this("", "", "", type, nature, null, (File) null);
+        this("", "", "", type, nature, null, (Path) null);
     }
 
     /**
@@ -61,7 +62,7 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param nature The nature of the metadata, must not be {@code null}.
      */
     public DefaultMetadata(String groupId, String type, Nature nature) {
-        this(groupId, "", "", type, nature, null, (File) null);
+        this(groupId, "", "", type, nature, null, (Path) null);
     }
 
     /**
@@ -73,7 +74,7 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param nature The nature of the metadata, must not be {@code null}.
      */
     public DefaultMetadata(String groupId, String artifactId, String type, Nature nature) {
-        this(groupId, artifactId, "", type, nature, null, (File) null);
+        this(groupId, artifactId, "", type, nature, null, (Path) null);
     }
 
     /**
@@ -86,7 +87,7 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param nature The nature of the metadata, must not be {@code null}.
      */
     public DefaultMetadata(String groupId, String artifactId, String version, String type, Nature nature) {
-        this(groupId, artifactId, version, type, nature, null, (File) null);
+        this(groupId, artifactId, version, type, nature, null, (Path) null);
     }
 
     /**
@@ -98,7 +99,9 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param type The type of the metadata, e.g. "maven-metadata.xml", may be {@code null}.
      * @param nature The nature of the metadata, must not be {@code null}.
      * @param file The resolved file of the metadata, may be {@code null}.
+     * @deprecated Use {@link #DefaultMetadata(String, String, String, String, Nature, Path)} instead.
      */
+    @Deprecated
     public DefaultMetadata(String groupId, String artifactId, String version, String type, Nature nature, File file) {
         this(groupId, artifactId, version, type, nature, null, file);
     }
@@ -111,9 +114,26 @@ public final class DefaultMetadata extends AbstractMetadata {
      * @param version The version to which this metadata applies, may be {@code null}.
      * @param type The type of the metadata, e.g. "maven-metadata.xml", may be {@code null}.
      * @param nature The nature of the metadata, must not be {@code null}.
+     * @param path The resolved file of the metadata, may be {@code null}.
+     * @since 2.0.0
+     */
+    public DefaultMetadata(String groupId, String artifactId, String version, String type, Nature nature, Path path) {
+        this(groupId, artifactId, version, type, nature, null, path);
+    }
+
+    /**
+     * Creates a new metadata for the groupId:artifactId:version level with the specific type and nature.
+     *
+     * @param groupId The group identifier to which this metadata applies, may be {@code null}.
+     * @param artifactId The artifact identifier to which this metadata applies, may be {@code null}.
+     * @param version The version to which this metadata applies, may be {@code null}.
+     * @param type The type of the metadata, e.g. "maven-metadata.xml", may be {@code null}.
+     * @param nature The nature of the metadata, must not be {@code null}.
      * @param properties The properties of the metadata, may be {@code null} if none.
      * @param file The resolved file of the metadata, may be {@code null}.
+     * @deprecated Use {@link #DefaultMetadata(String, String, String, String, Nature, Map, Path)} instead.
      */
+    @Deprecated
     public DefaultMetadata(
             String groupId,
             String artifactId,
@@ -127,7 +147,36 @@ public final class DefaultMetadata extends AbstractMetadata {
         this.version = emptify(version);
         this.type = emptify(type);
         this.nature = requireNonNull(nature, "metadata nature cannot be null");
-        this.file = file;
+        this.path = file != null ? file.toPath() : null;
+        this.properties = copyProperties(properties);
+    }
+
+    /**
+     * Creates a new metadata for the groupId:artifactId:version level with the specific type and nature.
+     *
+     * @param groupId The group identifier to which this metadata applies, may be {@code null}.
+     * @param artifactId The artifact identifier to which this metadata applies, may be {@code null}.
+     * @param version The version to which this metadata applies, may be {@code null}.
+     * @param type The type of the metadata, e.g. "maven-metadata.xml", may be {@code null}.
+     * @param nature The nature of the metadata, must not be {@code null}.
+     * @param properties The properties of the metadata, may be {@code null} if none.
+     * @param path The resolved file of the metadata, may be {@code null}.
+     * @since 2.0.0
+     */
+    public DefaultMetadata(
+            String groupId,
+            String artifactId,
+            String version,
+            String type,
+            Nature nature,
+            Map<String, String> properties,
+            Path path) {
+        this.groupId = emptify(groupId);
+        this.artifactId = emptify(artifactId);
+        this.version = emptify(version);
+        this.type = emptify(type);
+        this.nature = requireNonNull(nature, "metadata nature cannot be null");
+        this.path = path;
         this.properties = copyProperties(properties);
     }
 
@@ -137,7 +186,7 @@ public final class DefaultMetadata extends AbstractMetadata {
             String version,
             String type,
             Nature nature,
-            File file,
+            Path path,
             Map<String, String> properties) {
         // NOTE: This constructor assumes immutability of the provided properties, for internal use only
         this.groupId = emptify(groupId);
@@ -145,7 +194,7 @@ public final class DefaultMetadata extends AbstractMetadata {
         this.version = emptify(version);
         this.type = emptify(type);
         this.nature = nature;
-        this.file = file;
+        this.path = path;
         this.properties = properties;
     }
 
@@ -153,30 +202,43 @@ public final class DefaultMetadata extends AbstractMetadata {
         return (str == null) ? "" : str;
     }
 
+    @Override
     public String getGroupId() {
         return groupId;
     }
 
+    @Override
     public String getArtifactId() {
         return artifactId;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public String getType() {
         return type;
     }
 
+    @Override
     public Nature getNature() {
         return nature;
     }
 
+    @Deprecated
+    @Override
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
     }
 
+    @Override
+    public Path getPath() {
+        return path;
+    }
+
+    @Override
     public Map<String, String> getProperties() {
         return properties;
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/MergeableMetadata.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/MergeableMetadata.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.metadata;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RepositoryException;
 
@@ -34,8 +35,23 @@ public interface MergeableMetadata extends Metadata {
      * @param current The path to the current metadata file, may not exist but must not be {@code null}.
      * @param result The path to the result file where the merged metadata should be stored, must not be {@code null}.
      * @throws RepositoryException If the metadata could not be merged.
+     * @deprecated Use {@link #merge(Path, Path)} instead.
      */
+    @Deprecated
     void merge(File current, File result) throws RepositoryException;
+
+    /**
+     * Merges this metadata into the current metadata (if any). Note that this method will be invoked regardless whether
+     * metadata currently exists or not.
+     *
+     * @param current The path to the current metadata file, may not exist but must not be {@code null}.
+     * @param result The path to the result file where the merged metadata should be stored, must not be {@code null}.
+     * @throws RepositoryException If the metadata could not be merged.
+     * @since 2.0.0
+     */
+    default void merge(Path current, Path result) throws RepositoryException {
+        merge(current.toFile(), result.toFile());
+    }
 
     /**
      * Indicates whether this metadata has been merged.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/Metadata.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/metadata/Metadata.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.metadata;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -96,16 +97,37 @@ public interface Metadata {
      * Gets the file of this metadata. Note that only resolved metadata has a file associated with it.
      *
      * @return The file or {@code null} if none.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     File getFile();
+
+    /**
+     * Gets the file of this metadata. Note that only resolved metadata has a file associated with it.
+     *
+     * @return The file or {@code null} if none.
+     * @since 2.0.0
+     */
+    Path getPath();
 
     /**
      * Sets the file of the metadata.
      *
      * @param file The file of the metadata, may be {@code null}
      * @return The new metadata, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     Metadata setFile(File file);
+
+    /**
+     * Sets the file of the metadata.
+     *
+     * @param path The file of the metadata, may be {@code null}
+     * @return The new metadata, never {@code null}.
+     * @since 2.0.0
+     */
+    Metadata setPath(Path path);
 
     /**
      * Gets the specified property.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalArtifactResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalArtifactResult.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.repository;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +32,7 @@ public final class LocalArtifactResult {
 
     private final LocalArtifactRequest request;
 
-    private File file;
+    private Path path;
 
     private boolean available;
 
@@ -61,9 +62,23 @@ public final class LocalArtifactResult {
      * remote repository that is not part of the list of remote repositories used for the query.
      *
      * @return The file to the requested artifact or {@code null} if the artifact does not exist locally.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the file to the requested artifact. Note that this file must not be used unless {@link #isAvailable()}
+     * returns {@code true}. An artifact file can be found but considered unavailable if the artifact was cached from a
+     * remote repository that is not part of the list of remote repositories used for the query.
+     *
+     * @return The file to the requested artifact or {@code null} if the artifact does not exist locally.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -71,9 +86,22 @@ public final class LocalArtifactResult {
      *
      * @param file The artifact file, may be {@code null}.
      * @return This result for chaining, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     public LocalArtifactResult setFile(File file) {
-        this.file = file;
+        return setPath(file != null ? file.toPath() : null);
+    }
+
+    /**
+     * Sets the file to requested artifact.
+     *
+     * @param path The artifact file, may be {@code null}.
+     * @return This result for chaining, never {@code null}.
+     * @since 2.0.0
+     */
+    public LocalArtifactResult setPath(Path path) {
+        this.path = path;
         return this;
     }
 
@@ -126,6 +154,6 @@ public final class LocalArtifactResult {
 
     @Override
     public String toString() {
-        return getFile() + " (" + (isAvailable() ? "available" : "unavailable") + ")";
+        return getPath() + " (" + (isAvailable() ? "available" : "unavailable") + ")";
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalMetadataResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalMetadataResult.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.repository;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +32,7 @@ public final class LocalMetadataResult {
 
     private final LocalMetadataRequest request;
 
-    private File file;
+    private Path path;
 
     private boolean stale;
 
@@ -57,9 +58,21 @@ public final class LocalMetadataResult {
      * Gets the file to the requested metadata if the metadata is available in the local repository.
      *
      * @return The file to the requested metadata or {@code null}.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the file to the requested metadata if the metadata is available in the local repository.
+     *
+     * @return The file to the requested metadata or {@code null}.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -67,9 +80,22 @@ public final class LocalMetadataResult {
      *
      * @param file The metadata file, may be {@code null}.
      * @return This result for chaining, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     public LocalMetadataResult setFile(File file) {
-        this.file = file;
+        return setPath(file != null ? file.toPath() : null);
+    }
+
+    /**
+     * Sets the file to requested metadata.
+     *
+     * @param path The metadata file, may be {@code null}.
+     * @return This result for chaining, never {@code null}.
+     * @since 2.0.0
+     */
+    public LocalMetadataResult setPath(Path path) {
+        this.path = path;
         return this;
     }
 
@@ -95,6 +121,6 @@ public final class LocalMetadataResult {
 
     @Override
     public String toString() {
-        return request.toString() + "(" + getFile() + ")";
+        return request.toString() + "(" + getPath() + ")";
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalRepository.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/LocalRepository.java
@@ -19,6 +19,9 @@
 package org.eclipse.aether.repository;
 
 import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 /**
@@ -29,7 +32,7 @@ import java.util.Objects;
  */
 public final class LocalRepository implements ArtifactRepository {
 
-    private final File basedir;
+    private final Path basePath;
 
     private final String type;
 
@@ -39,16 +42,39 @@ public final class LocalRepository implements ArtifactRepository {
      * @param basedir The base directory of the repository, may be {@code null}.
      */
     public LocalRepository(String basedir) {
-        this((basedir != null) ? new File(basedir) : null, "");
+        this.basePath = Paths.get(RepositoryUriUtils.toUri(basedir)).toAbsolutePath();
+        this.type = "";
     }
 
     /**
      * Creates a new local repository with the specified base directory and unknown type.
      *
      * @param basedir The base directory of the repository, may be {@code null}.
+     * @since 2.0.0
      */
+    public LocalRepository(URI basedir) {
+        this((basedir != null) ? Paths.get(basedir) : null, "");
+    }
+
+    /**
+     * Creates a new local repository with the specified base directory and unknown type.
+     *
+     * @param basedir The base directory of the repository, may be {@code null}.
+     * @deprecated Use {@link #LocalRepository(Path)} instead.
+     */
+    @Deprecated
     public LocalRepository(File basedir) {
         this(basedir, "");
+    }
+
+    /**
+     * Creates a new local repository with the specified base directory and unknown type.
+     *
+     * @param basePath The base directory of the repository, may be {@code null}.
+     * @since 2.0.0
+     */
+    public LocalRepository(Path basePath) {
+        this(basePath, "");
     }
 
     /**
@@ -56,16 +82,31 @@ public final class LocalRepository implements ArtifactRepository {
      *
      * @param basedir The base directory of the repository, may be {@code null}.
      * @param type The type of the repository, may be {@code null}.
+     * @deprecated Use {@link #LocalRepository(Path, String)} instead.
      */
+    @Deprecated
     public LocalRepository(File basedir, String type) {
-        this.basedir = basedir;
+        this(basedir != null ? basedir.toPath() : null, type);
+    }
+
+    /**
+     * Creates a new local repository with the specified properties.
+     *
+     * @param basePath The base directory of the repository, may be {@code null}.
+     * @param type The type of the repository, may be {@code null}.
+     * @since 2.0.0
+     */
+    public LocalRepository(Path basePath, String type) {
+        this.basePath = basePath;
         this.type = (type != null) ? type : "";
     }
 
+    @Override
     public String getContentType() {
         return type;
     }
 
+    @Override
     public String getId() {
         return "local";
     }
@@ -74,14 +115,26 @@ public final class LocalRepository implements ArtifactRepository {
      * Gets the base directory of the repository.
      *
      * @return The base directory or {@code null} if none.
+     * @deprecated Use {@link #getBasePath()} instead.
      */
+    @Deprecated
     public File getBasedir() {
-        return basedir;
+        return basePath != null ? basePath.toFile() : null;
+    }
+
+    /**
+     * Gets the base directory of the repository.
+     *
+     * @return The base directory or {@code null} if none.
+     * @since 2.0.0
+     */
+    public Path getBasePath() {
+        return basePath;
     }
 
     @Override
     public String toString() {
-        return getBasedir() + " (" + getContentType() + ")";
+        return getBasePath() + " (" + getContentType() + ")";
     }
 
     @Override
@@ -95,13 +148,13 @@ public final class LocalRepository implements ArtifactRepository {
 
         LocalRepository that = (LocalRepository) obj;
 
-        return Objects.equals(basedir, that.basedir) && Objects.equals(type, that.type);
+        return Objects.equals(basePath, that.basePath) && Objects.equals(type, that.type);
     }
 
     @Override
     public int hashCode() {
         int hash = 17;
-        hash = hash * 31 + hash(basedir);
+        hash = hash * 31 + hash(basePath);
         hash = hash * 31 + hash(type);
         return hash;
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/NoLocalRepositoryManagerException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/NoLocalRepositoryManagerException.java
@@ -72,7 +72,7 @@ public class NoLocalRepositoryManagerException extends RepositoryException {
     private static String toMessage(LocalRepository repository) {
         if (repository != null) {
             return "No manager available for local repository ("
-                    + repository.getBasedir().getAbsolutePath() + ") of type " + repository.getContentType();
+                    + repository.getBasePath().toAbsolutePath() + ") of type " + repository.getContentType();
         } else {
             return "No manager available for local repository";
         }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/RepositoryUriUtils.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/RepositoryUriUtils.java
@@ -16,23 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.eclipse.aether.transport.file;
+package org.eclipse.aether.repository;
+
+import java.io.File;
+import java.net.URI;
 
 /**
  * URL handling for file URLs. Based on org.apache.maven.wagon.PathUtils.
+ *
+ * @since 2.0.0
  */
-final class PathUtils {
+public final class RepositoryUriUtils {
 
-    private PathUtils() {}
+    private RepositoryUriUtils() {}
+
+    public static URI toUri(String repositoryUrl) {
+        final String protocol = protocol(repositoryUrl);
+        if ("file".equals(protocol)
+                || protocol.isEmpty()
+                || protocol.length() == 1
+                        && (Character.isLetter(protocol.charAt(0)) && Character.isUpperCase(protocol.charAt(0)))) {
+            return new File(basedir(repositoryUrl)).toURI();
+        } else {
+            return URI.create(repositoryUrl);
+        }
+    }
 
     /**
-     * Return the protocol name. <br/>
-     * E.g: for input <code>http://www.codehause.org</code> this method will return <code>http</code>
+     * Return the protocol name.
      *
      * @param url the url
-     * @return the host name
+     * @return the protocol or empty string.
      */
-    public static String protocol(final String url) {
+    private static String protocol(final String url) {
         final int pos = url.indexOf(":");
 
         if (pos == -1) {
@@ -47,10 +63,10 @@ final class PathUtils {
      * @param url the file-repository URL
      * @return the basedir of the repository
      */
-    public static String basedir(String url) {
-        String protocol = PathUtils.protocol(url);
+    private static String basedir(String url) {
+        String protocol = protocol(url);
 
-        String retValue = null;
+        String retValue;
 
         if (!protocol.isEmpty()) {
             retValue = url.substring(protocol.length() + 1);
@@ -97,7 +113,7 @@ final class PathUtils {
      * @param url The URL to decode, may be <code>null</code>.
      * @return The decoded URL or <code>null</code> if the input was <code>null</code>.
      */
-    static String decode(String url) {
+    private static String decode(String url) {
         String decoded = url;
         if (url != null) {
             int pos = -1;

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/repository/WorkspaceReader.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/repository/WorkspaceReader.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.repository;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.eclipse.aether.artifact.Artifact;
@@ -44,6 +45,18 @@ public interface WorkspaceReader {
      * @return The path to the artifact or {@code null} if the artifact is not available.
      */
     File findArtifact(Artifact artifact);
+
+    /**
+     * Locates the specified artifact.
+     *
+     * @param artifact The artifact to locate, must not be {@code null}.
+     * @return The path to the artifact or {@code null} if the artifact is not available.
+     * @since 2.0.0
+     */
+    default Path findArtifactPath(Artifact artifact) {
+        File file = findArtifact(artifact);
+        return file != null ? file.toPath() : null;
+    }
 
     /**
      * Determines all available versions of the specified artifact.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResolutionException.java
@@ -102,7 +102,7 @@ public class ArtifactResolutionException extends RepositoryException {
                 LocalArtifactResult localResult = result.getLocalArtifactResult();
                 if (localResult != null) {
                     buffer.append(" (");
-                    if (localResult.getFile() != null) {
+                    if (localResult.getPath() != null) {
                         buffer.append("present");
                         if (!localResult.isAvailable()) {
                             buffer.append(", but unavailable");

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/ArtifactResult.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  * The result of an artifact resolution request.
  *
  * @see RepositorySystem#resolveArtifacts(org.eclipse.aether.RepositorySystemSession, java.util.Collection)
- * @see Artifact#getFile()
+ * @see Artifact#getPath()
  */
 public final class ArtifactResult {
 
@@ -217,10 +217,10 @@ public final class ArtifactResult {
      * of the specified remote repositories.
      *
      * @return {@code true} if the artifact was resolved, {@code false} otherwise.
-     * @see Artifact#getFile()
+     * @see Artifact#getPath()
      */
     public boolean isResolved() {
-        return getArtifact() != null && getArtifact().getFile() != null;
+        return getArtifact() != null && getArtifact().getPath() != null;
     }
 
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/MetadataResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/MetadataResult.java
@@ -127,10 +127,10 @@ public final class MetadataResult {
      * refetch the metadata from the remote repository.
      *
      * @return {@code true} if the metadata was resolved, {@code false} otherwise.
-     * @see Metadata#getFile()
+     * @see Metadata#getPath()
      */
     public boolean isResolved() {
-        return getMetadata() != null && getMetadata().getFile() != null;
+        return getMetadata() != null && getMetadata().getPath() != null;
     }
 
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/MetadataNotFoundException.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/MetadataNotFoundException.java
@@ -41,7 +41,7 @@ public class MetadataNotFoundException extends MetadataTransferException {
         if (repository == null) {
             return "";
         } else {
-            return prefix + repository.getId() + " (" + repository.getBasedir() + ")";
+            return prefix + repository.getId() + " (" + repository.getBasePath().toAbsolutePath() + ")";
         }
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.transfer;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RequestTrace;
 
@@ -33,7 +34,7 @@ public final class TransferResource {
 
     private final String resourceName;
 
-    private final File file;
+    private final Path path;
 
     private final long startTime;
 
@@ -56,9 +57,30 @@ public final class TransferResource {
      * @param trace The trace information, may be {@code null}.
      *
      * @since 1.1.0
+     * @deprecated Use {@link TransferResource(String, String, String, Path, RequestTrace)} instead.
      */
+    @Deprecated
     public TransferResource(
             String repositoryId, String repositoryUrl, String resourceName, File file, RequestTrace trace) {
+        this(repositoryId, repositoryUrl, resourceName, file != null ? file.toPath() : null, trace);
+    }
+
+    /**
+     * Creates a new transfer resource with the specified properties.
+     *
+     * @param repositoryId The ID of the repository used to transfer the resource, may be {@code null} or
+     *                     empty if unknown.
+     * @param repositoryUrl The base URL of the repository, may be {@code null} or empty if unknown. If not empty, a
+     *            trailing slash will automatically be added if missing.
+     * @param resourceName The relative path to the resource within the repository, may be {@code null}. A leading slash
+     *            (if any) will be automatically removed.
+     * @param path The source/target file involved in the transfer, may be {@code null}.
+     * @param trace The trace information, may be {@code null}.
+     *
+     * @since 2.0.0
+     */
+    public TransferResource(
+            String repositoryId, String repositoryUrl, String resourceName, Path path, RequestTrace trace) {
         if (repositoryId == null || repositoryId.isEmpty()) {
             this.repositoryId = "";
         } else {
@@ -81,7 +103,7 @@ public final class TransferResource {
             this.resourceName = resourceName;
         }
 
-        this.file = file;
+        this.path = path;
 
         this.trace = trace;
 
@@ -100,7 +122,7 @@ public final class TransferResource {
     }
 
     /**
-     * The base URL of the repository, e.g. "http://repo1.maven.org/maven2/". Unless the URL is unknown, it will be
+     * The base URL of the repository, e.g. "https://repo1.maven.org/maven2/". Unless the URL is unknown, it will be
      * terminated by a trailing slash.
      *
      * @return The base URL of the repository or an empty string if unknown, never {@code null}.
@@ -123,9 +145,22 @@ public final class TransferResource {
      * remote resource, no local file will be involved in the transfer.
      *
      * @return The source/target file involved in the transfer or {@code null} if none.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the local file being uploaded or downloaded. When the repository system merely checks for the existence of a
+     * remote resource, no local file will be involved in the transfer.
+     *
+     * @return The source/target file involved in the transfer or {@code null} if none.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -195,6 +230,6 @@ public final class TransferResource {
 
     @Override
     public String toString() {
-        return getRepositoryUrl() + getResourceName() + " <> " + getFile();
+        return getRepositoryUrl() + getResourceName() + " <> " + getPath();
     }
 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/repository/LocalRepositoryTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/repository/LocalRepositoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.repository;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+
+import org.junit.jupiter.api.Test;
+
+public class LocalRepositoryTest {
+    @Test
+    void cwd() {
+        doIt(new File("."));
+    }
+
+    @Test
+    void allRoots() {
+        FileSystems.getDefault().getRootDirectories().forEach(p -> doIt(new File(p.toUri())));
+    }
+
+    @Test
+    void root() {
+        doIt(new File(File.separator));
+    }
+
+    @Test
+    void allSomePaths() {
+        FileSystems.getDefault()
+                .getRootDirectories()
+                .forEach(p -> doIt(new File(p.resolve("some/path").toUri())));
+    }
+
+    private void doIt(File file) {
+        new LocalRepository(file.toPath().toUri().toASCIIString());
+    }
+}

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/transfer/TransferEventTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/transfer/TransferEventTest.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.transfer;
 
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.mock;
  */
 public class TransferEventTest {
 
-    private static final TransferResource res = new TransferResource("none", "file://nil", "void", null, null);
+    private static final TransferResource res = new TransferResource("none", "file://nil", "void", (Path) null, null);
 
     private static final RepositorySystemSession session = mock(RepositorySystemSession.class);
 

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory.java
@@ -31,7 +31,7 @@ import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
 import org.eclipse.aether.spi.connector.transport.TransporterProvider;
-import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.spi.io.ChecksumProcessor;
 import org.eclipse.aether.transfer.NoRepositoryConnectorException;
 
 import static java.util.Objects.requireNonNull;
@@ -50,7 +50,7 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
 
     private final ChecksumPolicyProvider checksumPolicyProvider;
 
-    private final FileProcessor fileProcessor;
+    private final ChecksumProcessor checksumProcessor;
 
     private final Map<String, ProvidedChecksumsSource> providedChecksumsSources;
 
@@ -61,12 +61,12 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
             TransporterProvider transporterProvider,
             RepositoryLayoutProvider layoutProvider,
             ChecksumPolicyProvider checksumPolicyProvider,
-            FileProcessor fileProcessor,
+            ChecksumProcessor checksumProcessor,
             Map<String, ProvidedChecksumsSource> providedChecksumsSources) {
         this.transporterProvider = requireNonNull(transporterProvider, "transporter provider cannot be null");
         this.layoutProvider = requireNonNull(layoutProvider, "repository layout provider cannot be null");
         this.checksumPolicyProvider = requireNonNull(checksumPolicyProvider, "checksum policy provider cannot be null");
-        this.fileProcessor = requireNonNull(fileProcessor, "file processor cannot be null");
+        this.checksumProcessor = requireNonNull(checksumProcessor, "checksum processor cannot be null");
         this.providedChecksumsSources =
                 requireNonNull(providedChecksumsSources, "provided checksum sources cannot be null");
     }
@@ -99,7 +99,7 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
                 transporterProvider,
                 layoutProvider,
                 checksumPolicyProvider,
-                fileProcessor,
+                checksumProcessor,
                 providedChecksumsSources);
     }
 }

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumCalculator.java
@@ -19,12 +19,12 @@
 package org.eclipse.aether.connector.basic;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -78,17 +78,17 @@ final class ChecksumCalculator {
 
     private final List<Checksum> checksums;
 
-    private final File targetFile;
+    private final Path targetFile;
 
     public static ChecksumCalculator newInstance(
-            File targetFile, Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+            Path targetFile, Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
         if (checksumAlgorithmFactories == null || checksumAlgorithmFactories.isEmpty()) {
             return null;
         }
         return new ChecksumCalculator(targetFile, checksumAlgorithmFactories);
     }
 
-    private ChecksumCalculator(File targetFile, Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+    private ChecksumCalculator(Path targetFile, Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
         this.checksums = new ArrayList<>();
         Set<String> algos = new HashSet<>();
         for (ChecksumAlgorithmFactory checksumAlgorithmFactory : checksumAlgorithmFactories) {
@@ -107,7 +107,7 @@ final class ChecksumCalculator {
             return;
         }
 
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(targetFile.toPath()))) {
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(targetFile))) {
             long total = 0;
             final byte[] buffer = new byte[1024 * 32];
             while (total < dataOffset) {

--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumCalculatorTest.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumCalculatorTest.java
@@ -48,7 +48,7 @@ public class ChecksumCalculatorTest {
         for (String algo : algos) {
             checksumAlgorithmFactories.add(selector.select(algo));
         }
-        return ChecksumCalculator.newInstance(file, checksumAlgorithmFactories);
+        return ChecksumCalculator.newInstance(file.toPath(), checksumAlgorithmFactories);
     }
 
     private ByteBuffer toBuffer(String data) {

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>org.eclipse.sisu.inject</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.jimfs</groupId>
+      <artifactId>jimfs</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <optional>true</optional>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/DeployArtifacts.java
@@ -48,10 +48,10 @@ public class DeployArtifacts {
                         Booter.newRepositorySystemSession(system).build()) {
             Artifact jarArtifact =
                     new DefaultArtifact("test", "org.apache.maven.aether.examples", "", "jar", "0.1-SNAPSHOT");
-            jarArtifact = jarArtifact.setFile(new File("src/main/data/demo.jar"));
+            jarArtifact = jarArtifact.setPath(new File("src/main/data/demo.jar").toPath());
 
             Artifact pomArtifact = new SubArtifact(jarArtifact, "", "pom");
-            pomArtifact = pomArtifact.setFile(new File("pom.xml"));
+            pomArtifact = pomArtifact.setPath(new File("pom.xml").toPath());
 
             RemoteRepository distRepo = new RemoteRepository.Builder(
                             "org.apache.maven.aether.examples",

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/InstallArtifacts.java
@@ -47,10 +47,10 @@ public class InstallArtifacts {
                         Booter.newRepositorySystemSession(system).build()) {
             Artifact jarArtifact =
                     new DefaultArtifact("test", "org.apache.maven.resolver.examples", "", "jar", "0.1-SNAPSHOT");
-            jarArtifact = jarArtifact.setFile(new File("src/main/data/demo.jar"));
+            jarArtifact = jarArtifact.setPath(new File("src/main/data/demo.jar").toPath());
 
             Artifact pomArtifact = new SubArtifact(jarArtifact, "", "pom");
-            pomArtifact = pomArtifact.setFile(new File("pom.xml"));
+            pomArtifact = pomArtifact.setPath(new File("pom.xml").toPath());
 
             InstallRequest installRequest = new InstallRequest();
             installRequest.addArtifact(jarArtifact).addArtifact(pomArtifact);

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveArtifact.java
@@ -20,7 +20,6 @@ package org.apache.maven.resolver.examples;
 
 import org.apache.maven.resolver.examples.util.Booter;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -43,12 +42,12 @@ public class ResolveArtifact {
         System.out.println(ResolveArtifact.class.getSimpleName());
 
         try (RepositorySystem system = Booter.newRepositorySystem(Booter.selectFactory(args))) {
-            RepositorySystemSession.SessionBuilder sessionBuilder = Booter.newRepositorySystemSession(system);
             Artifact artifact;
             ArtifactRequest artifactRequest;
             ArtifactResult artifactResult;
 
-            try (CloseableSession session = sessionBuilder.build()) {
+            try (CloseableSession session =
+                    Booter.newRepositorySystemSession(system).build()) {
                 artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-util:1.3.3");
 
                 artifactRequest = new ArtifactRequest();
@@ -59,13 +58,13 @@ public class ResolveArtifact {
 
                 artifact = artifactResult.getArtifact();
 
-                System.out.println(artifact + " resolved to  " + artifact.getFile());
+                System.out.println(artifact + " resolved to  " + artifact.getPath());
             }
 
             // signature
-            sessionBuilder.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_FAIL);
-
-            try (CloseableSession session = sessionBuilder.build()) {
+            try (CloseableSession session = Booter.newRepositorySystemSession(system)
+                    .setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                    .build()) {
                 artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-util:jar.asc:1.3.3");
 
                 artifactRequest = new ArtifactRequest();
@@ -76,7 +75,7 @@ public class ResolveArtifact {
 
                 artifact = artifactResult.getArtifact();
 
-                System.out.println(artifact + " resolved signature to  " + artifact.getFile());
+                System.out.println(artifact + " resolved signature to  " + artifact.getPath());
             }
         }
     }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -52,20 +52,20 @@ public class ResolveTransitiveDependencies {
                         Booter.newRepositorySystemSession(system).build()) {
             Artifact artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-impl:1.3.3");
 
-            DependencyFilter classpathFlter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);
+            DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);
 
             CollectRequest collectRequest = new CollectRequest();
             collectRequest.setRoot(new Dependency(artifact, JavaScopes.COMPILE));
             collectRequest.setRepositories(Booter.newRepositories(system, session));
 
-            DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFlter);
+            DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFilter);
 
             List<ArtifactResult> artifactResults =
                     system.resolveDependencies(session, dependencyRequest).getArtifactResults();
 
             for (ArtifactResult artifactResult : artifactResults) {
                 System.out.println(artifactResult.getArtifact() + " resolved to "
-                        + artifactResult.getArtifact().getFile());
+                        + artifactResult.getArtifact().getPath());
             }
         }
     }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ReverseDependencyTree.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ReverseDependencyTree.java
@@ -22,7 +22,6 @@ import org.apache.maven.resolver.examples.util.Booter;
 import org.apache.maven.resolver.examples.util.ReverseTreeRepositoryListener;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
-import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
@@ -30,7 +29,6 @@ import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
-import org.eclipse.aether.util.listener.ChainedRepositoryListener;
 
 /**
  * Example of building reverse dependency tree using custom {@link ReverseTreeRepositoryListener}.
@@ -47,14 +45,11 @@ public class ReverseDependencyTree {
         System.out.println(ReverseDependencyTree.class.getSimpleName());
 
         try (RepositorySystem system = Booter.newRepositorySystem(Booter.selectFactory(args))) {
-            SessionBuilder sessionBuilder = Booter.newRepositorySystemSession(system);
-            try (CloseableSession session = sessionBuilder.build()) {
-                sessionBuilder.setRepositoryListener(new ChainedRepositoryListener(
-                        session.getRepositoryListener(), new ReverseTreeRepositoryListener()));
-            }
-            sessionBuilder.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, true);
-            sessionBuilder.setConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, true);
-            try (CloseableSession session = sessionBuilder.build()) {
+            try (CloseableSession session = Booter.newRepositorySystemSession(system)
+                    .withRepositoryListener(new ReverseTreeRepositoryListener())
+                    .setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, true)
+                    .setConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, true)
+                    .build()) {
                 Artifact artifact = new DefaultArtifact("org.apache.maven:maven-resolver-provider:3.6.1");
 
                 ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/supplier/SupplierRepositorySystemFactory.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/supplier/SupplierRepositorySystemFactory.java
@@ -35,7 +35,9 @@ public class SupplierRepositorySystemFactory {
             @Override
             protected Map<String, TransporterFactory> createTransporterFactories() {
                 Map<String, TransporterFactory> result = super.createTransporterFactories();
-                result.put(JdkTransporterFactory.NAME, new JdkTransporterFactory(getChecksumExtractor()));
+                result.put(
+                        JdkTransporterFactory.NAME,
+                        new JdkTransporterFactory(getChecksumExtractor(), getPathProcessor()));
                 result.put(JettyTransporterFactory.NAME, new JettyTransporterFactory(getChecksumExtractor()));
                 return result;
             }

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.maven.resolver.examples.util;
 
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -61,11 +61,22 @@ public class Booter {
     }
 
     public static SessionBuilder newRepositorySystemSession(RepositorySystem system) {
-        return new SessionBuilderSupplier(system)
+        // FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        SessionBuilder result = new SessionBuilderSupplier(system)
                 .get()
-                .withLocalRepositoryBaseDirectories(new File("target/local-repo"))
+                //        .withLocalRepositoryBaseDirectories(fs.getPath("local-repo"))
+                .withLocalRepositoryBaseDirectories(Paths.get("target/local-repo"))
                 .setRepositoryListener(new ConsoleRepositoryListener())
                 .setTransferListener(new ConsoleTransferListener());
+        result.setConfigProperty("aether.syncContext.named.factory", "noop");
+        // result.addOnSessionEndedHandler(() -> {
+        //     try {
+        //         fs.close();
+        //     } catch (IOException e) {
+        //         throw new UncheckedIOException(e);
+        //     }
+        // });
+        return result;
         // uncomment to generate dirty trees
         // session.setDependencyGraphTransformer( null );
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/UpdateCheck.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/UpdateCheck.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.impl;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -37,7 +38,7 @@ public final class UpdateCheck<T, E extends RepositoryException> {
 
     private T item;
 
-    private File file;
+    private Path path;
 
     private boolean fileValid = true;
 
@@ -108,9 +109,21 @@ public final class UpdateCheck<T, E extends RepositoryException> {
      * Returns the local file of the item.
      *
      * @return The local file of the item.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Returns the local file of the item.
+     *
+     * @return The local file of the item.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -118,9 +131,22 @@ public final class UpdateCheck<T, E extends RepositoryException> {
      *
      * @param file The file of the item, never {@code null} .
      * @return This object for chaining.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     public UpdateCheck<T, E> setFile(File file) {
-        this.file = file;
+        return setPath(file != null ? file.toPath() : null);
+    }
+
+    /**
+     * Sets the local file of the item.
+     *
+     * @param path The file of the item, never {@code null} .
+     * @return This object for chaining.
+     * @since 2.0.0
+     */
+    public UpdateCheck<T, E> setPath(Path path) {
+        this.path = path;
         return this;
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultChecksumProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultChecksumProcessor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.aether.spi.io.ChecksumProcessor;
+import org.eclipse.aether.spi.io.PathProcessor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A utility class helping with file-based operations.
+ */
+@Singleton
+@Named
+public class DefaultChecksumProcessor implements ChecksumProcessor {
+    private final PathProcessor pathProcessor;
+
+    @Inject
+    public DefaultChecksumProcessor(PathProcessor pathProcessor) {
+        this.pathProcessor = requireNonNull(pathProcessor);
+    }
+
+    @Override
+    public String readChecksum(final Path checksumPath) throws IOException {
+        // for now do exactly same as happened before, but FileProcessor is a component and can be replaced
+        String checksum = "";
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(checksumPath), StandardCharsets.UTF_8), 512)) {
+            while (true) {
+                String line = br.readLine();
+                if (line == null) {
+                    break;
+                }
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    checksum = line;
+                    break;
+                }
+            }
+        }
+
+        if (checksum.matches(".+= [0-9A-Fa-f]+")) {
+            int lastSpacePos = checksum.lastIndexOf(' ');
+            checksum = checksum.substring(lastSpacePos + 1);
+        } else {
+            int spacePos = checksum.indexOf(' ');
+
+            if (spacePos != -1) {
+                checksum = checksum.substring(0, spacePos);
+            }
+        }
+
+        return checksum;
+    }
+
+    @Override
+    public void writeChecksum(Path target, String checksum) throws IOException {
+        // for now do exactly same as happened before, but FileProcessor is a component and can be replaced
+        pathProcessor.write(target, checksum);
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultFileProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultFileProcessor.java
@@ -32,7 +32,10 @@ import org.eclipse.aether.util.FileUtils;
 
 /**
  * A utility class helping with file-based operations.
+ *
+ * @deprecated
  */
+@Deprecated
 @Singleton
 @Named
 public class DefaultFileProcessor implements FileProcessor {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
@@ -72,7 +72,7 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
                     buffer.append("Using manager ").append(manager.getClass().getSimpleName());
                     Utils.appendClassLoader(buffer, manager);
                     buffer.append(" with priority ").append(factory.getPriority());
-                    buffer.append(" for ").append(repository.getBasedir());
+                    buffer.append(" for ").append(repository.getBasePath());
 
                     LOGGER.debug(buffer.toString());
                 }
@@ -93,7 +93,7 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
         if (factories.isEmpty()) {
             buffer.append("No local repository managers registered");
         } else {
-            buffer.append("Cannot access ").append(repository.getBasedir());
+            buffer.append("Cannot access ").append(repository.getBasePath());
             buffer.append(" with type ").append(repository.getContentType());
             buffer.append(" using the available factories ");
             factories.list(buffer);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.util.FileUtils;
+
+/**
+ * A utility class helping with file-based operations.
+ */
+@Singleton
+@Named
+public class DefaultPathProcessor implements PathProcessor {
+    @Override
+    public void write(Path target, String data) throws IOException {
+        FileUtils.writeFile(target, p -> Files.write(p, data.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Override
+    public void write(Path target, InputStream source) throws IOException {
+        FileUtils.writeFile(target, p -> Files.copy(source, p, StandardCopyOption.REPLACE_EXISTING));
+    }
+
+    @Override
+    public void copy(Path source, Path target) throws IOException {
+        copy(source, target, null);
+    }
+
+    @Override
+    public long copy(Path source, Path target, ProgressListener listener) throws IOException {
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(source));
+                FileUtils.CollocatedTempFile tempTarget = FileUtils.newTempFile(target);
+                OutputStream out = new BufferedOutputStream(Files.newOutputStream(tempTarget.getPath()))) {
+            long result = copy(out, in, listener);
+            tempTarget.move();
+            return result;
+        }
+    }
+
+    private long copy(OutputStream os, InputStream is, ProgressListener listener) throws IOException {
+        long total = 0L;
+        byte[] buffer = new byte[1024 * 32];
+        while (true) {
+            int bytes = is.read(buffer);
+            if (bytes < 0) {
+                break;
+            }
+
+            os.write(buffer, 0, bytes);
+
+            total += bytes;
+
+            if (listener != null && bytes > 0) {
+                try {
+                    listener.progressed(ByteBuffer.wrap(buffer, 0, bytes));
+                } catch (Exception e) {
+                    // too bad
+                }
+            }
+        }
+
+        return total;
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
@@ -21,17 +21,18 @@ package org.eclipse.aether.internal.impl;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.Properties;
 
@@ -51,17 +52,26 @@ import org.slf4j.LoggerFactory;
 public final class DefaultTrackingFileManager implements TrackingFileManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTrackingFileManager.class);
 
+    @Deprecated
     @Override
     public Properties read(File file) {
-        if (Files.isReadable(file.toPath())) {
-            synchronized (getMutex(file)) {
-                try (FileInputStream stream = new FileInputStream(file);
-                        FileLock unused = fileLock(stream.getChannel(), Math.max(1, file.length()), true)) {
-                    Properties props = new Properties();
-                    props.load(stream);
-                    return props;
+        return read(file.toPath());
+    }
+
+    @Override
+    public Properties read(Path path) {
+        if (Files.isReadable(path)) {
+            synchronized (getMutex(path)) {
+                try {
+                    long fileSize = Files.size(path);
+                    try (FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.READ);
+                            FileLock unused = fileLock(fileChannel, Math.max(1, fileSize), true)) {
+                        Properties props = new Properties();
+                        props.load(Channels.newInputStream(fileChannel));
+                        return props;
+                    }
                 } catch (IOException e) {
-                    LOGGER.warn("Failed to read tracking file '{}'", file, e);
+                    LOGGER.warn("Failed to read tracking file '{}'", path, e);
                     throw new UncheckedIOException(e);
                 }
             }
@@ -69,45 +79,57 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
         return null;
     }
 
+    @Deprecated
     @Override
     public Properties update(File file, Map<String, String> updates) {
-        Properties props = new Properties();
+        return update(file.toPath(), updates);
+    }
 
+    @Override
+    public Properties update(Path path, Map<String, String> updates) {
+        Properties props = new Properties();
         try {
-            Files.createDirectories(file.getParentFile().toPath());
+            Files.createDirectories(path.getParent());
         } catch (IOException e) {
-            LOGGER.warn("Failed to create tracking file parent '{}'", file, e);
+            LOGGER.warn("Failed to create tracking file parent '{}'", path, e);
             throw new UncheckedIOException(e);
         }
 
-        synchronized (getMutex(file)) {
-            try (RandomAccessFile raf = new RandomAccessFile(file, "rw");
-                    FileLock unused = fileLock(raf.getChannel(), Math.max(1, raf.length()), false)) {
-                if (raf.length() > 0) {
-                    byte[] buffer = new byte[(int) raf.length()];
-                    raf.readFully(buffer);
-                    props.load(new ByteArrayInputStream(buffer));
+        synchronized (getMutex(path)) {
+            try {
+                long fileSize;
+                try {
+                    fileSize = Files.size(path);
+                } catch (IOException e) {
+                    fileSize = 0L;
                 }
-
-                for (Map.Entry<String, String> update : updates.entrySet()) {
-                    if (update.getValue() == null) {
-                        props.remove(update.getKey());
-                    } else {
-                        props.setProperty(update.getKey(), update.getValue());
+                try (FileChannel fileChannel = FileChannel.open(
+                                path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+                        FileLock unused = fileLock(fileChannel, Math.max(1, fileSize), false)) {
+                    if (fileSize > 0) {
+                        props.load(Channels.newInputStream(fileChannel));
                     }
-                }
 
-                LOGGER.debug("Writing tracking file '{}'", file);
-                ByteArrayOutputStream stream = new ByteArrayOutputStream(1024 * 2);
-                props.store(
-                        stream,
-                        "NOTE: This is a Maven Resolver internal implementation file"
-                                + ", its format can be changed without prior notice.");
-                raf.seek(0L);
-                raf.write(stream.toByteArray());
-                raf.setLength(raf.getFilePointer());
+                    for (Map.Entry<String, String> update : updates.entrySet()) {
+                        if (update.getValue() == null) {
+                            props.remove(update.getKey());
+                        } else {
+                            props.setProperty(update.getKey(), update.getValue());
+                        }
+                    }
+
+                    LOGGER.debug("Writing tracking file '{}'", path);
+                    ByteArrayOutputStream stream = new ByteArrayOutputStream(1024 * 2);
+                    props.store(
+                            stream,
+                            "NOTE: This is a Maven Resolver internal implementation file"
+                                    + ", its format can be changed without prior notice.");
+                    fileChannel.position(0);
+                    int written = fileChannel.write(ByteBuffer.wrap(stream.toByteArray()));
+                    fileChannel.truncate(written);
+                }
             } catch (IOException e) {
-                LOGGER.warn("Failed to write tracking file '{}'", file, e);
+                LOGGER.warn("Failed to write tracking file '{}'", path, e);
                 throw new UncheckedIOException(e);
             }
         }
@@ -115,7 +137,7 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
         return props;
     }
 
-    private Object getMutex(File file) {
+    private Object getMutex(Path path) {
         // The interned string of path is (mis)used as mutex, to exclude different threads going for same file,
         // as JVM file locking happens on JVM not on Thread level. This is how original code did it  ¯\_(ツ)_/¯
         /*
@@ -123,13 +145,7 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
          * piece of code might have locked the same file (unlikely though) or the canonical path fails to capture file
          * identity sufficiently as is the case with Java 1.6 and symlinks on Windows.
          */
-        try {
-            return file.getCanonicalPath().intern();
-        } catch (IOException e) {
-            LOGGER.warn("Failed to canonicalize path {}", file, e);
-            // TODO This is code smell and deprecated
-            return file.getAbsolutePath().intern();
-        }
+        return path.toAbsolutePath().normalize().toString().intern();
     }
 
     @SuppressWarnings({"checkstyle:magicnumber"})

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
@@ -91,7 +91,7 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
 
         if ("".equals(repository.getContentType()) || "default".equals(repository.getContentType())) {
             return new EnhancedLocalRepositoryManager(
-                    repository.getBasedir(),
+                    repository.getBasePath(),
                     localPathComposer,
                     trackingFilename,
                     trackingFileManager,

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
@@ -18,7 +18,8 @@
  */
 package org.eclipse.aether.internal.impl;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -48,9 +49,9 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
     private final LocalPathComposer localPathComposer;
 
-    SimpleLocalRepositoryManager(File basedir, String type, LocalPathComposer localPathComposer) {
-        requireNonNull(basedir, "base directory cannot be null");
-        repository = new LocalRepository(basedir.getAbsoluteFile(), type);
+    SimpleLocalRepositoryManager(Path basePath, String type, LocalPathComposer localPathComposer) {
+        requireNonNull(basePath, "base directory cannot be null");
+        repository = new LocalRepository(basePath.toAbsolutePath(), type);
         this.localPathComposer = requireNonNull(localPathComposer);
     }
 
@@ -132,14 +133,14 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
         LocalArtifactResult result = new LocalArtifactResult(request);
 
         String path;
-        File file;
+        Path filePath;
 
         // Local repository CANNOT have timestamped installed, they are created only during deploy
         if (Objects.equals(artifact.getVersion(), artifact.getBaseVersion())) {
             path = getPathForLocalArtifact(artifact);
-            file = new File(getRepository().getBasedir(), path);
-            if (file.isFile()) {
-                result.setFile(file);
+            filePath = getRepository().getBasePath().resolve(path);
+            if (Files.isRegularFile(filePath)) {
+                result.setPath(filePath);
                 result.setAvailable(true);
             }
         }
@@ -147,9 +148,9 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
         if (!result.isAvailable()) {
             for (RemoteRepository repository : request.getRepositories()) {
                 path = getPathForRemoteArtifact(artifact, repository, request.getContext());
-                file = new File(getRepository().getBasedir(), path);
-                if (file.isFile()) {
-                    result.setFile(file);
+                filePath = getRepository().getBasePath().resolve(path);
+                if (Files.isRegularFile(filePath)) {
+                    result.setPath(filePath);
                     result.setAvailable(true);
                     break;
                 }
@@ -184,9 +185,9 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
             path = getPathForLocalMetadata(metadata);
         }
 
-        File file = new File(getRepository().getBasedir(), path);
-        if (file.isFile()) {
-            result.setFile(file);
+        Path filePath = getRepository().getBasePath().resolve(path);
+        if (Files.isRegularFile(filePath)) {
+            result.setPath(filePath);
         }
 
         return result;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory.java
@@ -60,7 +60,7 @@ public class SimpleLocalRepositoryManagerFactory implements LocalRepositoryManag
         requireNonNull(repository, "repository cannot be null");
 
         if ("".equals(repository.getContentType()) || "simple".equals(repository.getContentType())) {
-            return new SimpleLocalRepositoryManager(repository.getBasedir(), "simple", localPathComposer);
+            return new SimpleLocalRepositoryManager(repository.getBasePath(), "simple", localPathComposer);
         } else {
             throw new NoLocalRepositoryManagerException(repository);
         }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManager.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.internal.impl;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
 
@@ -28,12 +29,29 @@ import java.util.Properties;
 public interface TrackingFileManager {
     /**
      * Reads up the specified properties file into {@link Properties}, if exists, otherwise {@code null} is returned.
+     * @deprecated Use {@link #read(Path)} instead.
      */
+    @Deprecated
     Properties read(File file);
+
+    /**
+     * Reads up the specified properties file into {@link Properties}, if exists, otherwise {@code null} is returned.
+     * @since 2.0.0
+     */
+    Properties read(Path path);
 
     /**
      * Applies updates to specified properties file and returns resulting {@link Properties} with contents same
      * as in updated file, never {@code null}.
+     * @deprecated Use {@link #update(Path, Map)} instead.
      */
+    @Deprecated
     Properties update(File file, Map<String, String> updates);
+
+    /**
+     * Applies updates to specified properties file and returns resulting {@link Properties} with contents same
+     * as in updated file, never {@code null}.
+     * @since 2.0.0
+     */
+    Properties update(Path path, Map<String, String> updates);
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
@@ -35,7 +35,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.internal.impl.LocalPathComposer;
 import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
-import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.spi.io.ChecksumProcessor;
 import org.eclipse.aether.util.ConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,13 +98,14 @@ public final class SparseDirectoryTrustedChecksumsSource extends FileTrustedChec
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SparseDirectoryTrustedChecksumsSource.class);
 
-    private final FileProcessor fileProcessor;
+    private final ChecksumProcessor checksumProcessor;
 
     private final LocalPathComposer localPathComposer;
 
     @Inject
-    public SparseDirectoryTrustedChecksumsSource(FileProcessor fileProcessor, LocalPathComposer localPathComposer) {
-        this.fileProcessor = requireNonNull(fileProcessor);
+    public SparseDirectoryTrustedChecksumsSource(
+            ChecksumProcessor checksumProcessor, LocalPathComposer localPathComposer) {
+        this.checksumProcessor = requireNonNull(checksumProcessor);
         this.localPathComposer = requireNonNull(localPathComposer);
     }
 
@@ -141,7 +142,7 @@ public final class SparseDirectoryTrustedChecksumsSource extends FileTrustedChec
                 }
 
                 try {
-                    String checksum = fileProcessor.readChecksum(checksumPath.toFile());
+                    String checksum = checksumProcessor.readChecksum(checksumPath);
                     if (checksum != null) {
                         checksums.put(checksumAlgorithmFactory.getName(), checksum);
                     }
@@ -196,7 +197,7 @@ public final class SparseDirectoryTrustedChecksumsSource extends FileTrustedChec
                 Path checksumPath = basedir.resolve(
                         calculateArtifactPath(originAware, artifact, artifactRepository, checksumAlgorithmFactory));
                 String checksum = requireNonNull(trustedArtifactChecksums.get(checksumAlgorithmFactory.getName()));
-                fileProcessor.writeChecksum(checksumPath.toFile(), checksum);
+                checksumProcessor.writeChecksum(checksumPath, checksum);
             }
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
@@ -169,7 +169,7 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
                 if (record) {
                     recordArtifactChecksums(session, artifactResult, checksumAlgorithms);
                 } else if (!validateArtifactChecksums(session, artifactResult, checksumAlgorithms, failIfMissing)) {
-                    artifactResult.setArtifact(artifactResult.getArtifact().setFile(null)); // make it unresolved
+                    artifactResult.setArtifact(artifactResult.getArtifact().setPath(null)); // make it unresolved
                 }
             }
         }
@@ -186,7 +186,7 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
         ArtifactRepository artifactRepository = artifactResult.getRepository();
         try {
             final Map<String, String> calculatedChecksums =
-                    ChecksumAlgorithmHelper.calculate(artifact.getFile(), checksumAlgorithmFactories);
+                    ChecksumAlgorithmHelper.calculate(artifact.getPath(), checksumAlgorithmFactories);
 
             for (TrustedChecksumsSource trustedChecksumsSource : trustedChecksumsSources.values()) {
                 TrustedChecksumsSource.Writer writer =
@@ -197,12 +197,12 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
                                 artifact, artifactRepository, checksumAlgorithmFactories, calculatedChecksums);
                     } catch (IOException e) {
                         throw new UncheckedIOException(
-                                "Could not write required checksums for " + artifact.getFile(), e);
+                                "Could not write required checksums for " + artifact.getPath(), e);
                     }
                 }
             }
         } catch (IOException e) {
-            throw new UncheckedIOException("Could not calculate required checksums for " + artifact.getFile(), e);
+            throw new UncheckedIOException("Could not calculate required checksums for " + artifact.getPath(), e);
         }
     }
 
@@ -222,7 +222,7 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
         try {
             // full set: calculate all algorithms we were asked for
             final Map<String, String> calculatedChecksums =
-                    ChecksumAlgorithmHelper.calculate(artifact.getFile(), checksumAlgorithmFactories);
+                    ChecksumAlgorithmHelper.calculate(artifact.getPath(), checksumAlgorithmFactories);
 
             for (Map.Entry<String, TrustedChecksumsSource> entry : trustedChecksumsSources.entrySet()) {
                 final String trustedSourceName = entry.getKey();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/DiscriminatingNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/DiscriminatingNameMapper.java
@@ -18,9 +18,9 @@
  */
 package org.eclipse.aether.internal.impl.synccontext.named;
 
-import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -110,7 +110,7 @@ public class DiscriminatingNameMapper implements NameMapper {
 
         if (discriminator == null || discriminator.isEmpty()) {
             String hostname = ConfigUtils.getString(session, this.hostname, CONFIG_PROP_HOSTNAME);
-            File basedir = session.getLocalRepository().getBasedir();
+            Path basedir = session.getLocalRepository().getBasePath();
             discriminator = hostname + ":" + basedir;
             try {
                 return StringDigestUtil.sha1(discriminator);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Artifact GAV {@link NameMapper}, uses artifact and metadata coordinates to name their corresponding locks. Is not
- * considering local repository, only the artifact coordinates. May use custom prefixes and sufixes and separators,
+ * considering local repository, only the artifact coordinates. May use custom prefixes and suffixes and separators,
  * hence this instance may or may not be filesystem friendly (depends on strings used).
  */
 public class GAVNameMapper implements NameMapper {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapper.java
@@ -31,6 +31,11 @@ public interface NameMapper {
     /**
      * Returns {@code true} if lock names returned by this lock name mapper are file system friendly, can be used
      * as file names and paths.
+     * <p>
+     * <em>Note:</em> The fact that name mapper is "file system friendly" means ONLY that names it produces CAN be
+     * used as file names and paths. Still, it does not mean they will work with ANY file based locking, as for example
+     * {@link org.eclipse.aether.named.providers.FileLockNamedLockFactory} expects names as string encoded
+     * {@link java.net.URI}s. The only name mapper doing it is {@link BasedirNameMapper}.
      *
      * @since 1.9.0
      */

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -38,10 +38,7 @@ import org.eclipse.aether.impl.UpdateCheckManager;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.Filters;
-import org.eclipse.aether.internal.test.util.TestFileProcessor;
-import org.eclipse.aether.internal.test.util.TestFileUtils;
-import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
-import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.internal.test.util.*;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
@@ -113,7 +110,7 @@ public class DefaultArtifactResolverTest {
     private DefaultArtifactResolver setupArtifactResolver(
             VersionResolver versionResolver, UpdateCheckManager updateCheckManager) {
         return new DefaultArtifactResolver(
-                new TestFileProcessor(),
+                new TestPathProcessor(),
                 new StubRepositoryEventDispatcher(),
                 versionResolver,
                 updateCheckManager,
@@ -365,7 +362,10 @@ public class DefaultArtifactResolverTest {
         repositoryConnectorProvider.setConnector(connector);
         resolver = setupArtifactResolver(
                 new StubVersionResolver(),
-                new DefaultUpdateCheckManager(new DefaultTrackingFileManager(), new DefaultUpdatePolicyAnalyzer()));
+                new DefaultUpdateCheckManager(
+                        new DefaultTrackingFileManager(),
+                        new DefaultUpdatePolicyAnalyzer(),
+                        new DefaultPathProcessor()));
 
         session.setResolutionErrorPolicy(new SimpleResolutionErrorPolicy(true, false));
         session.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_NEVER);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultChecksumPolicyProviderTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultChecksumPolicyProviderTest.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.nio.file.Path;
+
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -47,7 +49,7 @@ public class DefaultChecksumPolicyProviderTest {
         session = TestUtils.newSession();
         provider = new DefaultChecksumPolicyProvider();
         repository = new RemoteRepository.Builder("test", "default", "file:/void").build();
-        resource = new TransferResource(repository.getId(), repository.getUrl(), "file.txt", null, null);
+        resource = new TransferResource(repository.getId(), repository.getUrl(), "file.txt", (Path) null, null);
     }
 
     @AfterEach

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -34,8 +35,8 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeploymentException;
-import org.eclipse.aether.internal.test.util.TestFileProcessor;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
+import org.eclipse.aether.internal.test.util.TestPathProcessor;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.MergeableMetadata;
@@ -84,7 +85,7 @@ public class DefaultDeployerTest {
         connectorProvider = new StubRepositoryConnectorProvider();
 
         deployer = new DefaultDeployer(
-                new TestFileProcessor(),
+                new TestPathProcessor(),
                 new StubRepositoryEventDispatcher(),
                 connectorProvider,
                 new StubRemoteRepositoryManager(),
@@ -239,6 +240,10 @@ public class DefaultDeployerTest {
                 return this;
             }
 
+            public Metadata setPath(Path path) {
+                return this;
+            }
+
             public String getVersion() {
                 return "";
             }
@@ -259,6 +264,10 @@ public class DefaultDeployerTest {
                 return null;
             }
 
+            public Path getPath() {
+                return null;
+            }
+
             public String getArtifactId() {
                 return "aether";
             }
@@ -273,6 +282,10 @@ public class DefaultDeployerTest {
 
             public String getProperty(String key, String defaultValue) {
                 return defaultValue;
+            }
+
+            public void merge(Path current, Path result) throws RepositoryException {
+                merge(current != null ? current.toFile() : null, result != null ? result.toFile() : null);
             }
 
             public void merge(File current, File result) throws RepositoryException {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,10 +32,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallResult;
 import org.eclipse.aether.installation.InstallationException;
-import org.eclipse.aether.internal.test.util.TestFileProcessor;
-import org.eclipse.aether.internal.test.util.TestFileUtils;
-import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
-import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.internal.test.util.*;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.Metadata.Nature;
@@ -86,7 +84,7 @@ public class DefaultInstallerTest {
         localArtifactFile = new File(session.getLocalRepository().getBasedir(), localArtifactPath);
 
         installer = new DefaultInstaller(
-                new TestFileProcessor(),
+                new TestPathProcessor(),
                 new StubRepositoryEventDispatcher(),
                 Collections.emptyMap(),
                 new StubSyncContextFactory());
@@ -331,9 +329,9 @@ public class DefaultInstallerTest {
         installer.install(session, request);
 
         installer = new DefaultInstaller(
-                new DefaultFileProcessor() {
+                new DefaultPathProcessor() {
                     @Override
-                    public long copy(File src, File target, ProgressListener listener) throws IOException {
+                    public long copy(Path src, Path target, ProgressListener listener) throws IOException {
                         throw new IOException("copy called");
                     }
                 },

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
@@ -90,7 +90,8 @@ public class DefaultMetadataResolverTest {
                 new StubRemoteRepositoryManager(),
                 new StubSyncContextFactory(),
                 new DefaultOfflineController(),
-                remoteRepositoryFilterManager);
+                remoteRepositoryFilterManager,
+                new DefaultPathProcessor());
         repository = new RemoteRepository.Builder(
                         "test-DMRT",
                         "default",
@@ -267,7 +268,8 @@ public class DefaultMetadataResolverTest {
                 new StubRemoteRepositoryManager(),
                 new StubSyncContextFactory(),
                 new DefaultOfflineController(),
-                remoteRepositoryFilterManager);
+                remoteRepositoryFilterManager,
+                new DefaultPathProcessor());
 
         List<MetadataResult> results = resolver.resolveMetadata(session, Arrays.asList(request));
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
@@ -64,7 +64,7 @@ public class DefaultUpdateCheckManagerTest {
 
     @BeforeEach
     void setup() throws Exception {
-        File dir = TestFileUtils.createTempFile("");
+        File dir = TestFileUtils.createTempDir("");
         TestFileUtils.deleteFile(dir);
 
         File metadataFile = new File(dir, "metadata.txt");
@@ -78,7 +78,8 @@ public class DefaultUpdateCheckManagerTest {
                         "default",
                         TestFileUtils.createTempDir().toURI().toURL().toString())
                 .build();
-        manager = new DefaultUpdateCheckManager(new DefaultTrackingFileManager(), new DefaultUpdatePolicyAnalyzer());
+        manager = new DefaultUpdateCheckManager(
+                new DefaultTrackingFileManager(), new DefaultUpdatePolicyAnalyzer(), new DefaultPathProcessor());
         metadata = new DefaultMetadata(
                 "gid", "aid", "ver", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT, metadataFile);
         artifact = new DefaultArtifact("gid", "aid", "", "ext", "ver").setFile(artifactFile);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -107,7 +107,7 @@ public class EnhancedLocalRepositoryManagerTest {
 
     protected EnhancedLocalRepositoryManager getManager() {
         return new EnhancedLocalRepositoryManager(
-                basedir,
+                basedir.toPath(),
                 new DefaultLocalPathComposer(),
                 "_remote.repositories",
                 trackingFileManager,

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
@@ -31,7 +31,7 @@ public class EnhancedSplitLocalRepositoryManagerTest extends EnhancedLocalReposi
     protected EnhancedLocalRepositoryManager getManager() {
         session.setConfigProperty(DefaultLocalPathPrefixComposerFactory.CONFIG_PROP_SPLIT, Boolean.TRUE.toString());
         return new EnhancedLocalRepositoryManager(
-                basedir,
+                basedir.toPath(),
                 new DefaultLocalPathComposer(),
                 "_remote.repositories",
                 trackingFileManager,

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FailChecksumPolicyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/FailChecksumPolicyTest.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.nio.file.Path;
+
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
@@ -34,7 +36,7 @@ public class FailChecksumPolicyTest {
 
     @BeforeEach
     void setup() {
-        policy = new FailChecksumPolicy(new TransferResource("null", "file:/dev/null", "file.txt", null, null));
+        policy = new FailChecksumPolicy(new TransferResource("null", "file:/dev/null", "file.txt", (Path) null, null));
         exception = new ChecksumFailureException("test");
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/RecordingRepositoryConnector.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/RecordingRepositoryConnector.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -163,8 +164,8 @@ class RecordingRepositoryConnector implements RepositoryConnector {
         if (listener == null) {
             return;
         }
-        TransferEvent.Builder event =
-                new TransferEvent.Builder(session, new TransferResource(null, null, null, null, transfer.getTrace()));
+        TransferEvent.Builder event = new TransferEvent.Builder(
+                session, new TransferResource(null, null, null, (Path) null, transfer.getTrace()));
         event.setType(TransferEvent.EventType.INITIATED);
         listener.transferInitiated(event.build());
     }
@@ -174,8 +175,8 @@ class RecordingRepositoryConnector implements RepositoryConnector {
         if (listener == null) {
             return;
         }
-        TransferEvent.Builder event =
-                new TransferEvent.Builder(session, new TransferResource(null, null, null, null, transfer.getTrace()));
+        TransferEvent.Builder event = new TransferEvent.Builder(
+                session, new TransferResource(null, null, null, (Path) null, transfer.getTrace()));
         event.setException(transfer.getException());
         if (transfer.getException() != null) {
             listener.transferFailed(

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
@@ -48,7 +48,7 @@ public class SimpleLocalRepositoryManagerTest {
     @BeforeEach
     void setup() throws IOException {
         basedir = TestFileUtils.createTempDir("simple-repo");
-        manager = new SimpleLocalRepositoryManager(basedir, "simple", new DefaultLocalPathComposer());
+        manager = new SimpleLocalRepositoryManager(basedir.toPath(), "simple", new DefaultLocalPathComposer());
         session = TestUtils.newSession();
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.nio.file.Path;
+
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.eclipse.aether.transfer.TransferResource;
@@ -34,7 +36,7 @@ public class WarnChecksumPolicyTest {
 
     @BeforeEach
     void setup() {
-        policy = new WarnChecksumPolicy(new TransferResource("null", "file:/dev/null", "file.txt", null, null));
+        policy = new WarnChecksumPolicy(new TransferResource("null", "file:/dev/null", "file.txt", (Path) null, null));
         exception = new ChecksumFailureException("test");
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSourceTest.java
@@ -20,13 +20,15 @@ package org.eclipse.aether.internal.impl.checksum;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.impl.RepositorySystemLifecycle;
-import org.eclipse.aether.internal.impl.DefaultFileProcessor;
+import org.eclipse.aether.internal.impl.DefaultChecksumProcessor;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultPathProcessor;
 
 public class SparseDirectoryTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport {
     @Override
     protected FileTrustedChecksumsSourceSupport prepareSubject(RepositorySystemLifecycle lifecycle) {
-        return new SparseDirectoryTrustedChecksumsSource(new DefaultFileProcessor(), new DefaultLocalPathComposer());
+        return new SparseDirectoryTrustedChecksumsSource(
+                new DefaultChecksumProcessor(new DefaultPathProcessor()), new DefaultLocalPathComposer());
     }
 
     @Override

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -33,7 +33,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BasedirNameMapperTest extends NameMapperTestSupport {
-    private final String PS = File.separator;
+    private final String PS = "/"; // we work with URIs now, not OS file paths
 
     BasedirNameMapper mapper = new BasedirNameMapper(new HashingNameMapper(GAVNameMapper.gav()));
 
@@ -62,7 +62,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<String> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(names.size(), 1);
         assertEquals(
-                names.iterator().next(), basedir + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
+                names.iterator().next(),
+                basedir.toUri() + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -74,13 +75,14 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         assertEquals(names.size(), 1);
         assertEquals(
                 names.iterator().next(),
-                basedir + PS + "my" + PS + "locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
+                basedir.toUri() + PS + "my" + PS + "locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
     void absoluteLocksDir() throws IOException {
         String absoluteLocksDir = "/my/locks";
-        String customBaseDir = new File(absoluteLocksDir).getCanonicalPath();
+        String customBaseDir =
+                new File(absoluteLocksDir).getCanonicalFile().toPath().toUri().toASCIIString();
 
         configProperties.put("aether.syncContext.named.hashing.depth", "0");
         configProperties.put("aether.syncContext.named.basedir.locksDir", absoluteLocksDir);
@@ -98,7 +100,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<String> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(names.size(), 1);
         assertEquals(
-                names.iterator().next(), basedir + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
+                names.iterator().next(),
+                basedir.toUri() + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -110,7 +113,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<String> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(names.size(), 1);
         assertEquals(
-                names.iterator().next(), basedir + PS + ".locks" + PS + "293b3990971f4b4b02b220620d2538eaac5f221b");
+                names.iterator().next(),
+                basedir.toUri() + PS + ".locks" + PS + "293b3990971f4b4b02b220620d2538eaac5f221b");
     }
 
     @Test
@@ -126,7 +130,11 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Iterator<String> namesIterator = names.iterator();
 
         // they are sorted as well
-        assertEquals(namesIterator.next(), basedir + PS + ".locks" + PS + "d36504431d00d1c6e4d1c34258f2bf0a004de085");
-        assertEquals(namesIterator.next(), basedir + PS + ".locks" + PS + "fbcebba60d7eb931eca634f6ca494a8a1701b638");
+        assertEquals(
+                namesIterator.next(),
+                basedir.toUri() + PS + ".locks" + PS + "d36504431d00d1c6e4d1c34258f2bf0a004de085");
+        assertEquals(
+                namesIterator.next(),
+                basedir.toUri() + PS + ".locks" + PS + "fbcebba60d7eb931eca634f6ca494a8a1701b638");
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapperTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/NameMapperTestSupport.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl.synccontext.named;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 
 import org.eclipse.aether.RepositorySystemSession;
@@ -33,7 +34,7 @@ import static org.mockito.Mockito.when;
  * Simple support class for {@link NameMapper} implementation UTs.
  */
 public abstract class NameMapperTestSupport {
-    protected String basedir;
+    protected Path basedir;
 
     protected HashMap<String, Object> configProperties;
 
@@ -41,10 +42,10 @@ public abstract class NameMapperTestSupport {
 
     @BeforeEach
     void before() throws IOException {
-        basedir = new File("/home/maven/.m2/repository").getCanonicalPath();
+        basedir = new File("/home/maven/.m2/repository").getCanonicalFile().toPath();
         configProperties = new HashMap<>();
 
-        LocalRepository localRepository = new LocalRepository(new File(basedir));
+        LocalRepository localRepository = new LocalRepository(basedir);
         session = mock(RepositorySystemSession.class);
         when(session.getConfigProperties()).thenReturn(configProperties);
         when(session.getLocalRepository()).thenReturn(localRepository);

--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/providers/FileLockNamedLockFactory.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
@@ -39,8 +40,9 @@ import org.eclipse.aether.named.support.NamedLockSupport;
 import static org.eclipse.aether.named.support.Retry.retry;
 
 /**
- * Named locks factory of {@link FileLockNamedLock}s. This is a bit special implementation, as it
- * expects locks names to be fully qualified absolute file system paths.
+ * Named locks factory of {@link FileLockNamedLock}s. This is a bit of special implementation, as it
+ * expects locks names to be proper URI string representations (use {@code file:} protocol for default
+ * file system).
  *
  * @since 1.7.3
  */
@@ -98,7 +100,7 @@ public class FileLockNamedLockFactory extends NamedLockFactorySupport {
 
     @Override
     protected NamedLockSupport createLock(final String name) {
-        Path path = Paths.get(name);
+        Path path = Paths.get(URI.create(name));
         FileChannel fileChannel = fileChannels.computeIfAbsent(name, k -> {
             try {
                 Files.createDirectories(path.getParent());

--- a/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/FileLockNamedLockFactorySupportTest.java
+++ b/maven-resolver-named-locks/src/test/java/org/eclipse/aether/named/FileLockNamedLockFactorySupportTest.java
@@ -39,7 +39,10 @@ public class FileLockNamedLockFactorySupportTest extends NamedLockFactoryTestSup
 
     @Override
     protected String lockName(TestInfo testInfo) {
-        return baseDir.resolve(testInfo.getDisplayName()).toAbsolutePath().toString();
+        return baseDir.resolve(testInfo.getDisplayName())
+                .toAbsolutePath()
+                .toUri()
+                .toASCIIString();
     }
 
     @BeforeAll

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactDownload.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactDownload.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -60,11 +61,30 @@ public final class ArtifactDownload extends ArtifactTransfer {
      * @param context The context in which this download is performed, may be {@code null}.
      * @param file The local file to download the artifact to, may be {@code null}.
      * @param checksumPolicy The checksum policy, may be {@code null}.
+     * @deprecated Use {@link ArtifactDownload(Artifact, String, Path, String)} instead.
      */
+    @Deprecated
     public ArtifactDownload(Artifact artifact, String context, File file, String checksumPolicy) {
         setArtifact(artifact);
         setRequestContext(context);
         setFile(file);
+        setChecksumPolicy(checksumPolicy);
+    }
+
+    /**
+     * Creates a new download with the specified properties.
+     *
+     * @param artifact The artifact to download, may be {@code null}.
+     * @param context The context in which this download is performed, may be {@code null}.
+     * @param path The local file to download the artifact to, may be {@code null}.
+     * @param checksumPolicy The checksum policy, may be {@code null}.
+     * @deprecated Use {@link ArtifactDownload(Artifact, String, Path, String)} instead.
+     * @since 2.0.0
+     */
+    public ArtifactDownload(Artifact artifact, String context, Path path, String checksumPolicy) {
+        setArtifact(artifact);
+        setRequestContext(context);
+        setPath(path);
         setChecksumPolicy(checksumPolicy);
     }
 
@@ -74,9 +94,16 @@ public final class ArtifactDownload extends ArtifactTransfer {
         return this;
     }
 
+    @Deprecated
     @Override
     public ArtifactDownload setFile(File file) {
         super.setFile(file);
+        return this;
+    }
+
+    @Override
+    public ArtifactDownload setPath(Path path) {
+        super.setPath(path);
         return this;
     }
 
@@ -222,6 +249,6 @@ public final class ArtifactDownload extends ArtifactTransfer {
 
     @Override
     public String toString() {
-        return getArtifact() + " - " + (isExistenceCheck() ? "?" : "") + getFile();
+        return getArtifact() + " - " + (isExistenceCheck() ? "?" : "") + getPath();
     }
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactTransfer.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactTransfer.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.transfer.ArtifactTransferException;
@@ -32,7 +33,7 @@ public abstract class ArtifactTransfer extends Transfer {
 
     private Artifact artifact;
 
-    private File file;
+    private Path path;
 
     private ArtifactTransferException exception;
 
@@ -66,9 +67,23 @@ public abstract class ArtifactTransfer extends Transfer {
      * completed such that an interrupted/failed download does not corrupt the current file contents.
      *
      * @return The local file or {@code null} if not set.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the local file the artifact is downloaded to or uploaded from. In case of a download, a connector should
+     * first transfer the bytes to a temporary file and only overwrite the target file once the entire download is
+     * completed such that an interrupted/failed download does not corrupt the current file contents.
+     *
+     * @return The local file or {@code null} if not set.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -76,9 +91,22 @@ public abstract class ArtifactTransfer extends Transfer {
      *
      * @param file The local file, may be {@code null}.
      * @return This transfer for chaining, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     public ArtifactTransfer setFile(File file) {
-        this.file = file;
+        return setPath(file != null ? file.toPath() : null);
+    }
+
+    /**
+     * Sets the local file the artifact is downloaded to or uploaded from.
+     *
+     * @param path The local file, may be {@code null}.
+     * @return This transfer for chaining, never {@code null}.
+     * @since 2.0.0
+     */
+    public ArtifactTransfer setPath(Path path) {
+        this.path = path;
         return this;
     }
 

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactUpload.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/ArtifactUpload.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
@@ -42,10 +43,24 @@ public final class ArtifactUpload extends ArtifactTransfer {
      *
      * @param artifact The artifact to upload, may be {@code null}.
      * @param file The local file to upload the artifact from, may be {@code null}.
+     * @deprecated Use {@link #ArtifactUpload(Artifact, Path)} instead.
      */
+    @Deprecated
     public ArtifactUpload(Artifact artifact, File file) {
         setArtifact(artifact);
         setFile(file);
+    }
+
+    /**
+     * Creates a new upload with the specified properties.
+     *
+     * @param artifact The artifact to upload, may be {@code null}.
+     * @param path The local file to upload the artifact from, may be {@code null}.
+     * @since 2.0.0
+     */
+    public ArtifactUpload(Artifact artifact, Path path) {
+        setArtifact(artifact);
+        setPath(path);
     }
 
     @Override
@@ -54,9 +69,16 @@ public final class ArtifactUpload extends ArtifactTransfer {
         return this;
     }
 
+    @Deprecated
     @Override
     public ArtifactUpload setFile(File file) {
         super.setFile(file);
+        return this;
+    }
+
+    @Override
+    public ArtifactUpload setPath(Path path) {
+        super.setPath(path);
         return this;
     }
 
@@ -80,6 +102,6 @@ public final class ArtifactUpload extends ArtifactTransfer {
 
     @Override
     public String toString() {
-        return getArtifact() + " - " + getFile();
+        return getArtifact() + " - " + getPath();
     }
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataDownload.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataDownload.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,10 +55,25 @@ public final class MetadataDownload extends MetadataTransfer {
      * @param context The context in which this download is performed, may be {@code null}.
      * @param file The local file to download the metadata to, may be {@code null}.
      * @param checksumPolicy The checksum policy, may be {@code null}.
+     * @deprecated Use {@link #MetadataDownload(Metadata, String, Path, String)} instead.
      */
+    @Deprecated
     public MetadataDownload(Metadata metadata, String context, File file, String checksumPolicy) {
+        this(metadata, context, file != null ? file.toPath() : null, checksumPolicy);
+    }
+
+    /**
+     * Creates a new download with the specified properties.
+     *
+     * @param metadata The metadata to download, may be {@code null}.
+     * @param context The context in which this download is performed, may be {@code null}.
+     * @param path The local file to download the metadata to, may be {@code null}.
+     * @param checksumPolicy The checksum policy, may be {@code null}.
+     * @since 2.0.0
+     */
+    public MetadataDownload(Metadata metadata, String context, Path path, String checksumPolicy) {
         setMetadata(metadata);
-        setFile(file);
+        setPath(path);
         setChecksumPolicy(checksumPolicy);
         setRequestContext(context);
     }
@@ -68,9 +84,16 @@ public final class MetadataDownload extends MetadataTransfer {
         return this;
     }
 
+    @Deprecated
     @Override
     public MetadataDownload setFile(File file) {
         super.setFile(file);
+        return this;
+    }
+
+    @Override
+    public MetadataDownload setPath(Path path) {
+        super.setPath(path);
         return this;
     }
 
@@ -160,6 +183,6 @@ public final class MetadataDownload extends MetadataTransfer {
 
     @Override
     public String toString() {
-        return getMetadata() + " - " + getFile();
+        return getMetadata() + " - " + getPath();
     }
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataTransfer.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataTransfer.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.transfer.MetadataTransferException;
@@ -32,7 +33,7 @@ public abstract class MetadataTransfer extends Transfer {
 
     private Metadata metadata;
 
-    private File file;
+    private Path path;
 
     private MetadataTransferException exception;
 
@@ -66,9 +67,23 @@ public abstract class MetadataTransfer extends Transfer {
      * completed such that an interrupted/failed download does not corrupt the current file contents.
      *
      * @return The local file or {@code null} if not set.
+     * @deprecated Use {@link #getPath()} instead.
      */
+    @Deprecated
     public File getFile() {
-        return file;
+        return path != null ? path.toFile() : null;
+    }
+
+    /**
+     * Gets the local file the metadata is downloaded to or uploaded from. In case of a download, a connector should
+     * first transfer the bytes to a temporary file and only overwrite the target file once the entire download is
+     * completed such that an interrupted/failed download does not corrupt the current file contents.
+     *
+     * @return The local file or {@code null} if not set.
+     * @since 2.0.0
+     */
+    public Path getPath() {
+        return path;
     }
 
     /**
@@ -76,9 +91,22 @@ public abstract class MetadataTransfer extends Transfer {
      *
      * @param file The local file, may be {@code null}.
      * @return This transfer for chaining, never {@code null}.
+     * @deprecated Use {@link #setPath(Path)} instead.
      */
+    @Deprecated
     public MetadataTransfer setFile(File file) {
-        this.file = file;
+        return setPath(file != null ? file.toPath() : null);
+    }
+
+    /**
+     * Sets the local file the metadata is downloaded to or uploaded from.
+     *
+     * @param path The local file, may be {@code null}.
+     * @return This transfer for chaining, never {@code null}.
+     * @since 2.0.0
+     */
+    public MetadataTransfer setPath(Path path) {
+        this.path = path;
         return this;
     }
 

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataUpload.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/MetadataUpload.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.spi.connector;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.metadata.Metadata;
@@ -43,10 +44,24 @@ public final class MetadataUpload extends MetadataTransfer {
      *
      * @param metadata The metadata to upload, may be {@code null}.
      * @param file The local file to upload the metadata from, may be {@code null}.
+     * @deprecated Use {@link #MetadataUpload(Metadata, Path)} instead.
      */
+    @Deprecated
     public MetadataUpload(Metadata metadata, File file) {
         setMetadata(metadata);
         setFile(file);
+    }
+
+    /**
+     * Creates a new upload with the specified properties.
+     *
+     * @param metadata The metadata to upload, may be {@code null}.
+     * @param path The local file to upload the metadata from, may be {@code null}.
+     * @since 2.0.0
+     */
+    public MetadataUpload(Metadata metadata, Path path) {
+        setMetadata(metadata);
+        setPath(path);
     }
 
     @Override
@@ -55,9 +70,16 @@ public final class MetadataUpload extends MetadataTransfer {
         return this;
     }
 
+    @Deprecated
     @Override
     public MetadataUpload setFile(File file) {
         super.setFile(file);
+        return this;
+    }
+
+    @Override
+    public MetadataUpload setPath(Path path) {
+        super.setPath(path);
         return this;
     }
 
@@ -81,6 +103,6 @@ public final class MetadataUpload extends MetadataTransfer {
 
     @Override
     public String toString() {
-        return getMetadata() + " - " + getFile();
+        return getMetadata() + " - " + getPath();
     }
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmHelper.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmHelper.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,22 @@ public final class ChecksumAlgorithmHelper {
      */
     public static Map<String, String> calculate(File file, List<ChecksumAlgorithmFactory> factories)
             throws IOException {
-        try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(file.toPath()))) {
+        return calculate(file.toPath(), factories);
+    }
+
+    /**
+     * Calculates checksums for specified file.
+     *
+     * @param path        The file for which to calculate checksums, must not be {@code null}.
+     * @param factories   The checksum algorithm factories to use, must not be {@code null}.
+     * @return The calculated checksums, indexed by algorithm name, or the exception that occurred while trying to
+     * calculate it, never {@code null}.
+     * @throws IOException In case of any problem.
+     * @since 2.0.0
+     */
+    public static Map<String, String> calculate(Path path, List<ChecksumAlgorithmFactory> factories)
+            throws IOException {
+        try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(path))) {
             return calculate(inputStream, factories);
         }
     }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/ChecksumProcessor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/ChecksumProcessor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.spi.io;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A utility component to perform checksum related operations.
+ *
+ * @since 2.0.0
+ */
+public interface ChecksumProcessor {
+    /**
+     * Reads checksum from specified file.
+     *
+     * @throws IOException in case of any IO error.
+     * @since 1.8.0
+     */
+    String readChecksum(Path checksumFile) throws IOException;
+
+    /**
+     * Writes checksum to specified file.
+     *
+     * @throws IOException in case of any IO error.
+     * @since 1.8.0
+     */
+    void writeChecksum(Path checksumFile, String checksum) throws IOException;
+}

--- a/maven-resolver-supplier/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
+++ b/maven-resolver-supplier/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
@@ -30,7 +30,7 @@ import org.eclipse.aether.impl.Deployer;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.version.Version;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +42,7 @@ public class RepositorySystemSupplierTest {
         try (RepositorySystem system = new RepositorySystemSupplier().get();
                 CloseableSession session = new SessionBuilderSupplier(system)
                         .get()
-                        .withLocalRepositoryBaseDirectories(new File("target/local-repo"))
+                        .withLocalRepositoryBaseDirectories(new File("target/local-repo").toPath())
                         .build()) {
             Artifact artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-util:[0,)");
             VersionRangeRequest rangeRequest = new VersionRangeRequest();
@@ -65,22 +65,22 @@ public class RepositorySystemSupplierTest {
         systemSupplier.get().close(); // get an instance and immediately shut it down, this closes supplier as well
         assertThrows(IllegalStateException.class, systemSupplier::get);
         assertThrows(IllegalStateException.class, systemSupplier::getRepositorySystem);
-        assertThrows(IllegalStateException.class, systemSupplier::getFileProcessor);
+        assertThrows(IllegalStateException.class, systemSupplier::getChecksumProcessor);
     }
 
     @Test
     void memorizing() {
         RepositorySystemSupplier systemSupplier = new RepositorySystemSupplier();
-        FileProcessor fileProcessor = systemSupplier.getFileProcessor();
+        PathProcessor pathProcessor = systemSupplier.getPathProcessor();
         Deployer deployer = systemSupplier.getDeployer();
         try (RepositorySystem repositorySystem = systemSupplier.get()) {
             assertSame(systemSupplier.get(), repositorySystem);
-            assertSame(systemSupplier.getFileProcessor(), fileProcessor);
+            assertSame(systemSupplier.getPathProcessor(), pathProcessor);
             assertSame(systemSupplier.getDeployer(), deployer);
         }
         assertThrows(IllegalStateException.class, systemSupplier::get);
         assertThrows(IllegalStateException.class, systemSupplier::getRepositorySystem);
         assertThrows(IllegalStateException.class, systemSupplier::getDeployer);
-        assertThrows(IllegalStateException.class, systemSupplier::getFileProcessor);
+        assertThrows(IllegalStateException.class, systemSupplier::getPathProcessor);
     }
 }

--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
@@ -344,8 +344,9 @@ public class HttpTransporterTest {
     protected void testGet_ToFile() throws Exception {
         File file = TestFileUtils.createTempFile("failure");
         RecordingTransportListener listener = new RecordingTransportListener();
-        GetTask task =
-                new GetTask(URI.create("repo/file.txt")).setDataFile(file).setListener(listener);
+        GetTask task = new GetTask(URI.create("repo/file.txt"))
+                .setDataPath(file.toPath())
+                .setListener(listener);
         transporter.get(task);
         assertEquals("test", TestFileUtils.readString(file));
         assertEquals(0L, listener.getDataOffset());
@@ -360,7 +361,7 @@ public class HttpTransporterTest {
         File file = TestFileUtils.createTempFile("failure");
         RecordingTransportListener listener = new RecordingTransportListener();
         GetTask task = new GetTask(URI.create("repo/dir/oldFile.txt"))
-                .setDataFile(file)
+                .setDataPath(file.toPath())
                 .setListener(listener);
         transporter.get(task);
         assertEquals("oldTest", TestFileUtils.readString(file));
@@ -376,8 +377,9 @@ public class HttpTransporterTest {
     protected void testGet_EmptyResource() throws Exception {
         File file = TestFileUtils.createTempFile("failure");
         RecordingTransportListener listener = new RecordingTransportListener();
-        GetTask task =
-                new GetTask(URI.create("repo/empty.txt")).setDataFile(file).setListener(listener);
+        GetTask task = new GetTask(URI.create("repo/empty.txt"))
+                .setDataPath(file.toPath())
+                .setListener(listener);
         transporter.get(task);
         assertEquals("", TestFileUtils.readString(file));
         assertEquals(0L, listener.getDataOffset());
@@ -546,7 +548,7 @@ public class HttpTransporterTest {
         File file = TestFileUtils.createTempFile("re");
         RecordingTransportListener listener = new RecordingTransportListener();
         GetTask task = new GetTask(URI.create("repo/resume.txt"))
-                .setDataFile(file, true)
+                .setDataPath(file.toPath(), true)
                 .setListener(listener);
         transporter.get(task);
         assertEquals("resumable", TestFileUtils.readString(file));
@@ -563,7 +565,7 @@ public class HttpTransporterTest {
         file.setLastModified(System.currentTimeMillis() - 5 * 60 * 1000);
         RecordingTransportListener listener = new RecordingTransportListener();
         GetTask task = new GetTask(URI.create("repo/resume.txt"))
-                .setDataFile(file, true)
+                .setDataPath(file.toPath(), true)
                 .setListener(listener);
         transporter.get(task);
         assertEquals("resumable", TestFileUtils.readString(file));
@@ -580,7 +582,7 @@ public class HttpTransporterTest {
         File file = TestFileUtils.createTempFile("re");
         RecordingTransportListener listener = new RecordingTransportListener();
         GetTask task = new GetTask(URI.create("repo/resume.txt"))
-                .setDataFile(file, true)
+                .setDataPath(file.toPath(), true)
                 .setListener(listener);
         transporter.get(task);
         assertEquals("resumable", TestFileUtils.readString(file));
@@ -615,7 +617,7 @@ public class HttpTransporterTest {
     protected void testGet_FileHandleLeak() throws Exception {
         for (int i = 0; i < 100; i++) {
             File file = TestFileUtils.createTempFile("failure");
-            transporter.get(new GetTask(URI.create("repo/file.txt")).setDataFile(file));
+            transporter.get(new GetTask(URI.create("repo/file.txt")).setDataPath(file.toPath()));
             assertTrue(file.delete(), i + ", " + file.getAbsolutePath());
         }
     }
@@ -694,7 +696,7 @@ public class HttpTransporterTest {
         File file = TestFileUtils.createTempFile("upload");
         RecordingTransportListener listener = new RecordingTransportListener();
         PutTask task =
-                new PutTask(URI.create("repo/file.txt")).setListener(listener).setDataFile(file);
+                new PutTask(URI.create("repo/file.txt")).setListener(listener).setDataPath(file.toPath());
         transporter.put(task);
         assertEquals(0L, listener.getDataOffset());
         assertEquals(6L, listener.getDataLength());
@@ -915,7 +917,7 @@ public class HttpTransporterTest {
         for (int i = 0; i < 100; i++) {
             File src = TestFileUtils.createTempFile("upload");
             File dst = new File(repoDir, "file.txt");
-            transporter.put(new PutTask(URI.create("repo/file.txt")).setDataFile(src));
+            transporter.put(new PutTask(URI.create("repo/file.txt")).setDataPath(src.toPath()));
             assertTrue(src.delete(), i + ", " + src.getAbsolutePath());
             assertTrue(dst.delete(), i + ", " + dst.getAbsolutePath());
         }

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestChecksumProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestChecksumProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.test.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.eclipse.aether.spi.io.ChecksumProcessor;
+
+/**
+ * A simple file processor implementation to help satisfy component requirements during tests.
+ */
+public class TestChecksumProcessor implements ChecksumProcessor {
+    private final TestFileProcessor testFileProcessor = new TestFileProcessor();
+
+    @Override
+    public String readChecksum(Path checksumFile) throws IOException {
+        return testFileProcessor.readChecksum(checksumFile.toFile());
+    }
+
+    @Override
+    public void writeChecksum(Path checksumFile, String checksum) throws IOException {
+        testFileProcessor.writeChecksum(checksumFile.toFile(), checksum);
+    }
+}

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.test.util;
+
+import java.io.*;
+import java.nio.file.Path;
+
+import org.eclipse.aether.spi.io.PathProcessor;
+
+/**
+ * A simple file processor implementation to help satisfy component requirements during tests.
+ */
+public class TestPathProcessor implements PathProcessor {
+
+    private final TestFileProcessor testFileProcessor = new TestFileProcessor();
+
+    public void mkdirs(Path directory) {
+        if (directory == null) {
+            return;
+        }
+        testFileProcessor.mkdirs(directory.toFile());
+    }
+
+    public void write(Path file, String data) throws IOException {
+        testFileProcessor.write(file.toFile(), data);
+    }
+
+    public void write(Path target, InputStream source) throws IOException {
+        testFileProcessor.write(target.toFile(), source);
+    }
+
+    public void copy(Path source, Path target) throws IOException {
+        copy(source, target, null);
+    }
+
+    public long copy(Path source, Path target, ProgressListener listener) throws IOException {
+        return testFileProcessor.copy(source.toFile(), target.toFile(), null);
+    }
+
+    public void move(Path source, Path target) throws IOException {
+        testFileProcessor.move(source.toFile(), target.toFile());
+    }
+}

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -62,6 +62,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-test-util</artifactId>
       <scope>test</scope>
@@ -69,6 +74,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.jimfs</groupId>
+      <artifactId>jimfs</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
@@ -26,6 +26,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
 import org.eclipse.aether.spi.connector.transport.http.HttpTransporter;
 import org.eclipse.aether.spi.connector.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 
 import static java.util.Objects.requireNonNull;
@@ -43,9 +44,12 @@ public final class JdkTransporterFactory implements HttpTransporterFactory {
 
     private final ChecksumExtractor checksumExtractor;
 
+    private final PathProcessor pathProcessor;
+
     @Inject
-    public JdkTransporterFactory(ChecksumExtractor checksumExtractor) {
+    public JdkTransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
         this.checksumExtractor = requireNonNull(checksumExtractor, "checksumExtractor");
+        this.pathProcessor = requireNonNull(pathProcessor, "pathProcessor");
     }
 
     @Override
@@ -68,7 +72,7 @@ public final class JdkTransporterFactory implements HttpTransporterFactory {
             throw new NoTransporterException(repository, "Only HTTP/HTTPS is supported");
         }
 
-        return new JdkTransporter(session, repository, javaVersion(), checksumExtractor);
+        return new JdkTransporter(session, repository, javaVersion(), checksumExtractor, pathProcessor);
     }
 
     private static int javaVersion() {

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.transport.jdk;
 import java.net.ConnectException;
 import java.net.URI;
 
+import org.eclipse.aether.internal.impl.DefaultPathProcessor;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.internal.test.util.http.HttpTransporterTest;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -84,14 +85,14 @@ class JdkTransporterTest extends HttpTransporterTest {
     protected void testPut_Authenticated_ExpectContinueRejected_ExplicitlyConfiguredHeader() {}
 
     public JdkTransporterTest() {
-        super(() -> new JdkTransporterFactory(standardChecksumExtractor()));
+        super(() -> new JdkTransporterFactory(standardChecksumExtractor(), new DefaultPathProcessor()));
     }
 
     @Test
     void enhanceConnectExceptionMessages() {
         String uri = "https://localhost:12345/";
         RemoteRepository remoteRepository = new RemoteRepository.Builder("central", "default", uri).build();
-        JdkTransporterFactory factory = new JdkTransporterFactory(s -> null);
+        JdkTransporterFactory factory = new JdkTransporterFactory(s -> null, new DefaultPathProcessor());
 
         try (Transporter transporter = factory.newInstance(TestUtils.newSession(), remoteRepository)) {
             transporter.peek(new PeekTask(URI.create("repo/file.txt")));

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
@@ -26,6 +26,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
 import org.eclipse.aether.spi.connector.transport.http.HttpTransporter;
 import org.eclipse.aether.spi.connector.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public final class JdkTransporterFactory implements HttpTransporterFactory {
     private float priority = 10.0f;
 
     @Inject
-    public JdkTransporterFactory(ChecksumExtractor checksumExtractor) {
+    public JdkTransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
         // this is to equalize all Java version constructors to be same, so Supplier could work across all versions
     }
 

--- a/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/PutTaskRequestContent.java
+++ b/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/PutTaskRequestContent.java
@@ -94,8 +94,8 @@ class PutTaskRequestContent extends AbstractRequestContent {
             ByteBuffer buffer;
             boolean last;
             if (channel == null) {
-                if (putTask.getDataFile() != null) {
-                    channel = Files.newByteChannel(putTask.getDataFile().toPath(), StandardOpenOption.READ);
+                if (putTask.getDataPath() != null) {
+                    channel = Files.newByteChannel(putTask.getDataPath(), StandardOpenOption.READ);
                 } else {
                     channel = Channels.newChannel(putTask.newInputStream());
                 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/DirectoryUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/DirectoryUtils.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.LocalRepository;
 
 import static java.util.Objects.requireNonNull;
 
@@ -67,7 +68,7 @@ public final class DirectoryUtils {
         if (namePath.isAbsolute()) {
             result = namePath.normalize();
         } else {
-            result = base.resolve(namePath).normalize();
+            result = base.resolve(name).normalize();
         }
 
         if (!Files.exists(result)) {
@@ -84,7 +85,7 @@ public final class DirectoryUtils {
      * Creates {@link Path} instance out of session configuration, and (if relative) resolve it against local
      * repository basedir. Pre-populates values and invokes {@link #resolveDirectory(String, Path, boolean)}.
      * <p>
-     * For this method to work, {@link org.eclipse.aether.repository.LocalRepository#getBasedir()} must return
+     * For this method to work, {@link LocalRepository#getBasePath()} must return
      * non-{@code null} value, otherwise {@link NullPointerException} is thrown.
      *
      * @param session     The session, may not be {@code null}.
@@ -100,10 +101,10 @@ public final class DirectoryUtils {
         requireNonNull(session, "session is null");
         requireNonNull(defaultName, "defaultName is null");
         requireNonNull(nameKey, "nameKey is null");
-        requireNonNull(session.getLocalRepository().getBasedir(), "session.localRepository.basedir is null");
+        requireNonNull(session.getLocalRepository().getBasePath(), "session.localRepository.basePath is null");
         return resolveDirectory(
                 ConfigUtils.getString(session, defaultName, nameKey),
-                session.getLocalRepository().getBasedir().toPath(),
+                session.getLocalRepository().getBasePath(),
                 mayCreate);
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -132,7 +132,7 @@ public final class FileUtils {
                     if (IS_WINDOWS) {
                         copy(tempFile, file);
                     } else {
-                        Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE);
+                        Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
                     }
                 }
                 Files.deleteIfExists(tempFile);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DelegatingArtifact.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/artifact/DelegatingArtifact.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.util.artifact;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.eclipse.aether.artifact.AbstractArtifact;
@@ -52,18 +53,22 @@ public abstract class DelegatingArtifact extends AbstractArtifact {
      */
     protected abstract DelegatingArtifact newInstance(Artifact delegate);
 
+    @Override
     public String getGroupId() {
         return delegate.getGroupId();
     }
 
+    @Override
     public String getArtifactId() {
         return delegate.getArtifactId();
     }
 
+    @Override
     public String getVersion() {
         return delegate.getVersion();
     }
 
+    @Override
     public Artifact setVersion(String version) {
         Artifact artifact = delegate.setVersion(version);
         if (artifact != delegate) {
@@ -72,28 +77,50 @@ public abstract class DelegatingArtifact extends AbstractArtifact {
         return this;
     }
 
+    @Override
     public String getBaseVersion() {
         return delegate.getBaseVersion();
     }
 
+    @Override
     public boolean isSnapshot() {
         return delegate.isSnapshot();
     }
 
+    @Override
     public String getClassifier() {
         return delegate.getClassifier();
     }
 
+    @Override
     public String getExtension() {
         return delegate.getExtension();
     }
 
+    @Deprecated
+    @Override
     public File getFile() {
         return delegate.getFile();
     }
 
+    @Override
+    public Path getPath() {
+        return delegate.getPath();
+    }
+
+    @Deprecated
+    @Override
     public Artifact setFile(File file) {
         Artifact artifact = delegate.setFile(file);
+        if (artifact != delegate) {
+            return newInstance(artifact);
+        }
+        return this;
+    }
+
+    @Override
+    public Artifact setPath(Path path) {
+        Artifact artifact = delegate.setPath(path);
         if (artifact != delegate) {
             return newInstance(artifact);
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/NodeListGenerator.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/NodeListGenerator.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.util.graph.visitor;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -97,9 +98,21 @@ public final class NodeListGenerator implements Consumer<DependencyNode> {
      * Gets the files of resolved artifacts seen during the graph traversal.
      *
      * @return The list of artifact files, never {@code null}.
+     * @deprecated Use {@link #getPaths()} instead.
      */
+    @Deprecated
     public List<File> getFiles() {
         return getFiles(getNodes());
+    }
+
+    /**
+     * Gets the files of resolved artifacts seen during the graph traversal.
+     *
+     * @return The list of artifact files, never {@code null}.
+     * @since 2.0.0
+     */
+    public List<Path> getPaths() {
+        return getPaths(getNodes());
     }
 
     /**
@@ -119,17 +132,18 @@ public final class NodeListGenerator implements Consumer<DependencyNode> {
     static List<Dependency> getDependencies(List<DependencyNode> nodes, boolean includeUnresolved) {
         return getNodesWithDependencies(nodes).stream()
                 .map(DependencyNode::getDependency)
-                .filter(d -> includeUnresolved || d.getArtifact().getFile() != null)
+                .filter(d -> includeUnresolved || d.getArtifact().getPath() != null)
                 .collect(toList());
     }
 
     static List<Artifact> getArtifacts(List<DependencyNode> nodes, boolean includeUnresolved) {
         return getNodesWithDependencies(nodes).stream()
                 .map(d -> d.getDependency().getArtifact())
-                .filter(artifact -> includeUnresolved || artifact.getFile() != null)
+                .filter(artifact -> includeUnresolved || artifact.getPath() != null)
                 .collect(toList());
     }
 
+    @Deprecated
     static List<File> getFiles(List<DependencyNode> nodes) {
         return getNodesWithDependencies(nodes).stream()
                 .map(d -> d.getDependency().getArtifact().getFile())
@@ -137,7 +151,17 @@ public final class NodeListGenerator implements Consumer<DependencyNode> {
                 .collect(toList());
     }
 
+    static List<Path> getPaths(List<DependencyNode> nodes) {
+        return getNodesWithDependencies(nodes).stream()
+                .map(d -> d.getDependency().getArtifact().getPath())
+                .filter(Objects::nonNull)
+                .collect(toList());
+    }
+
     static String getClassPath(List<DependencyNode> nodes) {
-        return getFiles(nodes).stream().map(File::getAbsolutePath).collect(joining(File.pathSeparator));
+        return getPaths(nodes).stream()
+                .map(Path::toAbsolutePath)
+                .map(Path::toString)
+                .collect(joining(File.pathSeparator));
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/ChainedLocalRepositoryManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/ChainedLocalRepositoryManager.java
@@ -18,7 +18,6 @@
  */
 package org.eclipse.aether.util.repository;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -120,7 +119,7 @@ public final class ChainedLocalRepositoryManager implements LocalRepositoryManag
 
         for (LocalRepositoryManager lrm : tail) {
             result = lrm.find(session, request);
-            if (result.getFile() != null) {
+            if (result.getPath() != null) {
                 if (ignoreTailAvailability) {
                     result.setAvailable(true);
                     return result;
@@ -141,7 +140,7 @@ public final class ChainedLocalRepositoryManager implements LocalRepositoryManag
             artifactPath = getPathForLocalArtifact(request.getArtifact());
         }
 
-        Path file = new File(head.getRepository().getBasedir(), artifactPath).toPath();
+        Path file = head.getRepository().getBasePath().resolve(artifactPath);
         if (Files.isRegularFile(file)) {
             head.add(session, request);
         }
@@ -150,13 +149,13 @@ public final class ChainedLocalRepositoryManager implements LocalRepositoryManag
     @Override
     public LocalMetadataResult find(RepositorySystemSession session, LocalMetadataRequest request) {
         LocalMetadataResult result = head.find(session, request);
-        if (result.getFile() != null) {
+        if (result.getPath() != null) {
             return result;
         }
 
         for (LocalRepositoryManager lrm : tail) {
             result = lrm.find(session, request);
-            if (result.getFile() != null) {
+            if (result.getPath() != null) {
                 return result;
             }
         }
@@ -172,7 +171,7 @@ public final class ChainedLocalRepositoryManager implements LocalRepositoryManag
             metadataPath = getPathForLocalMetadata(request.getMetadata());
         }
 
-        Path file = new File(head.getRepository().getBasedir(), metadataPath).toPath();
+        Path file = head.getRepository().getBasePath().resolve(metadataPath);
         if (Files.isRegularFile(file)) {
             head.add(session, request);
         }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/artifact/SubArtifactTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/artifact/SubArtifactTest.java
@@ -128,7 +128,7 @@ public class SubArtifactTest {
         Map<String, String> props = new HashMap<>();
         props.put("key", "value1");
 
-        Artifact a = new SubArtifact(newMainArtifact("gid:aid:ver"), "", "pom", props, null);
+        Artifact a = new SubArtifact(newMainArtifact("gid:aid:ver"), "", "pom", props, (File) null);
         assertEquals("value1", a.getProperty("key", null));
         props.clear();
         assertEquals("value1", a.getProperty("key", null));

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <!-- Used by Jetty Transport (client) and Test HTTP (server) -->
     <jettyVersion>10.0.20</jettyVersion>
     <!-- used by supplier and demo only -->
-    <mavenVersion>4.0.0-alpha-12</mavenVersion>
+    <mavenVersion>4.0.0-alpha-13-SNAPSHOT</mavenVersion>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
     <!-- MRESOLVER-422: keep this in sync with Javadoc plugin configuration (but cannot directly, as this below is range) -->
     <minimalJavaBuildVersion>[21,)</minimalJavaBuildVersion>
@@ -264,6 +264,12 @@
         <artifactId>slf4j-simple</artifactId>
         <version>${slf4jVersion}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.jimfs</groupId>
+        <artifactId>jimfs</artifactId>
+        <version>1.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Internally, stop using java.io.File and use NIO2 Paths instead. From outside, this should not make a lot of difference (and is enforced by japicmp as [documented here](https://maven.apache.org/resolver/api-compatibility.html)).

But, as a consequence: if Resolver used on FileSystem like Google JIMFS, whatever code touches File method (that will do Path.toFile() under the hood), it will explode. Hence, we need to make sure this call never happens internally, and leave it to consumer projects. Resolver alone should never invoke it.

Most notable changes:
* change internals to use NIO2 Paths.
* in resolver now everything is "resolved" from local repository `basePath`, hence, if you put your local repository onto non-default FileSystem, it will work just fine (as proved by Demo Snippets). Naturally, if anything touches `File` returning method, in case of non-default FileSystem, it explodes (Google JIMFs Path.toFile() simply throws).
* change transport-file to support any (and not only default) FileSystem, covered by tests. This makes possible to use any FileSystem hosted repositories as "remote file repositories". Covered by UTs that now runs as parameterized two times: using default and using JIMFS FileSystem (as it is simple to set up, very handy for testing).
* change file locking to support any (and not only default) FileSystem. Before this change the implicit requirement that "lock name is fully qualified absolute file system path", but now it changes to "lock name is proper string representation of an URI". The key change is in BasedirNameMapper, where one can now use custom `Path` (for example created with JIMFS) and use that to name locks (use `file:` for default FS or any other URIs, ie `jimfs:` ones).

---

If you build this locally, and then related [Maven PR](https://github.com/apache/maven/pull/1413) (~w/ japicmp disabled if not fixed~), and then uncomment Google FS in demo `Booter` class, you will end up with Resolver DEMOs running on in-memory FS.

---

https://issues.apache.org/jira/browse/MRESOLVER-496