### PR TITLE
[MRESOLVER-588] Add env-variables as sys-props in Maven-4 SessionBuilderSupplier

### DIFF
--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -19,8 +19,10 @@
 package org.eclipse.aether.supplier;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.function.Supplier;
 
+import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
@@ -70,6 +72,11 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
 
     protected void configureSessionBuilder(SessionBuilder session) {
         session.setSystemProperties(System.getProperties());
+        boolean caseSensitive = !Os.IS_WINDOWS;
+        System.getenv().forEach((key, value) -> {
+            key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
+            session.setSystemProperty(key, value);
+        });
         session.setDependencyTraverser(getDependencyTraverser());
         session.setDependencyManager(getDependencyManager());
         session.setDependencySelector(getDependencySelector());


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/MRESOLVER-588 for the Maven-3 `SessionBuilderSupplier`

