### PR TITLE
[Build] Define all MANIFEST.MF entries through the bnd-maven-plugin

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -32,8 +32,9 @@
   <description>The application programming interface for the repository system.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}.api</Bundle-SymbolicName>
+    <bnd.instructions.additions><![CDATA[
+      Automatic-Module-Name: org.apache.maven.resolver
+    ]]></bnd.instructions.additions>
   </properties>
 
   <dependencies>

--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Connector Basic</name>
   <description>A repository connector implementation for repositories using URI-based layouts.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.connector.basic</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -32,10 +32,6 @@
   <description>A module to demonstrate the usage of Maven Artifact Resolver with Maven repositories
     by means of various runnable code snippets.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.demo.snippets</Automatic-Module-Name>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-demos/pom.xml
+++ b/maven-resolver-demos/pom.xml
@@ -49,7 +49,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <configuration>
-            <!-- This is needed to prevent jar plugin to fail due to a missing manifest and wrong automatic module name. -->
+            <!-- This is needed to prevent jar plugin to fail due to a missing manifest. -->
             <archive combine.self="override" />
           </configuration>
         </plugin>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Implementation</name>
   <description>An implementation of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.impl</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-named-locks-hazelcast/pom.xml
+++ b/maven-resolver-named-locks-hazelcast/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Named Locks using Hazelcast</name>
   <description>A synchronization utility implementation using Hazelcast.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named.hazelcast</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-named-locks-redisson/pom.xml
+++ b/maven-resolver-named-locks-redisson/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Named Locks using Redisson</name>
   <description>A synchronization utility implementation using Redisson.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named.redisson</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-named-locks/pom.xml
+++ b/maven-resolver-named-locks/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Named Locks</name>
   <description>A synchronization utility implementation using Named locks.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.named</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver SPI</name>
   <description>The service provider interface for repository system implementations and repository connectors.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.spi</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-supplier/pom.xml
+++ b/maven-resolver-supplier/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Instance Supplier</name>
   <description>A helper module to provide RepositorySystem instances.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.supplier</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-test-util/pom.xml
+++ b/maven-resolver-test-util/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Test Utilities</name>
   <description>A collection of utility classes to ease testing of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.testutil</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-classpath/pom.xml
+++ b/maven-resolver-transport-classpath/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport Classpath</name>
   <description>A transport implementation for repositories using classpath:// URLs.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.classpath</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-file/pom.xml
+++ b/maven-resolver-transport-file/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport File</name>
   <description>A transport implementation for repositories using file:// URLs.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.file</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-transport-http/pom.xml
+++ b/maven-resolver-transport-http/pom.xml
@@ -32,8 +32,6 @@
   <description>A transport implementation for repositories using http:// and https:// URLs.</description>
 
   <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.http</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
     <jettyVersion>9.4.54.v20240208</jettyVersion>
   </properties>
 

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Transport Wagon</name>
   <description>A transport implementation based on Maven Wagon.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.transport.wagon</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -31,11 +31,6 @@
   <name>Maven Artifact Resolver Utilities</name>
   <description>A collection of utility classes to ease usage of the repository system.</description>
 
-  <properties>
-    <Automatic-Module-Name>org.apache.maven.resolver.util</Automatic-Module-Name>
-    <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <minimalMavenBuildVersion>[3.8.7,)</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>[1.8.0-362,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2024-04-26T10:43:34Z</project.build.outputTimestamp>
+    <bnd.instructions.additions />
   </properties>
 
   <dependencyManagement>
@@ -471,11 +472,13 @@
           <version>6.4.0</version>
           <configuration>
             <bnd><![CDATA[
-              Bundle-SymbolicName: ${Bundle-SymbolicName}
+              Bundle-SymbolicName: org.apache.${replacestring;${project.artifactId};-;.}
+              Automatic-Module-Name: ${Bundle-SymbolicName}
               # Export packages not containing the substring 'internal'
               -exportcontents: ${removeall;${packages};${packages;NAMED;*internal*}}
               # Reproducible build
               -noextraheaders: true
+              ${bnd.instructions.additions}
             ]]></bnd>
           </configuration>
         </plugin>
@@ -485,9 +488,6 @@
           <configuration>
             <archive>
               <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-              <manifestEntries>
-                <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
-              </manifestEntries>
             </archive>
           </configuration>
         </plugin>


### PR DESCRIPTION
Define all MANIFEST.MF entries through the bnd-maven-plugin and derive `Bundle-SymbolicName` header from the `artifactId`.

This changes the 'Bundle-SymbolicName' and 'Automatic-Module-Name' for the following modules:
- `maven-resolver-named-locks` from `org.apache.maven.resolver.named` to `org.apache.maven.resolver.named.locks`
- `maven-resolver-test-util` from `org.apache.maven.resolver.testutil` to `org.apache.maven.resolver.test.util`

This is effectively the back-port of https://github.com/apache/maven-resolver/pull/517 to the `maven-resolver-1.9.x` branch.
The main difference is that unlike in #517, this change does not 'prepare' the introduction of JPMS `module-info.java/class` files.