### PR TITLE
[MRESOLVER-635] Use Instant instead of untyped millis for TransferResource startTime

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -40,11 +40,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-core</artifactId>
-      <version>4.0.0-rc-2-SNAPSHOT</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -40,6 +40,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-api-core</artifactId>
+      <version>4.0.0-rc-2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.temporal.Temporal;
 
 import org.eclipse.aether.RequestTrace;
 
@@ -43,7 +42,7 @@ public final class TransferResource {
 
     private final Path path;
 
-    private final Temporal startTime;
+    private final Instant startTime;
 
     private final RequestTrace trace;
 
@@ -257,7 +256,7 @@ public final class TransferResource {
      *
      * @return The timestamp when the transfer of this resource was started.
      */
-    public Temporal getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -233,7 +233,9 @@ public final class TransferResource {
      * Gets the timestamp when the transfer of this resource was started.
      *
      * @return The timestamp when the transfer of this resource was started.
+     * @deprecated use {@link #getStartTime()}
      */
+    @Deprecated
     public long getTransferStartTime() {
         return startTime.toEpochMilli();
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -248,7 +248,7 @@ public final class TransferResource {
      */
     @Deprecated
     public long getTransferStartTime() {
-        return Instant.from(startTime).toEpochMilli();
+        return startTime.toEpochMilli();
     }
 
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.transfer;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.Instant;
 
 import org.eclipse.aether.RequestTrace;
 
@@ -38,7 +39,7 @@ public final class TransferResource {
 
     private final Path path;
 
-    private final long startTime;
+    private final Instant startTime;
 
     private final RequestTrace trace;
 
@@ -114,7 +115,7 @@ public final class TransferResource {
         this.path = path;
         this.resource = resource;
         this.trace = trace;
-        this.startTime = System.currentTimeMillis();
+        this.startTime = Instant.now();
     }
 
     /**
@@ -234,6 +235,15 @@ public final class TransferResource {
      * @return The timestamp when the transfer of this resource was started.
      */
     public long getTransferStartTime() {
+        return startTime.toEpochMilli();
+    }
+
+    /**
+     * Gets the timestamp when the transfer of this resource was started.
+     *
+     * @return The timestamp when the transfer of this resource was started.
+     */
+    public Instant getStartTime() {
         return startTime;
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -21,7 +21,9 @@ package org.eclipse.aether.transfer;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.temporal.Temporal;
 
+import org.apache.maven.api.MonotonicTime;
 import org.eclipse.aether.RequestTrace;
 
 /**
@@ -39,7 +41,7 @@ public final class TransferResource {
 
     private final Path path;
 
-    private final Instant startTime;
+    private final MonotonicTime startTime;
 
     private final RequestTrace trace;
 
@@ -115,7 +117,7 @@ public final class TransferResource {
         this.path = path;
         this.resource = resource;
         this.trace = trace;
-        this.startTime = Instant.now();
+        this.startTime = MonotonicTime.now();
     }
 
     /**
@@ -237,7 +239,7 @@ public final class TransferResource {
      */
     @Deprecated
     public long getTransferStartTime() {
-        return startTime.toEpochMilli();
+        return startTime.getWallTime().toEpochMilli();
     }
 
     /**
@@ -245,7 +247,7 @@ public final class TransferResource {
      *
      * @return The timestamp when the transfer of this resource was started.
      */
-    public Instant getStartTime() {
+    public MonotonicTime getStartTime() {
         return startTime;
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/transfer/TransferResource.java
@@ -20,16 +20,18 @@ package org.eclipse.aether.transfer;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.Temporal;
 
-import org.apache.maven.api.MonotonicTime;
 import org.eclipse.aether.RequestTrace;
 
 /**
  * Describes a resource being uploaded or downloaded by the repository system.
  */
 public final class TransferResource {
+
+    private static Clock clock = Clock.systemUTC();
 
     private final String repositoryId;
 
@@ -41,13 +43,21 @@ public final class TransferResource {
 
     private final Path path;
 
-    private final MonotonicTime startTime;
+    private final Temporal startTime;
 
     private final RequestTrace trace;
 
     private long contentLength = -1L;
 
     private long resumeOffset;
+
+    public static Clock getClock() {
+        return clock;
+    }
+
+    public static void setClock(Clock clock) {
+        TransferResource.clock = clock;
+    }
 
     /**
      * Creates a new transfer resource with the specified properties.
@@ -117,7 +127,7 @@ public final class TransferResource {
         this.path = path;
         this.resource = resource;
         this.trace = trace;
-        this.startTime = MonotonicTime.now();
+        this.startTime = getClock().instant();
     }
 
     /**
@@ -239,7 +249,7 @@ public final class TransferResource {
      */
     @Deprecated
     public long getTransferStartTime() {
-        return startTime.getWallTime().toEpochMilli();
+        return Instant.from(startTime).toEpochMilli();
     }
 
     /**
@@ -247,7 +257,7 @@ public final class TransferResource {
      *
      * @return The timestamp when the transfer of this resource was started.
      */
-    public MonotonicTime getStartTime() {
+    public Temporal getStartTime() {
         return startTime;
     }
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
@@ -22,6 +22,7 @@ import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -117,7 +118,7 @@ public class ConsoleTransferListener extends AbstractTransferListener {
             String len = contentLength >= 1024 ? toKB(contentLength) + " KB" : contentLength + " B";
 
             String throughput = "";
-            Duration duration = MonotonicTime.now().durationSince(resource.getStartTime());
+            Duration duration = Duration.between(resource.getStartTime(), Instant.now());
             if (duration.toMillis() > 0) {
                 long bytes = contentLength - resource.getResumeOffset();
                 DecimalFormat format = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH));

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
@@ -21,6 +21,8 @@ package org.apache.maven.resolver.examples.util;
 import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -116,11 +118,11 @@ public class ConsoleTransferListener extends AbstractTransferListener {
             String len = contentLength >= 1024 ? toKB(contentLength) + " KB" : contentLength + " B";
 
             String throughput = "";
-            long duration = System.currentTimeMillis() - resource.getTransferStartTime();
-            if (duration > 0) {
+            Duration duration = Duration.between(Instant.now(), resource.getStartTime());
+            if (duration.toMillis() > 0) {
                 long bytes = contentLength - resource.getResumeOffset();
                 DecimalFormat format = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH));
-                double kbPerSec = (bytes / 1024.0) / (duration / 1000.0);
+                double kbPerSec = (bytes / 1024.0) / duration.toSeconds();
                 throughput = " at " + format.format(kbPerSec) + " KB/sec";
             }
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/ConsoleTransferListener.java
@@ -22,7 +22,6 @@ import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -118,7 +117,7 @@ public class ConsoleTransferListener extends AbstractTransferListener {
             String len = contentLength >= 1024 ? toKB(contentLength) + " KB" : contentLength + " B";
 
             String throughput = "";
-            Duration duration = Duration.between(Instant.now(), resource.getStartTime());
+            Duration duration = MonotonicTime.now().durationSince(resource.getStartTime());
             if (duration.toMillis() > 0) {
                 long bytes = contentLength - resource.getResumeOffset();
                 DecimalFormat format = new DecimalFormat("0.0", new DecimalFormatSymbols(Locale.ENGLISH));


### PR DESCRIPTION
This also provides a clean for Maven to inject the `MonotonicClock` from https://github.com/apache/maven/pull/1965

---

https://issues.apache.org/jira/browse/MRESOLVER-635