### PR TITLE
Ability to augment metadata nature for version range request

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 
 /**
@@ -37,6 +38,8 @@ public final class VersionRangeRequest {
     private Artifact artifact;
 
     private List<RemoteRepository> repositories = Collections.emptyList();
+
+    private Metadata.Nature nature = Metadata.Nature.RELEASE_OR_SNAPSHOT;
 
     private String context = "";
 
@@ -59,6 +62,22 @@ public final class VersionRangeRequest {
     public VersionRangeRequest(Artifact artifact, List<RemoteRepository> repositories, String context) {
         setArtifact(artifact);
         setRepositories(repositories);
+        setRequestContext(context);
+    }
+
+    /**
+     * Creates a request with the specified properties.
+     *
+     * @param artifact The artifact whose version range should be resolved, may be {@code null}.
+     * @param repositories The repositories to resolve the version from, may be {@code null}.
+     * @param nature The nature of metadata to use for resolving the version from, may be {@code null}.
+     * @param context The context in which this request is made, may be {@code null}.
+     */
+    public VersionRangeRequest(
+            Artifact artifact, List<RemoteRepository> repositories, Metadata.Nature nature, String context) {
+        setArtifact(artifact);
+        setRepositories(repositories);
+        setNature(nature);
         setRequestContext(context);
     }
 
@@ -102,6 +121,32 @@ public final class VersionRangeRequest {
             this.repositories = Collections.emptyList();
         } else {
             this.repositories = repositories;
+        }
+        return this;
+    }
+
+    /**
+     * The nature of metadata to use for resolving the version from, never {@code null}.
+     *
+     * @return The nature, never {@code null}.
+     * @since 2.0.11
+     */
+    public Metadata.Nature getNature() {
+        return nature;
+    }
+
+    /**
+     * Sets the nature of metadata to use for resolving the version from
+     *
+     * @param nature The nature, may be {@code null}.
+     * @return This request for chaining, never {@code null}.
+     * @since 2.0.11
+     */
+    public VersionRangeRequest setNature(Metadata.Nature nature) {
+        if (nature == null) {
+            this.nature = Metadata.Nature.RELEASE_OR_SNAPSHOT;
+        } else {
+            this.nature = nature;
         }
         return this;
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
@@ -72,6 +72,7 @@ public final class VersionRangeRequest {
      * @param repositories The repositories to resolve the version from, may be {@code null}.
      * @param nature The nature of metadata to use for resolving the version from, may be {@code null}.
      * @param context The context in which this request is made, may be {@code null}.
+     * @since 2.0.11
      */
     public VersionRangeRequest(
             Artifact artifact, List<RemoteRepository> repositories, Metadata.Nature nature, String context) {

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/resolution/VersionRangeRequest.java
@@ -127,6 +127,22 @@ public final class VersionRangeRequest {
     }
 
     /**
+     * Adds the specified repository for the resolution.
+     *
+     * @param repository The repository to add, may be {@code null}.
+     * @return This request for chaining, never {@code null}.
+     */
+    public VersionRangeRequest addRepository(RemoteRepository repository) {
+        if (repository != null) {
+            if (this.repositories.isEmpty()) {
+                this.repositories = new ArrayList<>();
+            }
+            this.repositories.add(repository);
+        }
+        return this;
+    }
+
+    /**
      * The nature of metadata to use for resolving the version from, never {@code null}.
      *
      * @return The nature, never {@code null}.
@@ -148,22 +164,6 @@ public final class VersionRangeRequest {
             this.nature = Metadata.Nature.RELEASE_OR_SNAPSHOT;
         } else {
             this.nature = nature;
-        }
-        return this;
-    }
-
-    /**
-     * Adds the specified repository for the resolution.
-     *
-     * @param repository The repository to add, may be {@code null}.
-     * @return This request for chaining, never {@code null}.
-     */
-    public VersionRangeRequest addRepository(RemoteRepository repository) {
-        if (repository != null) {
-            if (this.repositories.isEmpty()) {
-                this.repositories = new ArrayList<>();
-            }
-            this.repositories.add(repository);
         }
         return this;
     }


### PR DESCRIPTION
The idea is to let caller be able to augment the nature of metadata to resolve version range from.

Resolver already handles this, and is more elegant, than to have caller fiddle with filtering the remote repositories or alike. Also, this way client code (ie. Maven) can expose more fine grained configuration for this.