### PR TITLE
[MRESOLVER-27] turn api, spi and utils into Java 9 modules

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -32,8 +32,7 @@
   <description>The application programming interface for the repository system.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}.api</Bundle-SymbolicName>
+    <Bundle-SymbolicName>org.apache.maven.resolver.api</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -58,6 +57,32 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>module-descriptor</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <includes>
+                <include>module-info.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-resolver-api/src/main/java/module-info.java
+++ b/maven-resolver-api/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.maven.resolver {
+    exports org.eclipse.aether;
+    exports org.eclipse.aether.artifact;
+    exports org.eclipse.aether.collection;
+    exports org.eclipse.aether.deployment;
+    exports org.eclipse.aether.graph;
+    exports org.eclipse.aether.installation;
+    exports org.eclipse.aether.metadata;
+    exports org.eclipse.aether.repository;
+    exports org.eclipse.aether.resolution;
+    exports org.eclipse.aether.scope;
+    exports org.eclipse.aether.transfer;
+    exports org.eclipse.aether.version;
+}

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -97,6 +97,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-generator-gnupg/pom.xml
+++ b/maven-resolver-generator-gnupg/pom.xml
@@ -132,6 +132,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -118,6 +118,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -95,6 +95,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -156,6 +156,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-named-locks/pom.xml
+++ b/maven-resolver-named-locks/pom.xml
@@ -79,6 +79,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -32,8 +32,7 @@
   <description>The service provider interface for repository system implementations and repository connectors.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.spi</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
+    <Bundle-SymbolicName>org.apache.maven.resolver.spi</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -57,6 +56,32 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>module-descriptor</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <includes>
+                <include>module-info.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-resolver-spi/src/main/java/module-info.java
+++ b/maven-resolver-spi/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.maven.resolver.spi {
+    exports org.eclipse.aether.spi.artifact;
+    exports org.eclipse.aether.spi.artifact.decorator;
+    exports org.eclipse.aether.spi.artifact.generator;
+    exports org.eclipse.aether.spi.checksums;
+    exports org.eclipse.aether.spi.connector;
+    exports org.eclipse.aether.spi.connector.checksum;
+    exports org.eclipse.aether.spi.connector.filter;
+    exports org.eclipse.aether.spi.connector.layout;
+    exports org.eclipse.aether.spi.connector.transport;
+    exports org.eclipse.aether.spi.connector.transport.http;
+    exports org.eclipse.aether.spi.io;
+    exports org.eclipse.aether.spi.localrepo;
+    exports org.eclipse.aether.spi.resolution;
+    exports org.eclipse.aether.spi.synccontext;
+}

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -154,6 +154,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-supplier-mvn4/pom.xml
+++ b/maven-resolver-supplier-mvn4/pom.xml
@@ -148,6 +148,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-test-http/pom.xml
+++ b/maven-resolver-test-http/pom.xml
@@ -107,6 +107,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -64,6 +64,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-tools/src/main/java/org/eclipse/aether/tools/CollectConfiguration.java
+++ b/maven-resolver-tools/src/main/java/org/eclipse/aether/tools/CollectConfiguration.java
@@ -55,6 +55,7 @@ public class CollectConfiguration {
                 .map(Path::toAbsolutePath)
                 .filter(p -> p.getFileName().toString().endsWith(".java"))
                 .filter(p -> p.toString().contains("/src/main/java/"))
+                .filter(p -> !p.toString().endsWith("/module-info.java"))
                 .forEach(p -> {
                     JavaType<?> type = parse(p);
                     if (type instanceof JavaClassSource javaClassSource) {

--- a/maven-resolver-transport-apache/pom.xml
+++ b/maven-resolver-transport-apache/pom.xml
@@ -132,6 +132,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -84,6 +84,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -99,6 +99,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-transport-jetty/pom.xml
+++ b/maven-resolver-transport-jetty/pom.xml
@@ -119,6 +119,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -125,6 +125,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -32,8 +32,7 @@
   <description>A collection of utility classes to ease usage of the repository system.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.util</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
+    <Bundle-SymbolicName>org.apache.maven.resolver.util</Bundle-SymbolicName>
   </properties>
 
   <dependencies>
@@ -62,6 +61,32 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>module-descriptor</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <includes>
+                <include>module-info.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-resolver-util/src/main/java/module-info.java
+++ b/maven-resolver-util/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module org.apache.maven.resolver.util {
+    requires org.apache.maven.resolver;
+
+    exports org.eclipse.aether.util;
+    exports org.eclipse.aether.util.artifact;
+    exports org.eclipse.aether.util.concurrency;
+    exports org.eclipse.aether.util.filter;
+    exports org.eclipse.aether.util.graph.manager;
+    exports org.eclipse.aether.util.graph.selector;
+    exports org.eclipse.aether.util.graph.transformer;
+    exports org.eclipse.aether.util.graph.traverser;
+    exports org.eclipse.aether.util.graph.visitor;
+    exports org.eclipse.aether.util.listener;
+    exports org.eclipse.aether.util.repository;
+    exports org.eclipse.aether.util.version;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -610,17 +610,6 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <archive>
-              <manifestEntries>
-                <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
-              </manifestEntries>
-            </archive>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
provided a `module-info` for the 3 mentioned modules. This i,plies, that the automatic module cannot be defined globally, because it is not allowed to have both a module descriptor and an automatic-module-name entry.

@cstamas not sure why the build fails, seems some java parser doesn't understand module descriptors.