### PR TITLE
[MRESOLVER-579] Fix overwrite of SSLParameters in JDK HTTP transport when securityMode is "insecure"

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -488,7 +488,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
                             .sslContext(sslContext);
 
                     if (insecure) {
-                        SSLParameters sslParameters = new SSLParameters();
+                        SSLParameters sslParameters = sslContext.getDefaultSSLParameters();
                         sslParameters.setEndpointIdentificationAlgorithm(null);
                         builder.sslParameters(sslParameters);
                     }


### PR DESCRIPTION
I have been experimenting with Maven 4.0.0-beta-4, specifically testing its HTTP/2 support. During my tests, I used a self-signed certificate for the testing repository and disabled TLS validation. This approach produced unexpected behavior. While TLS certificate validation was indeed disabled as expected, it also caused the ALPN extension to be omitted from the Client Hello message.

To further investigate, I added the self-signed certificate to the JDK's cacerts keystore and removed the insecure option. With this configuration, ALPN support was restored, and HTTP/2 worked correctly again. This behavior can lead to problems if the server prioritizes HTTP/2 or does not support HTTP/1.1.

This change addresses an issue where SSLParameters were being overwritten (introduced in 08f102a4579a911afff8a8301cb1a708c3bc26af), causing the loss of multiple TLS extensions, including ALPN and SNI. Setting the `aether.transport.https.securityMode=insecure` property disables TLS validation but also inadvertently disabled ALPN and SNI.

Now, SSLParameters are derived from SSLContext defaults to ensure proper handling of these extensions, even when TLS validation is disabled in JDK HTTP transport.

TODOs:

- [x] Add test coverage 

---

https://issues.apache.org/jira/browse/MRESOLVER-579