### PR TITLE
Metadata type out of coordinates (#1491)

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -89,13 +89,19 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
     }
 
     private String insertRepositoryKey(String metadataType, String repositoryKey) {
-        String result;
-        int idx = metadataType.indexOf('.');
-        if (idx < 0) {
-            result = metadataType + '-' + repositoryKey;
+        if (metadataType.contains("/") && !metadataType.endsWith("/")) {
+            int lastSlash = metadataType.lastIndexOf('/');
+            return metadataType.substring(0, lastSlash + 1)
+                    + insertRepositoryKey(metadataType.substring(lastSlash + 1), repositoryKey);
         } else {
-            result = metadataType.substring(0, idx) + '-' + repositoryKey + metadataType.substring(idx);
+            String result;
+            int idx = metadataType.indexOf('.');
+            if (idx < 0) {
+                result = metadataType + '-' + repositoryKey;
+            } else {
+                result = metadataType.substring(0, idx) + '-' + repositoryKey + metadataType.substring(idx);
+            }
+            return result;
         }
-        return result;
     }
 }


### PR DESCRIPTION
Fix for metadata type that contains `/` (slash), as right now the layout get messed up in such cases. Originally, the "type" was filename, and GAV are the coordinates, but with this simple change, we can (re)use Resolver to resolve files that are not in "addressable space", but still have all the benefit of caching/auth etc.

This is a backport for #1491 