### PR TITLE
[MRESOLVER-628] Explicit cache key for prioritized components

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider.java
@@ -60,7 +60,10 @@ public class DefaultLocalRepositoryProvider implements LocalRepositoryProvider {
         requireNonNull(repository, "repository cannot be null");
 
         PrioritizedComponents<LocalRepositoryManagerFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session, localRepositoryManagerFactories, LocalRepositoryManagerFactory::getPriority);
+                session,
+                LocalRepositoryManagerFactory.class,
+                localRepositoryManagerFactories,
+                LocalRepositoryManagerFactory::getPriority);
 
         List<NoLocalRepositoryManagerException> errors = new ArrayList<>();
         for (PrioritizedComponent<LocalRepositoryManagerFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider.java
@@ -78,7 +78,7 @@ public class DefaultRepositoryConnectorProvider implements RepositoryConnectorPr
         }
 
         PrioritizedComponents<RepositoryConnectorFactory> factories = PrioritizedComponents.reuseOrCreate(
-                session, connectorFactories, RepositoryConnectorFactory::getPriority);
+                session, RepositoryConnectorFactory.class, connectorFactories, RepositoryConnectorFactory::getPriority);
 
         RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter(session);
         List<NoRepositoryConnectorException> errors = new ArrayList<>();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider.java
@@ -59,8 +59,8 @@ public final class DefaultRepositoryLayoutProvider implements RepositoryLayoutPr
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "remote repository cannot be null");
 
-        PrioritizedComponents<RepositoryLayoutFactory> factories =
-                PrioritizedComponents.reuseOrCreate(session, layoutFactories, RepositoryLayoutFactory::getPriority);
+        PrioritizedComponents<RepositoryLayoutFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session, RepositoryLayoutFactory.class, layoutFactories, RepositoryLayoutFactory::getPriority);
 
         List<NoRepositoryLayoutException> errors = new ArrayList<>();
         for (PrioritizedComponent<RepositoryLayoutFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTransporterProvider.java
@@ -59,8 +59,8 @@ public final class DefaultTransporterProvider implements TransporterProvider {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        PrioritizedComponents<TransporterFactory> factories =
-                PrioritizedComponents.reuseOrCreate(session, transporterFactories, TransporterFactory::getPriority);
+        PrioritizedComponents<TransporterFactory> factories = PrioritizedComponents.reuseOrCreate(
+                session, TransporterFactory.class, transporterFactories, TransporterFactory::getPriority);
 
         List<NoTransporterException> errors = new ArrayList<>();
         for (PrioritizedComponent<TransporterFactory> factory : factories.getEnabled()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Utils.java
@@ -48,7 +48,8 @@ public final class Utils {
 
     private static PrioritizedComponents<ArtifactDecoratorFactory> sortArtifactDecoratorFactories(
             RepositorySystemSession session, Map<String, ArtifactDecoratorFactory> factories) {
-        return PrioritizedComponents.reuseOrCreate(session, factories, ArtifactDecoratorFactory::getPriority);
+        return PrioritizedComponents.reuseOrCreate(
+                session, ArtifactDecoratorFactory.class, factories, ArtifactDecoratorFactory::getPriority);
     }
 
     public static List<? extends ArtifactDecorator> getArtifactDecorators(
@@ -67,7 +68,8 @@ public final class Utils {
 
     private static PrioritizedComponents<ArtifactGeneratorFactory> sortArtifactGeneratorFactories(
             RepositorySystemSession session, Map<String, ArtifactGeneratorFactory> factories) {
-        return PrioritizedComponents.reuseOrCreate(session, factories, ArtifactGeneratorFactory::getPriority);
+        return PrioritizedComponents.reuseOrCreate(
+                session, ArtifactGeneratorFactory.class, factories, ArtifactGeneratorFactory::getPriority);
     }
 
     private static List<? extends ArtifactGenerator> doGetArtifactGenerators(
@@ -107,7 +109,8 @@ public final class Utils {
 
     private static PrioritizedComponents<MetadataGeneratorFactory> sortMetadataGeneratorFactories(
             RepositorySystemSession session, Map<String, MetadataGeneratorFactory> factories) {
-        return PrioritizedComponents.reuseOrCreate(session, factories, MetadataGeneratorFactory::getPriority);
+        return PrioritizedComponents.reuseOrCreate(
+                session, MetadataGeneratorFactory.class, factories, MetadataGeneratorFactory::getPriority);
     }
 
     private static List<? extends MetadataGenerator> doGetMetadataGenerators(


### PR DESCRIPTION
As original solution using map.hashCode may clash, and in that case runtime "just in time" class clast issue happens.

Rather provide explicit discriminator class "what is in maps" and use that to create key to cache in session.

---

https://issues.apache.org/jira/browse/MRESOLVER-628