### PR TITLE
[Build] Define all MANIFEST.MF entries through the bnd-maven-plugin

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -32,8 +32,9 @@
   <description>The application programming interface for the repository system.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}.api</Bundle-SymbolicName>
+    <bnd.instructions.additions><![CDATA[
+      Automatic-Module-Name: org.apache.maven.resolver
+    ]]></bnd.instructions.additions>
   </properties>
 
   <dependencies>

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Connector Basic</name>
   <description>A repository connector implementation for repositories using URI-based layouts.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.connector.basic</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-generator-gnupg/pom.xml
+++ b/maven-resolver-generator-gnupg/pom.xml
@@ -32,9 +32,6 @@
   <description>A generator implementation for GnuPG signatures.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.generator.gnupg</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>17</javaVersion>
     <bouncycastleVersion>1.78.1</bouncycastleVersion>
   </properties>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Implementation</name>
   <description>An implementation of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.impl</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Named Locks using Hazelcast</name>
   <description>A synchronization utility implementation using Hazelcast.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named.hazelcast</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -32,9 +32,6 @@
   <description>A synchronization utility implementation using Redisson.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named.redisson</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <testcontainersVersion>1.19.8</testcontainersVersion>
   </properties>
 

--- a/maven-resolver-named-locks/pom.xml
+++ b/maven-resolver-named-locks/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Named Locks</name>
   <description>A synchronization utility implementation using Named locks.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver SPI</name>
   <description>The service provider interface for repository system implementations and repository connectors.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.spi</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -32,8 +32,9 @@
   <description>A helper module to provide RepositorySystem instances.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.supplier</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
+    <bnd.instructions.additions><![CDATA[
+      Bundle-SymbolicName: org.apache.maven.resolver.supplier
+    ]]></bnd.instructions.additions>
   </properties>
 
   <dependencies>

--- a/maven-resolver-supplier-mvn4/pom.xml
+++ b/maven-resolver-supplier-mvn4/pom.xml
@@ -33,9 +33,9 @@
 
   <properties>
     <javaVersion>17</javaVersion>
-
-    <Automatic-Module-Name>org.apache.maven.resolver.supplier</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
+    <bnd.instructions.additions><![CDATA[
+      Bundle-SymbolicName: org.apache.maven.resolver.supplier
+    ]]></bnd.instructions.additions>
   </properties>
 
   <dependencies>

--- a/maven-resolver-test-http/pom.xml
+++ b/maven-resolver-test-http/pom.xml
@@ -32,9 +32,6 @@
   <description>A collection of utility classes to ease testing of HTTP transports.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.test.http</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>11</javaVersion>
   </properties>
 

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Test Utilities</name>
   <description>A collection of utility classes to ease testing of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.test.util</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-tools/pom.xml
+++ b/maven-resolver-tools/pom.xml
@@ -34,9 +34,6 @@
   <properties>
     <javaVersion>17</javaVersion>
     <maven.deploy.skip>true</maven.deploy.skip>
-
-    <Automatic-Module-Name>org.apache.maven.resolver.tools</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
   </properties>
 
   <dependencies>

--- a/maven-resolver-transport-apache/pom.xml
+++ b/maven-resolver-transport-apache/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport Apache</name>
   <description>A transport implementation for repositories using http:// and https:// URLs.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.apache</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport Classpath</name>
   <description>A transport implementation for repositories using classpath:// URLs.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.classpath</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport File</name>
   <description>A transport implementation for repositories using file:// URLs.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.file</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/pom.xml
@@ -33,9 +33,6 @@
   <description>Maven Artifact Transport JDK Java 11+.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.jdk</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>11</javaVersion>
   </properties>
 

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-21/pom.xml
@@ -33,9 +33,6 @@
   <description>Maven Artifact Transport JDK Java 11+.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.jdk</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>21</javaVersion>
   </properties>
 

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/pom.xml
@@ -33,9 +33,6 @@
   <description>Maven Artifact Transport JDK Java 11+.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.jdk</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>8</javaVersion>
   </properties>
 

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk/pom.xml
@@ -33,9 +33,9 @@
   <description>Maven Artifact Transport JDK Java 11+.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.jdk</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
+    <bnd.instructions.additions><![CDATA[
+      Multi-Release: true
+    ]]></bnd.instructions.additions>
     <javaVersion>11</javaVersion>
   </properties>
 
@@ -148,18 +148,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-            <manifestEntries>
-              <Multi-Release>true</Multi-Release>
-            </manifestEntries>
-          </archive>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven-resolver-transport-jetty/pom.xml
+++ b/maven-resolver-transport-jetty/pom.xml
@@ -33,9 +33,6 @@
   <description>Maven Artifact Transport Jetty.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.jetty</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-
     <javaVersion>11</javaVersion>
   </properties>
 

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport Wagon</name>
   <description>A transport implementation based on Maven Wagon.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.wagon</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Utilities</name>
   <description>A collection of utility classes to ease usage of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.util</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <project.build.outputTimestamp>2024-04-26T11:50:22Z</project.build.outputTimestamp>
     <!-- site fixes: skip PMD as it does not support Java 21 -->
     <pmd.skip>true</pmd.skip>
+    <bnd.instructions.additions />
   </properties>
 
   <dependencyManagement>
@@ -606,11 +607,13 @@
           <version>7.0.0</version>
           <configuration>
             <bnd><![CDATA[
-              Bundle-SymbolicName: ${Bundle-SymbolicName}
+              Bundle-SymbolicName: org.apache.${replacestring;${project.artifactId};-;.}
+              Automatic-Module-Name: ${Bundle-SymbolicName}
               # Export packages not containing the substring 'internal'
               -exportcontents: ${removeall;${packages};${packages;NAMED;*internal*}}
               # Reproducible build
               -noextraheaders: true
+              ${bnd.instructions.additions}
             ]]></bnd>
           </configuration>
         </plugin>
@@ -620,9 +623,6 @@
           <configuration>
             <archive>
               <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-              <manifestEntries>
-                <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
-              </manifestEntries>
             </archive>
           </configuration>
         </plugin>


### PR DESCRIPTION
and derive 'Bundle-SymbolicName' header from the artifactId where possible.

This is originally created for https://github.com/apache/maven-resolver/pull/516, but would probably also make https://github.com/apache/maven-resolver/pull/506 simpler.