### PR TITLE
[1.9.x] Tame bnd plugin warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,9 +490,9 @@
               -noextraheaders: true
               ${bnd.instructions.additions}
               # Remove warnings (as we keep things simple)
-              -fixupmessages: \\
-                'Unused Import-Package instructions';is:=ignore,\\
-                'Unused Export-Package instructions';is:=ignore,\\
+              -fixupmessages: \
+                'Unused Import-Package instructions';is:=ignore,\
+                'Unused Export-Package instructions';is:=ignore
             ]]></bnd>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,10 @@
               # Reproducible build
               -noextraheaders: true
               ${bnd.instructions.additions}
+              # Remove warnings (as we keep things simple)
+              -fixupmessages: \\
+                'Unused Import-Package instructions';is:=ignore,\\
+                'Unused Export-Package instructions';is:=ignore,\\
             ]]></bnd>
           </configuration>
         </plugin>


### PR DESCRIPTION
To keep things simple, we config the plugin in
one place, but in some modules this config emits
warnings. This change just makes it go away.

No other source or any alike change, no issue either.