### PR TITLE
Add generated file warning headers to velocity templates

### DIFF
--- a/maven-resolver-tools/src/main/resources/configuration.md.vm
+++ b/maven-resolver-tools/src/main/resources/configuration.md.vm
@@ -37,6 +37,12 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<!--
+THIS FILE IS GENERATED - DO NOT EDIT
+Generated from: maven-resolver-tools/src/main/resources/configuration.md.vm
+To modify this file, edit the template and regenerate.
+-->
+
 ]]#
 
 #macro(value $val)

--- a/maven-resolver-tools/src/main/resources/configuration.properties.vm
+++ b/maven-resolver-tools/src/main/resources/configuration.properties.vm
@@ -33,6 +33,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+# THIS FILE IS GENERATED - DO NOT EDIT
+# Generated from: maven-resolver-tools/src/main/resources/configuration.properties.vm
+# To modify this file, edit the template and regenerate.
 #]]#
 props.count = ${keys.size()}
 #foreach($key in $keys)

--- a/maven-resolver-tools/src/main/resources/configuration.yaml.vm
+++ b/maven-resolver-tools/src/main/resources/configuration.yaml.vm
@@ -33,6 +33,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+# THIS FILE IS GENERATED - DO NOT EDIT
+# Generated from: maven-resolver-tools/src/main/resources/configuration.yaml.vm
+# To modify this file, edit the template and regenerate.
 #]]#
 props:
   #foreach($key in $keys)


### PR DESCRIPTION
Add comment headers to velocity templates to indicate that the generated files should not be modified directly. The headers include information about the source template and instructions to modify the template instead of the generated file.