### PR TITLE
[MRESOLVER-536] Followup change: log failures

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
@@ -58,7 +58,7 @@ public class DefaultPathProcessor implements PathProcessor {
             if (e instanceof AccessDeniedException) {
                 throw e;
             }
-            logger.debug("Failed to set last-modified: {}", path, e);
+            logger.trace("Failed to set last modified date: {}", path, e);
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
@@ -21,15 +21,24 @@ package org.eclipse.aether.internal.impl;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
 
 import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility class helping with file-based operations.
@@ -37,6 +46,24 @@ import org.eclipse.aether.util.FileUtils;
 @Singleton
 @Named
 public class DefaultPathProcessor implements PathProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public boolean setLastModified(Path path, long value) throws IOException {
+        try {
+            Files.setLastModifiedTime(path, FileTime.fromMillis(value));
+            return true;
+        } catch (FileSystemException e) {
+            // MRESOLVER-536: Java uses generic FileSystemException for some weird cases,
+            // but some subclasses like AccessDeniedEx should be re-thrown
+            if (e instanceof AccessDeniedException) {
+                throw e;
+            }
+            logger.debug("Failed to set last-modified: {}", path, e);
+            return false;
+        }
+    }
+
     @Override
     public void write(Path target, String data) throws IOException {
         FileUtils.writeFile(target, p -> Files.write(p, data.getBytes(StandardCharsets.UTF_8)));

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
@@ -49,10 +49,9 @@ public class DefaultPathProcessor implements PathProcessor {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
-    public boolean setLastModified(Path path, long value) throws IOException {
+    public void setLastModified(Path path, long value) throws IOException {
         try {
             Files.setLastModifiedTime(path, FileTime.fromMillis(value));
-            return true;
         } catch (FileSystemException e) {
             // MRESOLVER-536: Java uses generic FileSystemException for some weird cases,
             // but some subclasses like AccessDeniedEx should be re-thrown
@@ -60,7 +59,6 @@ public class DefaultPathProcessor implements PathProcessor {
                 throw e;
             }
             logger.debug("Failed to set last-modified: {}", path, e);
-            return false;
         }
     }
 

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
@@ -20,11 +20,9 @@ package org.eclipse.aether.spi.io;
 
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
 
 /**
  * A utility component to perform file-based operations.
@@ -52,21 +50,12 @@ public interface PathProcessor {
      * Sets last modified of path in milliseconds, if exists.
      *
      * @param path The path, may be {@code null}.
-     * @throws UncheckedIOException If an I/O error occurs.
+     * @throws IOException If an I/O error occurs.
      * @return {@code true} if timestamp was successfully set, {@code false} otherwise. Reasons of {@code false} may
-     * be multiple, from file not found, to FS not supporting the setting the TS.
+     * be multiple, ranging from "file not found" to cases when FS does not support the setting the mtime.
      * @since TBD
      */
-    default boolean setLastModified(Path path, long value) {
-        try {
-            Files.setLastModifiedTime(path, FileTime.fromMillis(value));
-            return true;
-        } catch (FileSystemException e) {
-            return false; // not found Ex belongs here as well
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+    boolean setLastModified(Path path, long value) throws IOException;
 
     /**
      * Returns size of file, if exists.

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
@@ -50,12 +50,11 @@ public interface PathProcessor {
      * Sets last modified of path in milliseconds, if exists.
      *
      * @param path The path, may be {@code null}.
-     * @throws IOException If an I/O error occurs.
-     * @return {@code true} if timestamp was successfully set, {@code false} otherwise. Reasons of {@code false} may
-     * be multiple, ranging from "file not found" to cases when FS does not support the setting the mtime.
+     * @throws IOException If an I/O error occurs. Some exceptions/reasons of failure to set mtime may be swallowed,
+     * and can be multiple, ranging from "file not found" to cases when FS does not support the setting the mtime.
      * @since TBD
      */
-    boolean setLastModified(Path path, long value) throws IOException;
+    void setLastModified(Path path, long value) throws IOException;
 
     /**
      * Returns size of file, if exists.
@@ -122,13 +121,12 @@ public interface PathProcessor {
      * @param source The file to copy from, must not be {@code null}.
      * @param target The file to copy to, must not be {@code null}.
      * @throws IOException If an I/O error occurs.
-     * @return {@code true} if timestamp was successfully set, {@code false} otherwise.
      * @see #setLastModified(Path, long)
      * @since TBD
      */
-    default boolean copyWithTimestamp(Path source, Path target) throws IOException {
+    default void copyWithTimestamp(Path source, Path target) throws IOException {
         copy(source, target, null);
-        return setLastModified(target, Files.getLastModifiedTime(source).toMillis());
+        setLastModified(target, Files.getLastModifiedTime(source).toMillis());
     }
 
     /**

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
@@ -19,7 +19,9 @@
 package org.eclipse.aether.internal.test.util;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 
 import org.eclipse.aether.spi.io.PathProcessor;
 
@@ -29,6 +31,12 @@ import org.eclipse.aether.spi.io.PathProcessor;
 public class TestPathProcessor implements PathProcessor {
 
     private final TestFileProcessor testFileProcessor = new TestFileProcessor();
+
+    @Override
+    public boolean setLastModified(Path path, long value) throws IOException {
+        Files.setLastModifiedTime(path, FileTime.fromMillis(value));
+        return true;
+    }
 
     public void mkdirs(Path directory) {
         if (directory == null) {

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
@@ -33,9 +33,8 @@ public class TestPathProcessor implements PathProcessor {
     private final TestFileProcessor testFileProcessor = new TestFileProcessor();
 
     @Override
-    public boolean setLastModified(Path path, long value) throws IOException {
+    public void setLastModified(Path path, long value) throws IOException {
         Files.setLastModifiedTime(path, FileTime.fromMillis(value));
-        return true;
     }
 
     public void mkdirs(Path directory) {


### PR DESCRIPTION
Do not swallow cases like AccessDeniedEx, and log failures. Make new method `void` as nothing is interested in return value, while all we wanted (swallow some and log) is handled here.

This PR builds upon prev PR https://github.com/apache/maven-resolver/pull/468

---

https://issues.apache.org/jira/browse/MRESOLVER-536