### PR TITLE
Tame bnd plugin warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,10 @@
               # Reproducible build
               -noextraheaders: true
               ${bnd.instructions.additions}
+              # Remove warnings (as we keep things simple)
+              -fixupmessages: \\
+                'Unused Import-Package instructions';is:=ignore,\\
+                'Unused Export-Package instructions';is:=ignore,\\
             ]]></bnd>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -625,9 +625,9 @@
               -noextraheaders: true
               ${bnd.instructions.additions}
               # Remove warnings (as we keep things simple)
-              -fixupmessages: \\
-                'Unused Import-Package instructions';is:=ignore,\\
-                'Unused Export-Package instructions';is:=ignore,\\
+              -fixupmessages: \
+                'Unused Import-Package instructions';is:=ignore, \
+                'Unused Export-Package instructions';is:=ignore
             ]]></bnd>
           </configuration>
         </plugin>


### PR DESCRIPTION
To keep things simple, we config the plugin in
one place, but in some modules this config emits
warnings. This change just makes it go away.

No other source or any alike change, no issue either.