### PR TITLE
[MRESOLVER-585] Explain reason for this method

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -194,6 +194,12 @@ public interface RepositorySystemSession {
         /**
          * Sets the local repository manager used during this session. <em>Note:</em> Eventually, a valid session must have
          * a local repository manager set.
+         * <p>
+         * The provisioning of {@link org.eclipse.aether.repository.LocalRepositoryManager} for use with this
+         * method introduces chicken and egg situation. Integrators MUST NOT use this method, but instead, hook into
+         * Local Repository Manager Provider by any means they can (ie by using Provider or Sisu Components) and use
+         * custom string and/or priorities instead. This method existence is not meant for "everyday use" (normal
+         * session creation), but for some more advanced use cases. Do not use it, unless you know what are you doing.
          *
          * @param localRepositoryManager The local repository manager used during this session, may be {@code null}.
          * @return This session for chaining, never {@code null}.


### PR DESCRIPTION
This method is NOT the "usual" way to introduce new LRM implementation. LRM is special in a sense, is needed early. Proper way is to integrate with LRMProvider instead and tune priorities and/or LocalRepository type strings.

---

https://issues.apache.org/jira/browse/MRESOLVER-585