### PR TITLE
[MRESOLVER-681] Sigstore TCCL bugfix

### DIFF
--- a/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
+++ b/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
@@ -77,6 +77,8 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
 
             // sign relevant artifacts
             ArrayList<Artifact> result = new ArrayList<>();
+            ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(KeylessSigner.class.getClassLoader());
             try (KeylessSigner signer = publicStaging
                     ? KeylessSigner.builder().sigstoreStagingDefaults().build()
                     : KeylessSigner.builder().sigstorePublicDefaults().build()) {
@@ -122,6 +124,8 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
                                 signatureTempFile.toFile()));
                     }
                 }
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalClassLoader);
             }
             logger.info("Signed {} artifacts with Sigstore", result.size());
             return result;
@@ -132,6 +136,12 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
         } catch (IOException e) {
             throw new UncheckedIOException("IO problem", e);
         }
+    }
+
+    private KeylessSigner getKeylessSigner() throws Exception {
+        return publicStaging
+                ? KeylessSigner.builder().sigstoreStagingDefaults().build()
+                : KeylessSigner.builder().sigstorePublicDefaults().build();
     }
 
     @Override

--- a/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
+++ b/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
@@ -138,12 +138,6 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
         }
     }
 
-    private KeylessSigner getKeylessSigner() throws Exception {
-        return publicStaging
-                ? KeylessSigner.builder().sigstoreStagingDefaults().build()
-                : KeylessSigner.builder().sigstorePublicDefaults().build();
-    }
-
     @Override
     public void close() {
         signatureTempFiles.forEach(p -> {


### PR DESCRIPTION
Seems sigstore depends on TCCL that went unnoticed in test, but explodes when this generator used as Maven extension.

---

https://issues.apache.org/jira/browse/MRESOLVER-681