### PR TITLE
[MRESOLVER-586] Avoid copying the type default properties map

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
@@ -118,7 +118,7 @@ public final class DefaultArtifact extends AbstractArtifact {
         classifier = get(m.group(6), type == null ? "" : type.getClassifier());
         this.version = emptify(m.group(7));
         this.path = null;
-        this.properties = merge(properties, (type != null) ? type.getProperties() : null);
+        this.properties = mergeArtifactProperties(properties, (type != null) ? type.getProperties() : null);
     }
 
     private static String get(String value, String defaultValue) {
@@ -207,21 +207,27 @@ public final class DefaultArtifact extends AbstractArtifact {
         }
         this.version = emptify(version);
         this.path = null;
-        this.properties = merge(properties, (type != null) ? type.getProperties() : null);
+        this.properties = mergeArtifactProperties(properties, (type != null) ? type.getProperties() : null);
     }
 
-    private static Map<String, String> merge(Map<String, String> dominant, Map<String, String> recessive) {
+    private static Map<String, String> mergeArtifactProperties(
+            Map<String, String> artifactProperties, Map<String, String> typeDefaultProperties) {
         Map<String, String> properties;
 
-        if ((dominant == null || dominant.isEmpty()) && (recessive == null || recessive.isEmpty())) {
-            properties = Collections.emptyMap();
+        if (artifactProperties == null || artifactProperties.isEmpty()) {
+            if (typeDefaultProperties == null || typeDefaultProperties.isEmpty()) {
+                properties = Collections.emptyMap();
+            } else {
+                // type default properties are already unmodifiable
+                return typeDefaultProperties;
+            }
         } else {
             properties = new HashMap<>();
-            if (recessive != null) {
-                properties.putAll(recessive);
+            if (typeDefaultProperties != null) {
+                properties.putAll(typeDefaultProperties);
             }
-            if (dominant != null) {
-                properties.putAll(dominant);
+            if (artifactProperties != null) {
+                properties.putAll(artifactProperties);
             }
             properties = Collections.unmodifiableMap(properties);
         }


### PR DESCRIPTION
When we don't have specific properties for a DefaultArtifact, we can just reuse the type default properties map as it's readonly and immutable.
The patch contains some additional changes as I renamed the method and parameters to make them more specific so that the method wouldn't be used for things that wouldn't be safe.