### PR TITLE
[MRESOLVER-570] Remove excessive strictness of OSGi dependency metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,10 @@
               Bundle-SymbolicName: ${Bundle-SymbolicName}
               # Export packages not containing the substring 'internal'
               -exportcontents: ${removeall;${packages};${packages;NAMED;*internal*}}
+              # Mark optional Maven dependencies as optional
+              Import-Package: \
+                javax.inject*;resolution:=optional, \
+                *
               # Reproducible build
               -noextraheaders: true
             ]]></bnd>


### PR DESCRIPTION
- Mark optional Maven dependencies as optional in OSGi metadata
- Widen version range for org.slf4j.spi package to [1.7,3)
- Move bnd configuration section from execution to plugin configuration in order to simplify extensions in sub-modules.

This is a forward port of https://github.com/apache/maven-resolver/pull/505 to resolver-2.x/master, that skips the update of the bnd-maven-plugin since it is already at 7.0.0.

Fixes [MRESOLVER-570](https://issues.apache.org/jira/browse/MRESOLVER-570)
