### PR TITLE
[MRESOLVER-547] Just use setVersion

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -46,8 +46,6 @@ import java.util.stream.Stream;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.ArtifactType;
-import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.collection.DependencyManager;
@@ -451,14 +449,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
     private ArtifactDescriptorResult resolveDescriptorForVersion(
             Args args, DependencyProcessingContext context, Results results, Dependency dependency, Version version) {
         Artifact original = dependency.getArtifact();
-        Artifact newArtifact = new DefaultArtifact(
-                original.getGroupId(),
-                original.getArtifactId(),
-                original.getClassifier(),
-                original.getExtension(),
-                version.toString(),
-                original.getProperties(),
-                (ArtifactType) null);
+        Artifact newArtifact = original.setVersion(version.toString());
         Dependency newDependency =
                 new Dependency(newArtifact, dependency.getScope(), dependency.isOptional(), dependency.getExclusions());
         DependencyProcessingContext newContext = context.copy();


### PR DESCRIPTION
No need for full copy, Artifact is already immutable. Moreover, the instance may be not DefaultArtifact but something else. And finally, setVersion already have "optimization" to return this if version is same as the one we want to copy with.

---

https://issues.apache.org/jira/browse/MRESOLVER-547