### PR TITLE
Undo P-X raise

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>4.0.4</version>
+        <version>3.0.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
It does not matter, but I dislike to pull in alpha of Maven 4 (Resolver should not pull anything of
Maven only in demos).

---

Undo https://issues.apache.org/jira/browse/MRESOLVER-619