### PR TITLE
[1.9.x] [MRESOLVER-522] Improve congested file locks behaviour (#455)

### DIFF
--- a/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
+++ b/maven-resolver-named-locks/src/main/java/org/eclipse/aether/named/support/FileLockNamedLock.java
@@ -84,16 +84,16 @@ public final class FileLockNamedLock extends NamedLockSupport {
 
     @Override
     protected boolean doLockShared(final long time, final TimeUnit unit) throws InterruptedException {
-        return retry(time, unit, RETRY_SLEEP_MILLIS, this::doLockShared, null, false);
+        return retry(time, unit, RETRY_SLEEP_MILLIS, () -> doLockSharedPerform(time, unit), null, false);
     }
 
     @Override
     protected boolean doLockExclusively(final long time, final TimeUnit unit) throws InterruptedException {
-        return retry(time, unit, RETRY_SLEEP_MILLIS, this::doLockExclusively, null, false);
+        return retry(time, unit, RETRY_SLEEP_MILLIS, () -> doLockExclusivelyPerform(time, unit), null, false);
     }
 
-    private Boolean doLockShared() {
-        if (criticalRegion.tryLock()) {
+    private Boolean doLockSharedPerform(final long time, final TimeUnit unit) throws InterruptedException {
+        if (criticalRegion.tryLock(time, unit)) {
             try {
                 Deque<Boolean> steps = threadSteps.computeIfAbsent(Thread.currentThread(), k -> new ArrayDeque<>());
                 FileLock obtainedLock = fileLockRef.get();
@@ -127,8 +127,8 @@ public final class FileLockNamedLock extends NamedLockSupport {
         return null;
     }
 
-    private Boolean doLockExclusively() {
-        if (criticalRegion.tryLock()) {
+    private Boolean doLockExclusivelyPerform(final long time, final TimeUnit unit) throws InterruptedException {
+        if (criticalRegion.tryLock(time, unit)) {
             try {
                 Deque<Boolean> steps = threadSteps.computeIfAbsent(Thread.currentThread(), k -> new ArrayDeque<>());
                 FileLock obtainedLock = fileLockRef.get();


### PR DESCRIPTION
Instead to immediately give up and sleep, they will sit a while to enter critical region. This is important for "hot" locks.

Explanation: currently a "loser" will _immediately give up_ and will go to sleep 100ms if cannot enter critical region, even if winner exits critical region within next 5ms. The retry is needed to ensure that it is retried as much as given time/unit takes, that was before consumed by constant retries+sleeps. The logic still works, as if tryLock spends time/unit waiting on criticalRegion (which is possible only on VERY HIGHLY congested locks), there will be no retry happening.

Backport of 089796ba66d6f5f1a9d4fa7f797f613bae4f5373

---

https://issues.apache.org/jira/browse/MRESOLVER-522