### PR TITLE
[MRESOLVER-653] NPE in case of failed result

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
@@ -162,7 +162,7 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
         final boolean snapshots = ConfigUtils.getBoolean(session, false, CONFIG_PROP_SNAPSHOTS);
 
         for (ArtifactResult artifactResult : artifactResults) {
-            if (artifactResult.getArtifact().isSnapshot() && !snapshots) {
+            if (artifactResult.getRequest().getArtifact().isSnapshot() && !snapshots) {
                 continue;
             }
             if (artifactResult.isResolved()) {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -150,6 +150,14 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
     }
 
     @Test
+    void unresolvedArtifact() {
+        ArtifactResult artifactResult = createArtifactResult(artifactWithTrustedChecksum).setArtifact(null);
+        assertFalse(artifactResult.isResolved());
+
+        subject.postProcess(session, Collections.singletonList(artifactResult)); // no NPE
+    }
+
+    @Test
     void haveNoChecksumPass() {
         ArtifactResult artifactResult = createArtifactResult(artifactWithoutTrustedChecksum);
         assertTrue(artifactResult.isResolved());

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessorTest.java
@@ -151,7 +151,8 @@ public class TrustedChecksumsArtifactResolverPostProcessorTest implements Truste
 
     @Test
     void unresolvedArtifact() {
-        ArtifactResult artifactResult = createArtifactResult(artifactWithTrustedChecksum).setArtifact(null);
+        ArtifactResult artifactResult =
+                createArtifactResult(artifactWithTrustedChecksum).setArtifact(null);
         assertFalse(artifactResult.isResolved());
 
         subject.postProcess(session, Collections.singletonList(artifactResult)); // no NPE


### PR DESCRIPTION
Obvious typo: result artifact may be null, it is request artifact that wanted to be checked.

---

https://issues.apache.org/jira/browse/MRESOLVER-653