### PR TITLE
[MRESOLVER-27] Turn resolver api, spi and utils into Java 9 modules with generated module-info.class

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -33,7 +33,8 @@
 
   <properties>
     <bnd.instructions.additions><![CDATA[
-      Automatic-Module-Name: org.apache.maven.resolver
+      -jpms-module-info: org.apache.maven.resolver
+      -removeheaders Automatic-Module-Name
     ]]></bnd.instructions.additions>
   </properties>
 

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -31,6 +31,13 @@
   <name>Maven Artifact Resolver SPI</name>
   <description>The service provider interface for repository system implementations and repository connectors.</description>
 
+  <properties>
+    <bnd.instructions.additions><![CDATA[
+      -jpms-module-info
+      -removeheaders Automatic-Module-Name
+    ]]></bnd.instructions.additions>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -31,6 +31,13 @@
   <name>Maven Artifact Resolver Utilities</name>
   <description>A collection of utility classes to ease usage of the repository system.</description>
 
+  <properties>
+    <bnd.instructions.additions><![CDATA[
+      -jpms-module-info
+      -removeheaders Automatic-Module-Name
+    ]]></bnd.instructions.additions>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
This PR has the same intend as https://github.com/apache/maven-resolver/pull/508, but uses the `bnd-maven-plugin` to generate the `module-info.class` automatically using the `-jpms-module-info` instruction:
https://bnd.bndtools.org/releases/6.4.0/chapters/330-jpms.html

The differences to #508 are that the source `module-info.java` is not generated and that the `module-info.class` is always placed in the jar root. But since JRE's below Java-9 don't recognize that file, I hope that's not a problem.