### PR TITLE
[1.9.x] Update dependencies

### DIFF
--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>5.3.2</version>
+      <version>5.3.7</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
-      <version>3.23.4</version>
+      <version>3.28.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.16.0</version>
+      <version>1.16.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-    <jettyVersion>9.4.52.v20230823</jettyVersion>
+    <jettyVersion>9.4.54.v20240208</jettyVersion>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <maven.site.path>resolver-archives/resolver-LATEST</maven.site.path>
     <checkstyle.violation.ignore>None</checkstyle.violation.ignore>
     <sisuVersion>0.9.0.M2</sisuVersion>
-    <guiceVersion>5.1.0</guiceVersion>
+    <guiceVersion>6.0.0</guiceVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <!-- used by supplier and demo only -->
     <mavenVersion>3.9.6</mavenVersion>
@@ -226,6 +226,11 @@
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guiceVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.1.0-jre</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
     <failsafe.redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</failsafe.redirectTestOutputToFile>
     <maven.site.path>resolver-archives/resolver-LATEST</maven.site.path>
     <checkstyle.violation.ignore>None</checkstyle.violation.ignore>
-    <sisuVersion>0.3.5</sisuVersion>
+    <sisuVersion>0.9.0.M2</sisuVersion>
     <guiceVersion>5.1.0</guiceVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <!-- used by supplier and demo only -->
-    <mavenVersion>3.9.4</mavenVersion>
+    <mavenVersion>3.9.6</mavenVersion>
     <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2023-11-22T15:56:07Z</project.build.outputTimestamp>


### PR DESCRIPTION
Changes:
* hazelcast 5.3.7
* redisson 3.28.0
* commons-codec 1.16.1
* sisu 0.9.0.M2
* guice 6.0.0 (and guava 33.1.0)
* jetty 9.4.54 (used in tests)
* maven 3.9.6 (used in demos)

---

https://issues.apache.org/jira/browse/MRESOLVER-527
https://issues.apache.org/jira/browse/MRESOLVER-528
https://issues.apache.org/jira/browse/MRESOLVER-529
https://issues.apache.org/jira/browse/MRESOLVER-530
https://issues.apache.org/jira/browse/MRESOLVER-531
https://issues.apache.org/jira/browse/MRESOLVER-532
https://issues.apache.org/jira/browse/MRESOLVER-533