### PR TITLE
[MRESOLVER-612] Align timeout interpretations across HTTP transports

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -215,7 +215,7 @@ public final class ConfigurationProperties {
     /**
      * The default connect timeout to use if {@link #CONNECT_TIMEOUT} isn't set.
      */
-    public static final int DEFAULT_CONNECT_TIMEOUT = 10 * 1000;
+    public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
 
     /**
      * The maximum amount of time (in milliseconds) to wait for remaining data to arrive from a remote server. Note that

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -288,16 +288,20 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 .register(AuthSchemes.KERBEROS, new KerberosSchemeFactory())
                 .build();
         SocketConfig socketConfig =
-                SocketConfig.custom().setSoTimeout(requestTimeout).build();
+                // the time to establish connection (low level)
+                SocketConfig.custom().setSoTimeout(connectTimeout).build();
         RequestConfig requestConfig = RequestConfig.custom()
                 .setMaxRedirects(maxRedirects)
                 .setRedirectsEnabled(followRedirects)
                 .setRelativeRedirectsAllowed(followRedirects)
+                // the time waiting for data; max time between two data packets
+                .setSocketTimeout(requestTimeout)
+                // the time to establish the connection (high level)
                 .setConnectTimeout(connectTimeout)
-                .setConnectionRequestTimeout(connectTimeout)
+                // the time to wait for a connection from the connection manager/pool
+                .setConnectionRequestTimeout(requestTimeout)
                 .setLocalAddress(getHttpLocalAddress(session, repository))
                 .setCookieSpec(CookieSpecs.STANDARD)
-                .setSocketTimeout(requestTimeout)
                 .build();
 
         HttpRequestRetryHandler retryHandler;

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -299,7 +299,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 // the time to establish the connection (high level)
                 .setConnectTimeout(connectTimeout)
                 // the time to wait for a connection from the connection manager/pool
-                .setConnectionRequestTimeout(requestTimeout)
+                .setConnectionRequestTimeout(connectTimeout)
                 .setLocalAddress(getHttpLocalAddress(session, repository))
                 .setCookieSpec(CookieSpecs.STANDARD)
                 .build();

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -289,7 +289,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 .build();
         SocketConfig socketConfig =
                 // the time to establish connection (low level)
-                SocketConfig.custom().setSoTimeout(connectTimeout).build();
+                SocketConfig.custom().setSoTimeout(requestTimeout).build();
         RequestConfig requestConfig = RequestConfig.custom()
                 .setMaxRedirects(maxRedirects)
                 .setRedirectsEnabled(followRedirects)

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
@@ -84,6 +84,11 @@ class JdkTransporterTest extends HttpTransporterTest {
     @Test
     protected void testPut_Authenticated_ExpectContinueRejected_ExplicitlyConfiguredHeader() {}
 
+    @Override
+    @Disabled
+    @Test
+    protected void testRequestTimeout() throws Exception {}
+
     public JdkTransporterTest() {
         super(() -> new JdkTransporterFactory(standardChecksumExtractor(), new DefaultPathProcessor()));
     }


### PR DESCRIPTION
The `ConfigurationProperties#REQUEST_TIMEOUT` was wrongly interpreted by JDK and Jetty clients as "absolute max duration of HTTP request".

Also, up default CONNECT_TIMEOUT from 10sec to 30sec.

Changes per transport:
* apache: explain meaning in comments and fix one mixed up timeout
* JDK: remove use of request timeout (as it means "abs max time for request"), note that REQUEST_TIMEOUT is not supported, ignore UT
* Jetty: remove use of request timeout (as it means "abs max time for request"), use "idle timeout" that means "max time of silence between any traffic/sending or receiving packets".

---

https://issues.apache.org/jira/browse/MRESOLVER-612
https://issues.apache.org/jira/browse/MRESOLVER-615