### PR TITLE
Proxy protol loss

### DIFF
--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -366,7 +366,7 @@ final class HttpTransporter extends AbstractTransporter {
     private static HttpHost toHost(Proxy proxy) {
         HttpHost host = null;
         if (proxy != null) {
-            host = new HttpHost(proxy.getHost(), proxy.getPort());
+            host = new HttpHost(proxy.getHost(), proxy.getPort(), proxy.getType());
         }
         return host;
     }


### PR DESCRIPTION
Proxy falls back to HTTP but it may need to be HTTPS

Fixes #745