### PR TITLE
[1.9.x] [MRESOLVER-570] Remove excessive strictness of OSGi dependency metadata

### DIFF
--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -31,6 +31,18 @@
   <name>Maven Artifact Resolver Implementation</name>
   <description>An implementation of the repository system.</description>
 
+  <properties>
+    <bnd.instructions.additions><![CDATA[
+      # Mark optional Maven dependencies as optional
+      Import-Package: \
+        org.slf4j.spi;version="[1.7,3)", \
+        javax.inject;resolution:=optional,\
+        com.google.inject*;resolution:=optional, \
+        org.eclipse.sisu*;resolution:=optional, \
+        *
+    ]]></bnd.instructions.additions>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,10 @@
               Automatic-Module-Name: ${Bundle-SymbolicName}
               # Export packages not containing the substring 'internal'
               -exportcontents: ${removeall;${packages};${packages;NAMED;*internal*}}
+              # Mark optional Maven dependencies as optional
+              Import-Package: \
+                javax.inject*;resolution:=optional, \
+                *
               # Reproducible build
               -noextraheaders: true
               ${bnd.instructions.additions}


### PR DESCRIPTION
- Mark optional Maven dependencies as optional in OSGi metadata
It is an explicit decision from bndtools to require explicit configuration of a user to make a dependency optional, even if the corresponding maven dependency is optional: https://github.com/bndtools/bnd/issues/2713
- Widen version range for org.slf4j.spi package to [1.7,3)

Fixes [MRESOLVER-570](https://issues.apache.org/jira/browse/MRESOLVER-570)

