### PR TITLE
Drop Holder from depMgr

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/ClassicDependencyManager.java
@@ -66,11 +66,11 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
             int depth,
             int deriveUntil,
             int applyFrom,
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
                 depth,
@@ -97,11 +97,11 @@ public final class ClassicDependencyManager extends AbstractDependencyManager {
 
     @Override
     protected DependencyManager newInstance(
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions) {
         return new ClassicDependencyManager(
                 depth + 1,
                 deriveUntil,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DefaultDependencyManager.java
@@ -57,11 +57,11 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
             int depth,
             int deriveUntil,
             int applyFrom,
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
                 depth,
@@ -77,11 +77,11 @@ public final class DefaultDependencyManager extends AbstractDependencyManager {
 
     @Override
     protected DependencyManager newInstance(
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions) {
         return new DefaultDependencyManager(
                 depth + 1,
                 deriveUntil,

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -54,11 +54,11 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
             int depth,
             int deriveUntil,
             int applyFrom,
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions,
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions,
             SystemDependencyScope systemDependencyScope) {
         super(
                 depth,
@@ -74,11 +74,11 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
 
     @Override
     protected DependencyManager newInstance(
-            MMap<Key, Holder<String>> managedVersions,
-            MMap<Key, Holder<String>> managedScopes,
-            MMap<Key, Holder<Boolean>> managedOptionals,
-            MMap<Key, Holder<String>> managedLocalPaths,
-            MMap<Key, Collection<Holder<Collection<Exclusion>>>> managedExclusions) {
+            MMap<Key, String> managedVersions,
+            MMap<Key, String> managedScopes,
+            MMap<Key, Boolean> managedOptionals,
+            MMap<Key, String> managedLocalPaths,
+            MMap<Key, Collection<Exclusion>> managedExclusions) {
         return new TransitiveDependencyManager(
                 depth + 1,
                 deriveUntil,


### PR DESCRIPTION
As it make no sense: depMgr holds "applicable" information in own state, while Holder added extra layer of "depth" info. Basically Holder and depMgr instance itself were redundant to each other.