### PR TITLE
[1.9.x] [MRESOLVER-572] Export internal packages in OSGi metadata as x-internal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,10 @@
               Bundle-SymbolicName: org.apache.${replacestring;${project.artifactId};-;.}
               Automatic-Module-Name: ${Bundle-SymbolicName}
               # Export packages not containing the substring 'internal'
-              -exportcontents: ${removeall;${packages};${packages;NAMED;*internal*}}
+              -exportcontents: \
+                *.impl.*;x-internal:=true, \
+                *.internal.*;x-internal:=true, \
+                *
               # Mark optional Maven dependencies as optional
               Import-Package: \
                 javax.inject*;resolution:=optional, \


### PR DESCRIPTION
This makes maven-resolver-supplier usable as bundle in an OSGi runtime.
At the moment the bundle cannot resolve because the `internal.impl` packages it uses and imports in its OSGi metadata are not exported by `maven-resolver-impl`.

Just exporting internal packages fixes that and, although it is discouraged to use internal/impl packages, gives consumers that can
accept no API-compatibility guarantees the ability to access these packages.
Adding the directive `x-internal` is a convention that, at least when using Eclipse PDE, shows a corresponding warning at call-sides.

Fixes https://issues.apache.org/jira/browse/MRESOLVER-572

This PR is currently a draft since it contains as first commit the build unification of https://github.com/apache/maven-resolver/pull/509 and is built on top of that.