### PR TITLE
Rollback #746 with comments

### DIFF
--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
@@ -466,27 +466,6 @@ public class HttpTransporterTest {
     }
 
     @Test
-    protected void testGet_ProxyAuthenticatedHttps() throws Exception {
-        httpServer.addSslConnector();
-        httpServer.setProxyAuthentication("testuser", "testpass");
-        Authentication auth = new AuthenticationBuilder()
-                .addUsername("testuser")
-                .addPassword("testpass")
-                .build();
-        proxy = new Proxy(Proxy.TYPE_HTTPS, httpServer.getHost(), httpServer.getHttpsPort(), auth);
-        newTransporter("http://bad.localhost:1/");
-        RecordingTransportListener listener = new RecordingTransportListener();
-        GetTask task = new GetTask(URI.create("repo/file.txt")).setListener(listener);
-        transporter.get(task);
-        assertEquals("test", task.getDataString());
-        assertEquals(0L, listener.getDataOffset());
-        assertEquals(4L, listener.getDataLength());
-        assertEquals(1, listener.getStartedCount());
-        assertTrue(listener.getProgressedCount() > 0, "Count: " + listener.getProgressedCount());
-        assertEquals(task.getDataString(), listener.getBaos().toString(StandardCharsets.UTF_8));
-    }
-
-    @Test
     protected void testGet_ProxyUnauthenticated() throws Exception {
         httpServer.setProxyAuthentication("testuser", "testpass");
         proxy = new Proxy(Proxy.TYPE_HTTP, httpServer.getHost(), httpServer.getHttpPort());
@@ -1261,21 +1240,6 @@ public class HttpTransporterTest {
             assertEquals(401, e.getStatusCode());
         } catch (IOException e) {
             // accepted as well: point is to fail
-        }
-    }
-
-    @Test
-    public void testProxyType() throws Exception {
-        httpServer.addSslConnector();
-        proxy = new Proxy(Proxy.TYPE_HTTPS, httpServer.getHost(), httpServer.getHttpsPort(), null);
-        newTransporter("http://bad.localhost:1/");
-        try {
-            transporter.get(new GetTask(URI.create("foo/file.txt")));
-        } catch (HttpTransporterException e) {
-            assertEquals(404, e.getStatusCode());
-            assertEquals(
-                    "http://bad.localhost:1/foo/file.txt",
-                    httpServer.getLogEntries().get(0).getPath());
         }
     }
 

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -392,7 +392,11 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
     private static HttpHost toHost(Proxy proxy) {
         HttpHost host = null;
         if (proxy != null) {
-            host = new HttpHost(proxy.getHost(), proxy.getPort(), proxy.getType());
+            // in Maven, the proxy.protocol is used for proxy matching against remote repository protocol; no TLS proxy
+            // support
+            // https://github.com/apache/maven/issues/2519
+            // https://github.com/apache/maven-resolver/issues/745
+            host = new HttpHost(proxy.getHost(), proxy.getPort());
         }
         return host;
     }

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -104,6 +104,8 @@ import static org.eclipse.aether.transport.jdk.JdkTransporterConfigurationKeys.D
  * <ul>
  *     <li>Does not support {@link ConfigurationProperties#REQUEST_TIMEOUT}, see <a href="https://bugs.openjdk.org/browse/JDK-8258397">JDK-8258397</a></li>
  * </ul>
+ * <p>
+ * Related: <a href="https://dev.to/kdrakon/httpclient-can-t-connect-to-a-tls-proxy-118a">No TLS proxy supported</a>.
  *
  * @since 2.0.0
  */

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * JDK Transporter UT.
+ * Related: <a href="https://dev.to/kdrakon/httpclient-can-t-connect-to-a-tls-proxy-118a">No TLS proxy supported</a>.
  */
 class JdkTransporterTest extends HttpTransporterTest {
 
@@ -87,17 +88,6 @@ class JdkTransporterTest extends HttpTransporterTest {
     @Disabled
     @Test
     protected void testRequestTimeout() throws Exception {}
-
-    // https://dev.to/kdrakon/httpclient-can-t-connect-to-a-tls-proxy-118a
-    @Override
-    @Disabled
-    @Test
-    protected void testGet_ProxyAuthenticatedHttps() {}
-
-    @Override
-    @Disabled
-    @Test
-    public void testProxyType() {}
 
     public JdkTransporterTest() {
         super(() -> new JdkTransporterFactory(standardChecksumExtractor(), new DefaultPathProcessor()));

--- a/maven-resolver-transport-jetty/src/test/java/org/eclipse/aether/transport/jetty/JettyTransporterTest.java
+++ b/maven-resolver-transport-jetty/src/test/java/org/eclipse/aether/transport/jetty/JettyTransporterTest.java
@@ -58,16 +58,6 @@ class JettyTransporterTest extends HttpTransporterTest {
     @Test
     protected void testPut_Authenticated_ExpectContinueRejected_ExplicitlyConfiguredHeader() {}
 
-    @Override
-    @Disabled
-    @Test
-    protected void testGet_ProxyAuthenticatedHttps() {}
-
-    @Override
-    @Disabled
-    @Test
-    public void testProxyType() {}
-
     public JettyTransporterTest() {
         super(() -> new JettyTransporterFactory(standardChecksumExtractor(), new TestPathProcessor()));
     }


### PR DESCRIPTION
Also the added UTs made no sense from retrospective, as they used HTTP remote repo with HTTPS proxy, something Maven would never do.

Rolls back #746 but leaves traces and some context.