### PR TITLE
[1.9.x] [MRESOLVER-536] Do not belly up if FS does not support setting mtime

### DIFF
--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -31,7 +31,6 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -691,8 +690,7 @@ final class HttpTransporter extends AbstractTransporter {
                 if (lastModifiedHeader != null) {
                     Date lastModified = DateUtils.parseDate(lastModifiedHeader.getValue());
                     if (lastModified != null) {
-                        Files.setLastModifiedTime(
-                                task.getDataFile().toPath(), FileTime.fromMillis(lastModified.getTime()));
+                        task.getDataFile().setLastModified(lastModified.getTime());
                     }
                 }
             }


### PR DESCRIPTION
This seems more logical step, simply use File.setLastModified as it does not throws, and is used all over the 1.9.x codebase.

---

https://issues.apache.org/jira/browse/MRESOLVER-536