### PR TITLE
[1.9.x] [MRESOLVER-571] Import o.e.aether packages with the exact same version

### DIFF
--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -35,6 +35,7 @@
     <bnd.instructions.additions><![CDATA[
       # Mark optional Maven dependencies as optional
       Import-Package: \
+        org.eclipse.aether*;version="${range;[===,===];${mavenResolverVersion}}", \
         org.slf4j.spi;version="[1.7,3)", \
         javax.inject;resolution:=optional,\
         com.google.inject*;resolution:=optional, \

--- a/pom.xml
+++ b/pom.xml
@@ -474,13 +474,16 @@
             <bnd><![CDATA[
               Bundle-SymbolicName: org.apache.${replacestring;${project.artifactId};-;.}
               Automatic-Module-Name: ${Bundle-SymbolicName}
-              # Export packages not containing the substring 'internal'
+              # Export packages, but don't re-import own packages
               -exportcontents: \
-                *.impl.*;x-internal:=true, \
-                *.internal.*;x-internal:=true, \
-                *
-              # Mark optional Maven dependencies as optional
+                *.impl.*;x-internal:=true;-noimport:=true, \
+                *.internal.*;x-internal:=true;-noimport:=true, \
+                *;-noimport:=true
+              # Ensure only maven-resolver packages of exactly the same version are imported
+              # and mark optional Maven dependencies as optional.
+              mavenResolverVersion=${versionmask;===;${version_cleanup;${project.version}}}
               Import-Package: \
+                org.eclipse.aether*;version="${range;[===,===];${mavenResolverVersion}}", \
                 javax.inject*;resolution:=optional, \
                 *
               # Reproducible build


### PR DESCRIPTION
The documentation states that only maven-resolver artifacts of the exact same version should be used together.

With this change all `org.eclipse.aether*` packages are now imported with a strict version range of
`'org.eclipse.aether*;version="[@version,@version]"'
`
Fixes https://issues.apache.org/jira/browse/MRESOLVER-571

This PR currently also containes the changes planned for https://github.com/apache/maven-resolver/pull/505.
If there is agreement for this change, I'll forward port it to the `master/2.x`.