### PR TITLE
[MRESOLVER-588] Incomplete system properties in suppliers

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -64,7 +64,6 @@ public class Booter {
     public static SessionBuilder newRepositorySystemSession(RepositorySystem system) {
         SessionBuilder result = new SessionBuilderSupplier(system)
                 .get()
-                .setSystemProperties(System.getProperties())
                 .withLocalRepositoryBaseDirectories(Path.of("target/local-repo"))
                 .setRepositoryListener(new ConsoleRepositoryListener())
                 .setTransferListener(new ConsoleTransferListener())

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -19,8 +19,10 @@
 package org.eclipse.aether.supplier;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.function.Supplier;
 
+import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
@@ -70,6 +72,11 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
 
     protected void configureSessionBuilder(SessionBuilder session) {
         session.setSystemProperties(System.getProperties());
+        boolean caseSensitive = !Os.IS_WINDOWS;
+        System.getenv().forEach((key, value) -> {
+            key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
+            session.setSystemProperty(key, value);
+        });
         session.setDependencyTraverser(getDependencyTraverser());
         session.setDependencyManager(getDependencyManager());
         session.setDependencySelector(getDependencySelector());

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -18,9 +18,11 @@
  */
 package org.eclipse.aether.supplier;
 
+import java.util.Locale;
 import java.util.function.Supplier;
 
 import org.apache.maven.repository.internal.MavenSessionBuilderSupplier;
+import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
@@ -37,5 +39,16 @@ import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
 public class SessionBuilderSupplier extends MavenSessionBuilderSupplier {
     public SessionBuilderSupplier(RepositorySystem repositorySystem) {
         super(repositorySystem);
+    }
+
+    @Override
+    protected void configureSessionBuilder(SessionBuilder session) {
+        super.configureSessionBuilder(session);
+        session.setSystemProperties(System.getProperties());
+        boolean caseSensitive = !Os.IS_WINDOWS;
+        System.getenv().forEach((key, value) -> {
+            key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
+            session.setSystemProperty(key, value);
+        });
     }
 }


### PR DESCRIPTION
Maven3 supplier lacks `env.` entries from session system properties. Maven4 supplier has no system properties at all set.

Supersedes #539

---

https://issues.apache.org/jira/browse/MRESOLVER-588

Co-authored-by: @HannesWell 