### PR TITLE
[MRESOLVER-685] Connector pipelining

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnector.java
@@ -434,7 +434,7 @@ final class BasicRepositoryConnector implements RepositoryConnector {
 
     @Override
     public String toString() {
-        return String.valueOf(repository);
+        return BasicRepositoryConnectorFactory.NAME + "(" + repository + ")";
     }
 
     abstract class TaskRunner implements Runnable {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringPipelineRepositoryConnectorFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringPipelineRepositoryConnectorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.PipelineRepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A filtering connector factory.
+ *
+ * @since TBD
+ */
+@Singleton
+@Named(FilteringPipelineRepositoryConnectorFactory.NAME)
+public final class FilteringPipelineRepositoryConnectorFactory implements PipelineRepositoryConnectorFactory {
+    public static final String NAME = "rrf";
+
+    private final RemoteRepositoryFilterManager remoteRepositoryFilterManager;
+
+    private float priority;
+
+    @Inject
+    public FilteringPipelineRepositoryConnectorFactory(RemoteRepositoryFilterManager remoteRepositoryFilterManager) {
+        this.remoteRepositoryFilterManager = requireNonNull(remoteRepositoryFilterManager);
+    }
+
+    @Override
+    public RepositoryConnector newInstance(
+            RepositorySystemSession session, RemoteRepository repository, RepositoryConnector delegate) {
+        RemoteRepositoryFilter filter = remoteRepositoryFilterManager.getRemoteRepositoryFilter(session);
+        if (filter != null) {
+            return new FilteringRepositoryConnector(repository, delegate, filter);
+        } else {
+            return delegate;
+        }
+    }
+
+    @Override
+    public float getPriority() {
+        return priority;
+    }
+
+    public FilteringPipelineRepositoryConnectorFactory setPriority(float priority) {
+        this.priority = priority;
+        return this;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringRepositoryConnector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/FilteringRepositoryConnector.java
@@ -104,6 +104,6 @@ public final class FilteringRepositoryConnector implements RepositoryConnector {
 
     @Override
     public String toString() {
-        return "filtered(" + delegate.toString() + ")";
+        return FilteringPipelineRepositoryConnectorFactory.NAME + "(" + delegate.toString() + ")";
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/offline/OfflinePipelineRepositoryConnectorFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/offline/OfflinePipelineRepositoryConnectorFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.offline;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.OfflineController;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.PipelineRepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Offline connector factory.
+ *
+ * @since TBD
+ */
+@Singleton
+@Named(OfflinePipelineRepositoryConnectorFactory.NAME)
+public final class OfflinePipelineRepositoryConnectorFactory implements PipelineRepositoryConnectorFactory {
+    public static final String NAME = "offline";
+
+    private final OfflineController offlineController;
+
+    private float priority;
+
+    @Inject
+    public OfflinePipelineRepositoryConnectorFactory(OfflineController offlineController) {
+        this.offlineController = requireNonNull(offlineController);
+    }
+
+    @Override
+    public RepositoryConnector newInstance(
+            RepositorySystemSession session, RemoteRepository repository, RepositoryConnector delegate) {
+        return new OfflineRepositoryConnector(session, repository, offlineController, delegate);
+    }
+
+    @Override
+    public float getPriority() {
+        return priority;
+    }
+
+    public OfflinePipelineRepositoryConnectorFactory setPriority(float priority) {
+        this.priority = priority;
+        return this;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/offline/OfflineRepositoryConnector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/offline/OfflineRepositoryConnector.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.offline;
+
+import java.util.Collection;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.OfflineController;
+import org.eclipse.aether.internal.impl.Utils;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.ArtifactUpload;
+import org.eclipse.aether.spi.connector.MetadataDownload;
+import org.eclipse.aether.spi.connector.MetadataUpload;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.transfer.ArtifactTransferException;
+import org.eclipse.aether.transfer.MetadataTransferException;
+import org.eclipse.aether.transfer.RepositoryOfflineException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Offline connector, that prevents ANY remote access in case session is offline.
+ *
+ * @since TBD
+ */
+public final class OfflineRepositoryConnector implements RepositoryConnector {
+    private final RepositorySystemSession session;
+    private final RemoteRepository remoteRepository;
+    private final OfflineController offlineController;
+    private final RepositoryConnector delegate;
+
+    public OfflineRepositoryConnector(
+            RepositorySystemSession session,
+            RemoteRepository remoteRepository,
+            OfflineController offlineController,
+            RepositoryConnector delegate) {
+        this.session = requireNonNull(session);
+        this.remoteRepository = requireNonNull(remoteRepository);
+        this.offlineController = requireNonNull(offlineController);
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public void get(
+            Collection<? extends ArtifactDownload> artifactDownloads,
+            Collection<? extends MetadataDownload> metadataDownloads) {
+        try {
+            if (session.isOffline()) {
+                Utils.checkOffline(session, offlineController, remoteRepository);
+            }
+        } catch (RepositoryOfflineException e) {
+            if (artifactDownloads != null && !artifactDownloads.isEmpty()) {
+                artifactDownloads.forEach(
+                        d -> d.setException(new ArtifactTransferException(d.getArtifact(), remoteRepository, e)));
+            }
+            if (metadataDownloads != null && !metadataDownloads.isEmpty()) {
+                metadataDownloads.forEach(
+                        d -> d.setException(new MetadataTransferException(d.getMetadata(), remoteRepository, e)));
+            }
+            return;
+        }
+        delegate.get(artifactDownloads, metadataDownloads);
+    }
+
+    @Override
+    public void put(
+            Collection<? extends ArtifactUpload> artifactUploads,
+            Collection<? extends MetadataUpload> metadataUploads) {
+        try {
+            if (session.isOffline()) {
+                Utils.checkOffline(session, offlineController, remoteRepository);
+            }
+        } catch (RepositoryOfflineException e) {
+            if (artifactUploads != null && !artifactUploads.isEmpty()) {
+                artifactUploads.forEach(
+                        d -> d.setException(new ArtifactTransferException(d.getArtifact(), remoteRepository, e)));
+            }
+            if (metadataUploads != null && !metadataUploads.isEmpty()) {
+                metadataUploads.forEach(
+                        d -> d.setException(new MetadataTransferException(d.getMetadata(), remoteRepository, e)));
+            }
+            return;
+        }
+        delegate.put(artifactUploads, metadataUploads);
+    }
+
+    @Override
+    public String toString() {
+        return OfflinePipelineRepositoryConnectorFactory.NAME + "(" + delegate.toString() + ")";
+    }
+}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/PipelineRepositoryConnectorFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/connector/PipelineRepositoryConnectorFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.spi.connector;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * A pipeline factory to create piped repository connectors.
+ *
+ * @since TBD
+ */
+public interface PipelineRepositoryConnectorFactory {
+
+    /**
+     * Create a piped repository connector for the specified remote repository. Typically, a factory will inspect
+     * {@link RemoteRepository#getProtocol()} and {@link RemoteRepository#getContentType()} to determine whether it can
+     * handle a repository. This method never throws or returns {@code null}, least can do is to return the passed in
+     * delegate connector instance.
+     *
+     * @param session The repository system session from which to configure the connector, must not be {@code null}. In
+     *            particular, a connector must notify any {@link RepositorySystemSession#getTransferListener()} set for
+     *            the session and should obey the timeouts configured for the session.
+     * @param repository The remote repository to create a connector for, must not be {@code null}.
+     * @param delegate The delegate connector, never {@code null}. The delegate is "right hand" connector in connector
+     *                 pipeline.
+     * @return The connector for the given repository, never {@code null}. If pipeline wants to step aside, it must
+     * return the passed in delegate connector instance.
+     */
+    RepositoryConnector newInstance(
+            RepositorySystemSession session, RemoteRepository repository, RepositoryConnector delegate);
+
+    /**
+     * The priority of this pipeline factory.
+     */
+    float getPriority();
+}

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -99,8 +99,10 @@ import org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate;
 import org.eclipse.aether.internal.impl.collect.bf.BfDependencyCollector;
 import org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
+import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
@@ -121,6 +123,7 @@ import org.eclipse.aether.spi.artifact.generator.ArtifactGeneratorFactory;
 import org.eclipse.aether.spi.artifact.transformer.ArtifactTransformer;
 import org.eclipse.aether.spi.checksums.ProvidedChecksumsSource;
 import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.PipelineRepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
@@ -703,6 +706,27 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return result;
     }
 
+    private Map<String, PipelineRepositoryConnectorFactory> pipelineRepositoryConnectorFactories;
+
+    public final Map<String, PipelineRepositoryConnectorFactory> getPipelineRepositoryConnectorFactories() {
+        checkClosed();
+        if (pipelineRepositoryConnectorFactories == null) {
+            pipelineRepositoryConnectorFactories = createPipelineRepositoryConnectorFactories();
+        }
+        return pipelineRepositoryConnectorFactories;
+    }
+
+    protected Map<String, PipelineRepositoryConnectorFactory> createPipelineRepositoryConnectorFactories() {
+        HashMap<String, PipelineRepositoryConnectorFactory> result = new HashMap<>();
+        result.put(
+                FilteringPipelineRepositoryConnectorFactory.NAME,
+                new FilteringPipelineRepositoryConnectorFactory(getRemoteRepositoryFilterManager()));
+        result.put(
+                OfflinePipelineRepositoryConnectorFactory.NAME,
+                new OfflinePipelineRepositoryConnectorFactory(getOfflineController()));
+        return result;
+    }
+
     private RepositoryConnectorProvider repositoryConnectorProvider;
 
     public final RepositoryConnectorProvider getRepositoryConnectorProvider() {
@@ -715,7 +739,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
 
     protected RepositoryConnectorProvider createRepositoryConnectorProvider() {
         return new DefaultRepositoryConnectorProvider(
-                getRepositoryConnectorFactories(), getRemoteRepositoryFilterManager());
+                getRepositoryConnectorFactories(), getPipelineRepositoryConnectorFactories());
     }
 
     private Installer installer;

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -103,8 +103,10 @@ import org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate;
 import org.eclipse.aether.internal.impl.collect.bf.BfDependencyCollector;
 import org.eclipse.aether.internal.impl.collect.df.DfDependencyCollector;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
+import org.eclipse.aether.internal.impl.filter.FilteringPipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.filter.GroupIdRemoteRepositoryFilterSource;
 import org.eclipse.aether.internal.impl.filter.PrefixesRemoteRepositoryFilterSource;
+import org.eclipse.aether.internal.impl.offline.OfflinePipelineRepositoryConnectorFactory;
 import org.eclipse.aether.internal.impl.resolution.TrustedChecksumsArtifactResolverPostProcessor;
 import org.eclipse.aether.internal.impl.synccontext.DefaultSyncContextFactory;
 import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
@@ -125,6 +127,7 @@ import org.eclipse.aether.spi.artifact.generator.ArtifactGeneratorFactory;
 import org.eclipse.aether.spi.artifact.transformer.ArtifactTransformer;
 import org.eclipse.aether.spi.checksums.ProvidedChecksumsSource;
 import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.PipelineRepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
@@ -707,6 +710,27 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return result;
     }
 
+    private Map<String, PipelineRepositoryConnectorFactory> pipelineRepositoryConnectorFactories;
+
+    public final Map<String, PipelineRepositoryConnectorFactory> getPipelineRepositoryConnectorFactories() {
+        checkClosed();
+        if (pipelineRepositoryConnectorFactories == null) {
+            pipelineRepositoryConnectorFactories = createPipelineRepositoryConnectorFactories();
+        }
+        return pipelineRepositoryConnectorFactories;
+    }
+
+    protected Map<String, PipelineRepositoryConnectorFactory> createPipelineRepositoryConnectorFactories() {
+        HashMap<String, PipelineRepositoryConnectorFactory> result = new HashMap<>();
+        result.put(
+                FilteringPipelineRepositoryConnectorFactory.NAME,
+                new FilteringPipelineRepositoryConnectorFactory(getRemoteRepositoryFilterManager()));
+        result.put(
+                OfflinePipelineRepositoryConnectorFactory.NAME,
+                new OfflinePipelineRepositoryConnectorFactory(getOfflineController()));
+        return result;
+    }
+
     private RepositoryConnectorProvider repositoryConnectorProvider;
 
     public final RepositoryConnectorProvider getRepositoryConnectorProvider() {
@@ -719,7 +743,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
 
     protected RepositoryConnectorProvider createRepositoryConnectorProvider() {
         return new DefaultRepositoryConnectorProvider(
-                getRepositoryConnectorFactories(), getRemoteRepositoryFilterManager());
+                getRepositoryConnectorFactories(), getPipelineRepositoryConnectorFactories());
     }
 
     private Installer installer;


### PR DESCRIPTION
Ability to "pipe" connectors one onto another in controlled and configured fashion.

The ide is following:
- first (actually connecting to remote) connector is chosen as today (based on priority)
- next, new type of factories PipelinedRepositoryConnectorFactory is ordered (by priority) and they can (but does not have to) wrap the delegate in configured order.

Factored out existing RRF connector into new factory, and introduced another OfflinePRCF, as so far, "resolver offline" was in fact managed at different spots, and user was still able to circumvent offline setting. This now connector now wraps connector and refuses going remote if session if offline.

Vanilla resolver does this:
`offline( rrf( basic(repo) ) )`

---

https://issues.apache.org/jira/browse/MRESOLVER-685