### PR TITLE
Fix deployment

### DIFF
--- a/maven-resolver-tools/pom.xml
+++ b/maven-resolver-tools/pom.xml
@@ -178,7 +178,7 @@
             <goals>
               <goal>java</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>package</phase>
             <configuration>
               <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
               <arguments>
@@ -194,7 +194,7 @@
             <goals>
               <goal>java</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>package</phase>
             <configuration>
               <mainClass>org.eclipse.aether.tools.CollectConfiguration</mainClass>
               <arguments>
@@ -217,7 +217,7 @@
             <goals>
               <goal>attach-artifact</goal>
             </goals>
-            <phase>verify</phase>
+            <phase>package</phase>
             <configuration>
               <artifacts>
                 <artifact>


### PR DESCRIPTION
The maven-resolver-tools was not deployed before 2.0.3, and in 2.0.3 release had to manually add sigs for the two new files.

This is simple fix just by reordering generation/attach of the files to let gpg plugin sign them as well.