### PR TITLE
Align guice with Maven

### DIFF
--- a/maven-resolver-connector-basic/pom.xml
+++ b/maven-resolver-connector-basic/pom.xml
@@ -62,6 +62,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -108,6 +108,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/maven-resolver-impl/pom.xml
+++ b/maven-resolver-impl/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <classifier>classes</classifier>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <maven.site.path>resolver-archives/resolver-LATEST</maven.site.path>
     <checkstyle.violation.ignore>None</checkstyle.violation.ignore>
     <sisuVersion>0.9.0.M4</sisuVersion>
-    <guiceVersion>6.0.0</guiceVersion>
+    <guiceVersion>5.1.0</guiceVersion>
     <slf4jVersion>2.0.17</slf4jVersion>
     <testcontainersVersion>1.21.1</testcontainersVersion>
     <bouncycastleVersion>1.81</bouncycastleVersion>
@@ -272,17 +272,17 @@
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
         <version>${sisuVersion}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guiceVersion}</version>
+        <classifier>classes</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.4.8-jre</version>
       </dependency>
 
       <dependency>
@@ -312,6 +312,11 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpg-jdk18on</artifactId>
+        <version>${bouncycastleVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastleVersion}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Also align some other (transitive) dependencies that are enlisted.

Changes:
* downgrade to Guice 5.1.0 w/ classifier "classes".
* ASM is now coming in as transitive from Sisu
* manage and up guava to not trigger alarms
* add one out-of-line manage entry for bouncycastle lib (unused by us, but as transitive)