### PR TITLE
Use GET() and PUT() instead of method()

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -272,7 +272,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
         try {
             while (true) {
                 HttpRequest.Builder request =
-                        HttpRequest.newBuilder().uri(resolve(task)).method("GET", HttpRequest.BodyPublishers.noBody());
+                        HttpRequest.newBuilder().uri(resolve(task)).GET();
                 headers.forEach(request::setHeader);
 
                 if (resume) {
@@ -395,7 +395,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
         headers.forEach(request::setHeader);
         try (FileUtils.TempFile tempFile = FileUtils.newTempFile()) {
             utilPut(task, Files.newOutputStream(tempFile.getPath()), true);
-            request.method("PUT", HttpRequest.BodyPublishers.ofFile(tempFile.getPath()));
+            request.PUT(HttpRequest.BodyPublishers.ofFile(tempFile.getPath()));
 
             try {
                 HttpResponse<Void> response = send(request.build(), HttpResponse.BodyHandlers.discarding());


### PR DESCRIPTION
But this does not work for HEAD() that is 18+.
Moreover, builder `method(String, BodyPublisher)`
enforces body publisher as non-null, while the logic to stop emitting `Content-Length: 0` on GET and HEAD expects `null` body publisher.

Fixes #739
