### PR TITLE
Move out depth from DepMgr

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManager.java
@@ -40,7 +40,7 @@ public interface DependencyManager {
      * @param dependency The dependency to manage, must not be {@code null}.
      * @return The management update to apply to the dependency or {@code null} if the dependency is not managed at all.
      */
-    DependencyManagement manageDependency(Dependency dependency);
+    DependencyManagement manageDependency(int depth, Dependency dependency);
 
     /**
      * Derives a dependency manager for the specified collection context. When calculating the child manager,
@@ -50,5 +50,5 @@ public interface DependencyManager {
      * @return The dependency manager for the dependencies of the target node or {@code null} if dependency management
      *         should no longer be applied.
      */
-    DependencyManager deriveChildManager(DependencyCollectionContext context);
+    DependencyManager deriveChildManager(int depth, DependencyCollectionContext context);
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
@@ -86,11 +86,12 @@ public class PremanagedDependency {
     }
 
     public static PremanagedDependency create(
+            int depth,
             DependencyManager depManager,
             Dependency dependency,
             boolean disableVersionManagement,
             boolean premanagedState) {
-        DependencyManagement depMngt = depManager != null ? depManager.manageDependency(dependency) : null;
+        DependencyManagement depMngt = depManager != null ? depManager.manageDependency(depth, dependency) : null;
 
         int managedBits = 0;
         String premanagedVersion = null;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext.java
@@ -98,4 +98,8 @@ final class DependencyProcessingContext {
     DependencyNode getParent() {
         return parents.get(parents.size() - 1);
     }
+
+    int depth() {
+        return parents.size();
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegateTestSupport.java
@@ -624,7 +624,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         }
 
         @Override
-        public DependencyManagement manageDependency(Dependency dependency) {
+        public DependencyManagement manageDependency(int depth, Dependency dependency) {
             requireNonNull(dependency, "dependency cannot be null");
             String id = toKey(dependency);
             DependencyManagement mgmt = new DependencyManagement();
@@ -644,7 +644,7 @@ public abstract class DependencyCollectorDelegateTestSupport {
         }
 
         @Override
-        public DependencyManager deriveChildManager(DependencyCollectionContext context) {
+        public DependencyManager deriveChildManager(int depth, DependencyCollectionContext context) {
             requireNonNull(context, "context cannot be null");
             return this;
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -63,7 +63,6 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     private ClassicDependencyManager(
-            int depth,
             int deriveUntil,
             int applyFrom,
             MMap<Key, Holder<String>> managedVersions,
@@ -73,7 +72,6 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
-                depth,
                 deriveUntil,
                 applyFrom,
                 managedVersions,
@@ -85,14 +83,14 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
     }
 
     @Override
-    public DependencyManager deriveChildManager(DependencyCollectionContext context) {
+    public DependencyManager deriveChildManager(int depth, DependencyCollectionContext context) {
         // MNG-4720: Maven2 backward compatibility
         // Removing this IF makes one IT fail here (read comment above):
         // https://github.com/apache/maven-integration-testing/blob/b4e8fd52b99a058336f9c7c5ec44fdbc1427759c/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4720DependencyManagementExclusionMergeTest.java#L67
         if (depth == 1) {
             return newInstance(managedVersions, managedScopes, managedOptionals, managedLocalPaths, managedExclusions);
         }
-        return super.deriveChildManager(context);
+        return super.deriveChildManager(depth, context);
     }
 
     @Override
@@ -103,7 +101,6 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
             MMap<Key, Holder<String>> managedLocalPaths,
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
         return new ClassicDependencyManager(
-                depth + 1,
                 deriveUntil,
                 applyFrom,
                 managedVersions,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -54,7 +54,6 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     private DefaultDependencyManager(
-            int depth,
             int deriveUntil,
             int applyFrom,
             MMap<Key, Holder<String>> managedVersions,
@@ -64,7 +63,6 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
-                depth,
                 deriveUntil,
                 applyFrom,
                 managedVersions,
@@ -83,7 +81,6 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
             MMap<Key, Holder<String>> managedLocalPaths,
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
         return new DefaultDependencyManager(
-                depth + 1,
                 deriveUntil,
                 applyFrom,
                 managedVersions,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/NoopDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/NoopDependencyManager.java
@@ -41,12 +41,12 @@ public final class NoopDependencyManager implements DependencyManager {
      */
     public NoopDependencyManager() {}
 
-    public DependencyManager deriveChildManager(DependencyCollectionContext context) {
+    public DependencyManager deriveChildManager(int depth, DependencyCollectionContext context) {
         requireNonNull(context, "context cannot be null");
         return this;
     }
 
-    public DependencyManagement manageDependency(Dependency dependency) {
+    public DependencyManagement manageDependency(int depth, Dependency dependency) {
         requireNonNull(dependency, "dependency cannot be null");
         return null;
     }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -51,7 +51,6 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     private TransitiveDependencyManager(
-            int depth,
             int deriveUntil,
             int applyFrom,
             MMap<Key, Holder<String>> managedVersions,
@@ -61,7 +60,6 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
-                depth,
                 deriveUntil,
                 applyFrom,
                 managedVersions,
@@ -80,7 +78,6 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
             MMap<Key, Holder<String>> managedLocalPaths,
             MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
         return new TransitiveDependencyManager(
-                depth + 1,
                 deriveUntil,
                 applyFrom,
                 managedVersions,

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -75,58 +75,64 @@ public class DependencyManagerTest {
     void testClassic() {
         DependencyManager manager = new ClassicDependencyManager(null);
         DependencyManagement mngt;
+        int depth = 0;
 
         // depth=1: only exclusion applied, nothing more
-        manager = manager.deriveChildManager(newContext(
-                new Dependency(A2, null, null),
-                new Dependency(B, null, true),
-                new Dependency(C1, "newscope", null),
-                new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(
+                depth,
+                newContext(
+                        new Dependency(A2, null, null),
+                        new Dependency(B, null, true),
+                        new Dependency(C1, "newscope", null),
+                        new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=2: all applied (new ones ignored)
-        manager = manager.deriveChildManager(newContext(new Dependency(B2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(B2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
         assertNull(mngt.getVersion());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=3: all existing applied, new depMgt ignored, carried on only what we have so far
-        manager = manager.deriveChildManager(newContext(new Dependency(E2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(E2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
     }
 
@@ -134,58 +140,64 @@ public class DependencyManagerTest {
     void testClassicTransitive() {
         DependencyManager manager = new ClassicDependencyManager(true, null);
         DependencyManagement mngt;
+        int depth = 0;
 
         // depth=1: only exclusion applied, nothing more
-        manager = manager.deriveChildManager(newContext(
-                new Dependency(A2, null, null),
-                new Dependency(B, null, true),
-                new Dependency(C1, "newscope", null),
-                new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(
+                depth,
+                newContext(
+                        new Dependency(A2, null, null),
+                        new Dependency(B, null, true),
+                        new Dependency(C1, "newscope", null),
+                        new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=2: all applied (new ones ignored)
-        manager = manager.deriveChildManager(newContext(new Dependency(B2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(B2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
         assertNull(mngt.getVersion());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=3: all existing applied, new depMgt processed, carried on
-        manager = manager.deriveChildManager(newContext(new Dependency(E2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(E2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         // DO NOT APPLY ONTO ITSELF
         // assertNotNull(mngt);
         // assertEquals(mngt.getVersion(), E2.getVersion());
@@ -195,59 +207,65 @@ public class DependencyManagerTest {
     void testTransitive() {
         DependencyManager manager = new TransitiveDependencyManager(null);
         DependencyManagement mngt;
+        int depth = 0;
 
         // depth=1: only exclusion applied, nothing more
-        manager = manager.deriveChildManager(newContext(
-                new Dependency(A2, null, null),
-                new Dependency(B, null, true),
-                new Dependency(C1, "newscope", null),
-                new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(
+                depth,
+                newContext(
+                        new Dependency(A2, null, null),
+                        new Dependency(B, null, true),
+                        new Dependency(C1, "newscope", null),
+                        new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNull(mngt);
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=2: all applied
-        manager = manager.deriveChildManager(newContext(new Dependency(B2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(B2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
         // DO NOT APPLY ONTO ITSELF
         // assertEquals(B2.getVersion(), mngt.getVersion());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=3: all existing applied, new depMgt processed, carried on
-        manager = manager.deriveChildManager(newContext(new Dependency(E2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(E2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         // DO NOT APPLY ONTO ITSELF
         // assertNotNull(mngt);
         // assertEquals(mngt.getVersion(), E2.getVersion());
@@ -257,63 +275,69 @@ public class DependencyManagerTest {
     void testDefault() {
         DependencyManager manager = new DefaultDependencyManager(null);
         DependencyManagement mngt;
+        int depth = 0;
 
         // depth=1: all applied
-        manager = manager.deriveChildManager(newContext(
-                new Dependency(A2, null, null),
-                new Dependency(B, null, true),
-                new Dependency(C1, "newscope", null),
-                new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(
+                depth,
+                newContext(
+                        new Dependency(A2, null, null),
+                        new Dependency(B, null, true),
+                        new Dependency(C1, "newscope", null),
+                        new Dependency(D1, null, null, Collections.singleton(EXCLUSION))));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
         assertNull(mngt.getVersion());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=2: all applied
-        manager = manager.deriveChildManager(newContext(new Dependency(B2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(B2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
         // DO NOT APPLY ONTO ITSELF
         // assertEquals(B2.getVersion(), mngt.getVersion());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         assertNull(mngt);
 
         // depth=3: all existing applied, new depMgt processed, carried on
-        manager = manager.deriveChildManager(newContext(new Dependency(E2, null, null)));
-        mngt = manager.manageDependency(new Dependency(A1, null));
+        manager = manager.deriveChildManager(depth, newContext(new Dependency(E2, null, null)));
+        depth++;
+        mngt = manager.manageDependency(depth, new Dependency(A1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getVersion(), A2.getVersion());
-        mngt = manager.manageDependency(new Dependency(B1, null));
+        mngt = manager.manageDependency(depth, new Dependency(B1, null));
         assertNotNull(mngt);
         assertEquals(Boolean.TRUE, mngt.getOptional());
-        mngt = manager.manageDependency(new Dependency(C1, null));
+        mngt = manager.manageDependency(depth, new Dependency(C1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getScope(), "newscope");
-        mngt = manager.manageDependency(new Dependency(D1, null));
+        mngt = manager.manageDependency(depth, new Dependency(D1, null));
         assertNotNull(mngt);
         assertEquals(mngt.getExclusions(), Collections.singleton(EXCLUSION));
-        mngt = manager.manageDependency(new Dependency(E1, null));
+        mngt = manager.manageDependency(depth, new Dependency(E1, null));
         // DO NOT APPLY ONTO ITSELF
         // assertNotNull(mngt);
         // assertEquals(mngt.getVersion(), E2.getVersion());

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,12 @@
               <configuration>
                 <parameter>
                   <excludes>
+                    <exclude>org.eclipse.aether.collection.DependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.ClassicDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.DefaultDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.NoopDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.TransitiveDependencyManager</exclude>
+
                     <exclude>org.eclipse.aether.RepositoryCache</exclude>
                     <exclude>org.eclipse.aether.RepositoryListener</exclude>
                     <exclude>org.eclipse.aether.RepositorySystem</exclude>
@@ -435,6 +441,12 @@
               <configuration>
                 <parameter>
                   <excludes>
+                    <exclude>org.eclipse.aether.collection.DependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.ClassicDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.DefaultDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.NoopDependencyManager</exclude>
+                    <exclude>org.eclipse.aether.util.graph.manager.TransitiveDependencyManager</exclude>
+
                     <!-- MRESOLVER-338 Drop FileTransform API -->
                     <exclude>org.eclipse.aether.RepositorySystemSession#getFileTransformerManager()</exclude>
                     <exclude>org.eclipse.aether.DefaultRepositorySystemSession#getFileTransformerManager()</exclude>


### PR DESCRIPTION
As it makes it unique, and despite all the params are same, it will just cause doubled everything.

Track "depth" outside of mgr, but this causes binary/source breakage.