### PR TITLE
HTTP exceptions can carry more detail

### DIFF
--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/http/HttpTransporterExtraException.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/transport/http/HttpTransporterExtraException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.spi.connector.transport.http;
+
+/**
+ * Exception thrown by {@link HttpTransporter} in case of errors.
+ *
+ * @since 2.0.2
+ */
+public class HttpTransporterExtraException extends Exception {
+
+    public HttpTransporterExtraException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
HTTP1.1 has the ability to carry an [errorPhrase](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html) alongside the errorCode to provide additional context around the HTTP error code. Unfortunately [HTTP2](https://datatracker.ietf.org/doc/html/rfc9113) protocol does not provide this errorPhrase and as such some critical context may go missing.

There is an additional [RFC9457](https://www.rfc-editor.org/rfc/rfc9457) which permits adding problem details as a JSON object into the body. Adding this capability will give the ability to pass through context when using HTTP1.1 or 2

This is a PoC to show what might be an approach to add this capability