### PR TITLE
Make rwlock-local the default

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
@@ -29,7 +29,7 @@ import org.eclipse.aether.MultiRuntimeException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RepositorySystemLifecycle;
 import org.eclipse.aether.named.NamedLockFactory;
-import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
+import org.eclipse.aether.named.providers.LocalReadWriteLockNamedLockFactory;
 import org.eclipse.aether.util.ConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 @Named
 public class NamedLockFactoryAdapterFactoryImpl implements NamedLockFactoryAdapterFactory {
-    public static final String DEFAULT_FACTORY_NAME = FileLockNamedLockFactory.NAME;
+    public static final String DEFAULT_FACTORY_NAME = LocalReadWriteLockNamedLockFactory.NAME;
 
     public static final String DEFAULT_NAME_MAPPER_NAME = NameMappers.FILE_GAV_NAME;
 


### PR DESCRIPTION
The use of file lock seems overkill, as on most normal OSes is just not needed.

Basically this now aligns Resolver 2 with Resolver 1 regarding locking.