### PR TITLE
[MRESOLVER-629] JDK transport should default to HTTP/1.1

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterConfigurationKeys.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterConfigurationKeys.java
@@ -42,7 +42,7 @@ public final class JdkTransporterConfigurationKeys {
      */
     public static final String CONFIG_PROP_HTTP_VERSION = CONFIG_PROPS_PREFIX + "httpVersion";
 
-    public static final String DEFAULT_HTTP_VERSION = "HTTP_2";
+    public static final String DEFAULT_HTTP_VERSION = "HTTP_1_1";
 
     /**
      * The hard limit of maximum concurrent requests JDK transport can do. This is a workaround for the fact, that in


### PR DESCRIPTION
As it cannot cope well with HTTP/2 GOAWAY frame

---

https://issues.apache.org/jira/browse/MRESOLVER-629