### PR TITLE
[MRESOLVER-548] Artifact file/path improvements

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/AbstractArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/AbstractArtifact.java
@@ -82,7 +82,7 @@ public abstract class AbstractArtifact implements Artifact {
      * @param path The resolved file of the artifact, may be {@code null}.
      * @return The new artifact instance, never {@code null}.
      */
-    private Artifact newInstance(String version, Map<String, String> properties, Path path) {
+    protected Artifact newInstance(String version, Map<String, String> properties, Path path) {
         return new DefaultArtifact(
                 getGroupId(), getArtifactId(), getClassifier(), getExtension(), version, path, properties);
     }
@@ -96,30 +96,40 @@ public abstract class AbstractArtifact implements Artifact {
         return newInstance(version, getProperties(), getPath());
     }
 
+    @Deprecated
+    @Override
+    public Artifact setFile(File file) {
+        File current = getFile();
+        if (Objects.equals(current, file)) {
+            return this;
+        }
+        return newInstance(getVersion(), getProperties(), file != null ? file.toPath() : null);
+    }
+
     /**
      * This method should (and in Resolver is) overridden, but is kept just to preserve backward compatibility if
      * this class is extended somewhere.
      */
+    @Override
     public Path getPath() {
         File file = getFile();
         return file != null ? file.toPath() : null;
     }
 
-    @Deprecated
-    @Override
-    public Artifact setFile(File file) {
-        return setPath(file != null ? file.toPath() : null);
-    }
-
+    /**
+     * This method should (and in Resolver is) overridden, but is kept just to preserve backward compatibility if
+     * this class is extended somewhere.
+     */
     @Override
     public Artifact setPath(Path path) {
         Path current = getPath();
         if (Objects.equals(current, path)) {
             return this;
         }
-        return newInstance(getVersion(), getProperties(), path);
+        return setFile(path != null ? path.toFile() : null);
     }
 
+    @Override
     public Artifact setProperties(Map<String, String> properties) {
         Map<String, String> current = getProperties();
         if (current.equals(properties) || (properties == null && current.isEmpty())) {
@@ -128,6 +138,7 @@ public abstract class AbstractArtifact implements Artifact {
         return newInstance(getVersion(), copyProperties(properties), getPath());
     }
 
+    @Override
     public String getProperty(String key, String defaultValue) {
         String value = getProperties().get(key);
         return (value != null) ? value : defaultValue;

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -309,33 +310,48 @@ public final class DefaultArtifact extends AbstractArtifact {
         return (str == null) ? "" : str;
     }
 
+    @Override
     public String getGroupId() {
         return groupId;
     }
 
+    @Override
     public String getArtifactId() {
         return artifactId;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public String getClassifier() {
         return classifier;
     }
 
+    @Override
     public String getExtension() {
         return extension;
     }
 
     @Deprecated
+    @Override
     public File getFile() {
         return path != null ? path.toFile() : null;
     }
 
+    @Override
     public Path getPath() {
         return path;
+    }
+
+    @Override
+    public Artifact setPath(Path path) {
+        if (Objects.equals(this.path, path)) {
+            return this;
+        }
+        return newInstance(version, getProperties(), path);
     }
 
     public Map<String, String> getProperties() {


### PR DESCRIPTION
As original went from File to NIO2 Path, there were some changes left that may disturb code written agains Resolver 1.

The `AbstractArtifact` in resolver is extended in resolver in 3 classes. Still, there may be "outsider" extending it as well. Resolver classes all override properly the file/path related methods, but "outsiders" may not. It is wrong to have here "file -> path" redirection, as "outsider" may and is able only to override file related methods. Hence, `AbstractArtifact` should turn this around and make "path -> file" delegation instead, as 3rd party classes most probably overrode only file related methods.

---

https://issues.apache.org/jira/browse/MRESOLVER-548