### PR TITLE
[MRESOLVER-571] Import o.e.aether packages with the exact same version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -614,10 +614,15 @@
                 *.impl.*;x-internal:=true, \
                 *.internal.*;x-internal:=true, \
                 *
-              # Mark optional Maven dependencies as optional
+              # Ensure all maven-resolver packages of exactly the same version are imported
+              # and mark optional Maven dependencies as optional.
+              mavenResolverVersion=${versionmask;===;${version_cleanup;${project.version}}}
               Import-Package: \
+                org.eclipse.aether*;version="${range;[===,===];${mavenResolverVersion}}", \
                 javax.inject*;resolution:=optional, \
                 *
+              # No re-import of exported packages
+              -noimport:=true
               # Reproducible build
               -noextraheaders: true
               ${bnd.instructions.additions}


### PR DESCRIPTION
This is a forward-port of https://github.com/apache/maven-resolver/pull/507 to the master branch.
___
The documentation states that only maven-resolver artifacts of the exact same version should be used together.

With this change all org.eclipse.aether* packages are now imported with a strict version range of
'org.eclipse.aether*;version="[@version,@version]"'

Fixes https://issues.apache.org/jira/browse/MRESOLVER-571