### PR TITLE
[MRESOLVER-700] Bundle transport: read support

### DIFF
--- a/maven-resolver-transport-file/README.md
+++ b/maven-resolver-transport-file/README.md
@@ -1,0 +1,26 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# File transport
+
+This transport uses Java NIO2 `java.nio.file.FileSystem` to implement "remote storage". It is usable in variety of
+use cases, from plain local directory to much more.
+
+Valid URLs:
+* `bundle:local:/some/bundle.zip` - would go to given ZIP file on local FS
+* `bundle:remote:URL` - would use transport to get URL from remote
+* `bundle:artifact:GAV` - would resolve

--- a/maven-resolver-transport-file/README.md
+++ b/maven-resolver-transport-file/README.md
@@ -20,7 +20,8 @@
 This transport uses Java NIO2 `java.nio.file.FileSystem` to implement "remote storage". It is usable in variety of
 use cases, from plain local directory to much more.
 
-Valid URLs:
-* `bundle:local:/some/bundle.zip` - would go to given ZIP file on local FS
-* `bundle:remote:URL` - would use transport to get URL from remote
-* `bundle:artifact:GAV` - would resolve
+Valid file URLs:
+* as before (unchanged)
+
+Valid bundle URLs:
+* `bundle:file.zip` - should point to an existing ZIP file

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -44,11 +44,11 @@ final class FileTransporter extends AbstractTransporter {
      * file in remote repository reached by this transporter. Historically, and in some special cases (ZIP file system),
      * it is only {@link #COPY} that can be used.
      * <p>
-     * In case when contents of remote repository reached by this transport and target are on same {@link FileSystem},
-     * then {@link #SYMLINK} and {@link #HARDLINK} can be used as well, to reduce storage redundancy.
-     * <p>
-     * Still, Resolver cannot do much here, it is user who should evaluate of symlink/hardlink possibility, and if
-     * all found applicable, apply it. Resolver will not try play smart here.
+     * In case when contents of remote repository reached by this transport and target are on same volume,
+     * then {@link #SYMLINK} and {@link #HARDLINK} can be used as well, to reduce storage redundancy. Still, Resolver
+     * cannot do much smartness here, it is user who should evaluate this possibility, and if all conditions are met,
+     * apply it. Resolver does not try play smart here, it will obey configuration and most probably fail (ie cross
+     * volume hardlink).
      *
      * @since 2.0.2
      */
@@ -95,7 +95,7 @@ final class FileTransporter extends AbstractTransporter {
     }
 
     private WriteOp effectiveFileOp(WriteOp wanted, GetTask task) {
-        if (task.getDataPath() != null && task.getDataPath().getFileSystem() == fileSystem) {
+        if (task.getDataPath() != null) {
             return wanted;
         }
         // not default FS or task carries no path (caller wants in-memory read) = COPY must be used

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -44,9 +44,11 @@ final class FileTransporter extends AbstractTransporter {
      * file in remote repository reached by this transporter. Historically, and in some special cases (ZIP file system),
      * it is only {@link #COPY} that can be used.
      * <p>
-     * In case when contents of remote repository reached by this transport and target (usually Maven local repository)
-     * are on same {@link FileSystem}, then {@link #SYMLINK} and {@link #HARDLINK} can be used as well, to reduce
-     * redundancy somewhat.
+     * In case when contents of remote repository reached by this transport and target are on same {@link FileSystem},
+     * then {@link #SYMLINK} and {@link #HARDLINK} can be used as well, to reduce storage redundancy.
+     * <p>
+     * Still, Resolver cannot do much here, it is user who should evaluate of symlink/hardlink possibility, and if
+     * all found applicable, apply it. Resolver will not try play smart here.
      *
      * @since 2.0.2
      */
@@ -140,7 +142,7 @@ final class FileTransporter extends AbstractTransporter {
                 }
                 break;
             default:
-                throw new IllegalStateException("Unknown fileOp" + writeOp);
+                throw new IllegalStateException("Unknown fileOp " + writeOp);
         }
     }
 

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -98,8 +98,8 @@ public final class FileTransporterFactory implements TransporterFactory {
                 throw new UncheckedIOException(e); // hard failure; most probably user error (ie wrong path or perm)
             }
         } else {
-            // special case in file transport: to support custom FS providers (like JIMFS), we cannot
-            // cover "all possible protocols" to throw NoTransporterEx, but we rely on FS rejecting the URI
+            // special case in file: transport: to support custom FS providers (like JIMFS), we cannot
+            // cover all possible protocols (to throw NoTransporterEx), hence we rely on FS rejecting the URI
             FileTransporter.WriteOp writeOp = FileTransporter.WriteOp.COPY;
             if (repositoryUrl.startsWith("symlink+")) {
                 writeOp = FileTransporter.WriteOp.SYMLINK;

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -20,9 +20,16 @@ package org.eclipse.aether.transport.file;
 
 import javax.inject.Named;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -41,15 +48,6 @@ public final class FileTransporterFactory implements TransporterFactory {
     public static final String NAME = "file";
 
     private float priority;
-
-    /**
-     * Creates an (uninitialized) instance of this transporter factory. <em>Note:</em> In case of manual instantiation
-     * by clients, the new factory needs to be configured via its various mutators before first use or runtime errors
-     * will occur.
-     */
-    public FileTransporterFactory() {
-        // enables default constructor
-    }
 
     @Override
     public float getPriority() {
@@ -73,22 +71,46 @@ public final class FileTransporterFactory implements TransporterFactory {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        // special case in file transport: to support custom FS providers (like JIMFS), we cannot
-        // cover "all possible protocols" to throw NoTransporterEx, but we rely on FS rejecting the URI
-        FileTransporter.WriteOp writeOp = FileTransporter.WriteOp.COPY;
         String repositoryUrl = repository.getUrl();
-        if (repositoryUrl.startsWith("symlink+")) {
-            writeOp = FileTransporter.WriteOp.SYMLINK;
-            repositoryUrl = repositoryUrl.substring("symlink+".length());
-        } else if (repositoryUrl.startsWith("hardlink+")) {
-            writeOp = FileTransporter.WriteOp.HARDLINK;
-            repositoryUrl = repositoryUrl.substring("hardlink+".length());
-        }
-        try {
-            Path basePath = Paths.get(RepositoryUriUtils.toUri(repositoryUrl)).toAbsolutePath();
-            return new FileTransporter(basePath.getFileSystem(), false, basePath, writeOp);
-        } catch (FileSystemNotFoundException | IllegalArgumentException e) {
-            throw new NoTransporterException(repository, e);
+        if (repositoryUrl.startsWith("bundle:")) {
+            try {
+                repositoryUrl = repositoryUrl.substring("bundle:".length());
+                URI bundlePath = URI.create("jar:file:"
+                        + Paths.get(RepositoryUriUtils.toUri(repositoryUrl)).toAbsolutePath());
+                Map<String, String> env = new HashMap<>();
+                FileSystem fileSystem = FileSystems.newFileSystem(bundlePath, env);
+                return new FileTransporter(
+                        fileSystem,
+                        true,
+                        false,
+                        fileSystem.getPath(fileSystem.getSeparator()),
+                        FileTransporter.WriteOp.COPY);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e); // hard failure; most probably user error (ie wrong path or perm)
+            }
+        } else {
+            // special case in file transport: to support custom FS providers (like JIMFS), we cannot
+            // cover "all possible protocols" to throw NoTransporterEx, but we rely on FS rejecting the URI
+            FileTransporter.WriteOp writeOp = FileTransporter.WriteOp.COPY;
+            if (repositoryUrl.startsWith("symlink+")) {
+                writeOp = FileTransporter.WriteOp.SYMLINK;
+                repositoryUrl = repositoryUrl.substring("symlink+".length());
+            } else if (repositoryUrl.startsWith("hardlink+")) {
+                writeOp = FileTransporter.WriteOp.HARDLINK;
+                repositoryUrl = repositoryUrl.substring("hardlink+".length());
+            }
+            try {
+                Path basePath =
+                        Paths.get(RepositoryUriUtils.toUri(repositoryUrl)).toAbsolutePath();
+                return new FileTransporter(
+                        basePath.getFileSystem(),
+                        false,
+                        !basePath.getFileSystem().isReadOnly(),
+                        basePath,
+                        writeOp);
+            } catch (FileSystemNotFoundException | IllegalArgumentException e) {
+                throw new NoTransporterException(repository, e);
+            }
         }
     }
 }

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -75,7 +75,7 @@ public final class FileTransporterFactory implements TransporterFactory {
         if (repositoryUrl.startsWith("bundle:")) {
             try {
                 repositoryUrl = repositoryUrl.substring("bundle:".length());
-                URI bundlePath = URI.create("jar:file:"
+                URI bundlePath = URI.create("jar:file://"
                         + Paths.get(RepositoryUriUtils.toUri(repositoryUrl))
                                 .toAbsolutePath()
                                 .toString()

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -75,11 +75,11 @@ public final class FileTransporterFactory implements TransporterFactory {
         if (repositoryUrl.startsWith("bundle:")) {
             try {
                 repositoryUrl = repositoryUrl.substring("bundle:".length());
-                URI bundlePath = URI.create("jar:file://"
+                URI bundlePath = URI.create("jar:"
                         + Paths.get(RepositoryUriUtils.toUri(repositoryUrl))
                                 .toAbsolutePath()
-                                .toString()
-                                .replace('\\', '/'));
+                                .toUri()
+                                .toASCIIString());
                 Map<String, String> env = new HashMap<>();
                 FileSystem fileSystem = FileSystems.newFileSystem(bundlePath, env);
                 return new FileTransporter(

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -41,7 +41,7 @@ import org.eclipse.aether.transfer.NoTransporterException;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A transporter factory for repositories using the {@code file:} protocol.
+ * A transporter factory for repositories using the {@code file:} or {@code bundle:} protocol.
  */
 @Named(FileTransporterFactory.NAME)
 public final class FileTransporterFactory implements TransporterFactory {
@@ -65,6 +65,12 @@ public final class FileTransporterFactory implements TransporterFactory {
         return this;
     }
 
+    /**
+     * Creates new instance of {@link FileTransporter}.
+     *
+     * @param session The session.
+     * @param repository The remote repository.
+     */
     @Override
     public Transporter newInstance(RepositorySystemSession session, RemoteRepository repository)
             throws NoTransporterException {

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporterFactory.java
@@ -76,7 +76,10 @@ public final class FileTransporterFactory implements TransporterFactory {
             try {
                 repositoryUrl = repositoryUrl.substring("bundle:".length());
                 URI bundlePath = URI.create("jar:file:"
-                        + Paths.get(RepositoryUriUtils.toUri(repositoryUrl)).toAbsolutePath());
+                        + Paths.get(RepositoryUriUtils.toUri(repositoryUrl))
+                                .toAbsolutePath()
+                                .toString()
+                                .replace('\\', '/'));
                 Map<String, String> env = new HashMap<>();
                 FileSystem fileSystem = FileSystems.newFileSystem(bundlePath, env);
                 return new FileTransporter(

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/package-info.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/package-info.java
@@ -18,6 +18,6 @@
  * under the License.
  */
 /**
- * Support for downloads/uploads using the local filesystem as "remote" storage.
+ * Support for downloads/uploads using the Java NIO2 filesystem as "remote" storage.
  */
 package org.eclipse.aether.transport.file;

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -113,11 +113,8 @@ public class FileTransporterTest {
             Files.write(repoDir.resolve("empty.txt"), "".getBytes(StandardCharsets.UTF_8));
             Files.write(repoDir.resolve("some space.txt"), "space".getBytes(StandardCharsets.UTF_8));
             if (fs == FS.BUNDLE) {
-                URI bundle = URI.create("jar:file://"
-                        + repoDir.resolve("bundle.zip")
-                                .toAbsolutePath()
-                                .toString()
-                                .replace('\\', '/'));
+                URI bundle = URI.create("jar:"
+                        + repoDir.resolve("bundle.zip").toAbsolutePath().toUri().toASCIIString());
                 // zip it up and change uri to zip file path
                 HashMap<String, String> env = new HashMap<>();
                 env.put("create", "true");

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -113,8 +113,11 @@ public class FileTransporterTest {
             Files.write(repoDir.resolve("empty.txt"), "".getBytes(StandardCharsets.UTF_8));
             Files.write(repoDir.resolve("some space.txt"), "space".getBytes(StandardCharsets.UTF_8));
             if (fs == FS.BUNDLE) {
-                URI bundle =
-                        URI.create("jar:file:" + repoDir.resolve("bundle.zip").toAbsolutePath());
+                URI bundle = URI.create("jar:file:"
+                        + repoDir.resolve("bundle.zip")
+                                .toAbsolutePath()
+                                .toString()
+                                .replace('\\', '/'));
                 // zip it up and change uri to zip file path
                 HashMap<String, String> env = new HashMap<>();
                 env.put("create", "true");

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -113,7 +113,7 @@ public class FileTransporterTest {
             Files.write(repoDir.resolve("empty.txt"), "".getBytes(StandardCharsets.UTF_8));
             Files.write(repoDir.resolve("some space.txt"), "space".getBytes(StandardCharsets.UTF_8));
             if (fs == FS.BUNDLE) {
-                URI bundle = URI.create("jar:file:"
+                URI bundle = URI.create("jar:file://"
                         + repoDir.resolve("bundle.zip")
                                 .toAbsolutePath()
                                 .toString()

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -47,7 +47,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**


### PR DESCRIPTION
This PR slightly improves the file transport to fully utilize FileSystem, which now can be ZipFileSystem as well. The "old" part remains unchanged.

For factory just added `bundle:` prefix, that now may be in form `bundle:fileUri`, where `fileUri` is basically a path of a ZIP file that must exist. The ZIP file is read only.

The point of this PR is that user can now use a "bundle" (see https://central.sonatype.org/publish/publish-portal-upload/) just like we did before with staging repositories. Various tools (njord?) can produce bundles. The ZIP file is "mounted" and artifacts from it becomes reachable to Maven just like from any remote repository.

---

https://issues.apache.org/jira/browse/MRESOLVER-700