### PR TITLE
Ingest Maveniverse Heimdall

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
@@ -22,25 +22,25 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.eclipse.aether.MultiRuntimeException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.impl.RepositorySystemLifecycle;
+import org.eclipse.aether.internal.impl.filter.ruletree.GroupTree;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -54,18 +54,19 @@ import org.slf4j.LoggerFactory;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Remote repository filter source filtering on G coordinate. It is backed by a file that lists all allowed groupIds
- * and groupId not present in this file are filtered out.
+ * Remote repository filter source filtering on G coordinate. It is backed by a file that is parsed into {@link GroupTree}.
  * <p>
- * The file can be authored manually: format is one groupId per line, comments starting with "#" (hash) amd empty lines
- * for structuring are supported. The file can also be pre-populated by "record" functionality of this filter.
+ * The file can be authored manually. The file can also be pre-populated by "record" functionality of this filter.
  * When "recording", this filter will not filter out anything, but will instead populate the file with all encountered
- * groupIds.
+ * groupIds recorded as {@code =groupId}. The recorded file should be authored afterward to fine tune it, as there is
+ * no optimization in place (ie to look for smallest common parent groupId and alike).
  * <p>
  * The groupId file is expected on path "${basedir}/groupId-${repository.id}.txt".
  * <p>
  * The groupId file once loaded are cached in component, so in-flight groupId file change during component existence
  * are NOT noticed.
+ *
+ * @see GroupTree
  *
  * @since 1.9.0
  */
@@ -111,13 +112,15 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
 
     static final String GROUP_ID_FILE_SUFFIX = ".txt";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GroupIdRemoteRepositoryFilterSource.class);
+    private final Logger logger = LoggerFactory.getLogger(GroupIdRemoteRepositoryFilterSource.class);
 
     private final RepositorySystemLifecycle repositorySystemLifecycle;
 
-    private final ConcurrentHashMap<Path, Set<String>> rules;
+    private final ConcurrentHashMap<RemoteRepository, GroupTree> rules;
 
-    private final ConcurrentHashMap<Path, Boolean> changedRules;
+    private final ConcurrentHashMap<RemoteRepository, Path> ruleFiles;
+
+    private final ConcurrentHashMap<RemoteRepository, Set<String>> recordedRules;
 
     private final AtomicBoolean onShutdownHandlerRegistered;
 
@@ -125,13 +128,18 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
     public GroupIdRemoteRepositoryFilterSource(RepositorySystemLifecycle repositorySystemLifecycle) {
         this.repositorySystemLifecycle = requireNonNull(repositorySystemLifecycle);
         this.rules = new ConcurrentHashMap<>();
-        this.changedRules = new ConcurrentHashMap<>();
+        this.ruleFiles = new ConcurrentHashMap<>();
+        this.recordedRules = new ConcurrentHashMap<>();
         this.onShutdownHandlerRegistered = new AtomicBoolean(false);
     }
 
     @Override
     protected boolean isEnabled(RepositorySystemSession session) {
-        return ConfigUtils.getBoolean(session, false, CONFIG_PROP_ENABLED);
+        return ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED);
+    }
+
+    private boolean isRepositoryFilteringEnabled(RepositorySystemSession session, RemoteRepository remoteRepository) {
+        return ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED + "." + remoteRepository.getId());
     }
 
     @Override
@@ -150,58 +158,56 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
             }
             for (ArtifactResult artifactResult : artifactResults) {
                 if (artifactResult.isResolved() && artifactResult.getRepository() instanceof RemoteRepository) {
-                    Path filePath = filePath(
-                            getBasedir(session, LOCAL_REPO_PREFIX_DIR, CONFIG_PROP_BASEDIR, false),
-                            artifactResult.getRepository().getId());
-                    boolean newGroupId = rules.computeIfAbsent(
-                                    filePath, f -> Collections.synchronizedSet(new TreeSet<>()))
-                            .add(artifactResult.getArtifact().getGroupId());
-                    if (newGroupId) {
-                        changedRules.put(filePath, Boolean.TRUE);
+                    RemoteRepository remoteRepository = (RemoteRepository) artifactResult.getRepository();
+                    boolean repositoryFilteringEnabled = isRepositoryFilteringEnabled(session, remoteRepository);
+                    if (repositoryFilteringEnabled) {
+                        ruleFile(session, remoteRepository); // populate it; needed for save
+                        String line = "=" + artifactResult.getArtifact().getGroupId();
+                        recordedRules
+                                .computeIfAbsent(remoteRepository, k -> new TreeSet<>())
+                                .add(line);
+                        rules.compute(remoteRepository, (k, v) -> {
+                                    if (v == null || v == GroupTree.SENTINEL) {
+                                        v = new GroupTree("");
+                                    }
+                                    return v;
+                                })
+                                .loadNode(line);
                     }
                 }
             }
         }
     }
 
-    /**
-     * Returns the groupId path. The file and parents may not exist, this method merely calculate the path.
-     */
-    private Path filePath(Path basedir, String remoteRepositoryId) {
-        return basedir.resolve(GROUP_ID_FILE_PREFIX + remoteRepositoryId + GROUP_ID_FILE_SUFFIX);
+    private Path ruleFile(RepositorySystemSession session, RemoteRepository remoteRepository) {
+        return ruleFiles.computeIfAbsent(
+                remoteRepository, r -> getBasedir(session, LOCAL_REPO_PREFIX_DIR, CONFIG_PROP_BASEDIR, false)
+                        .resolve(GROUP_ID_FILE_PREFIX + remoteRepository.getId() + GROUP_ID_FILE_SUFFIX));
     }
 
-    private Set<String> cacheRules(RepositorySystemSession session, RemoteRepository remoteRepository) {
-        Path filePath = filePath(
-                getBasedir(session, LOCAL_REPO_PREFIX_DIR, CONFIG_PROP_BASEDIR, false), remoteRepository.getId());
-        return rules.computeIfAbsent(filePath, r -> {
-            Set<String> rules = loadRepositoryRules(filePath);
-            if (rules != NOT_PRESENT) {
-                LOGGER.info("Loaded {} groupId for remote repository {}", rules.size(), remoteRepository.getId());
-            }
-            return rules;
-        });
+    private GroupTree cacheRules(RepositorySystemSession session, RemoteRepository remoteRepository) {
+        return rules.computeIfAbsent(remoteRepository, r -> loadRepositoryRules(session, r));
     }
 
-    private Set<String> loadRepositoryRules(Path filePath) {
-        if (Files.isReadable(filePath)) {
-            try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
-                TreeSet<String> result = new TreeSet<>();
-                String groupId;
-                while ((groupId = reader.readLine()) != null) {
-                    if (!groupId.startsWith("#") && !groupId.trim().isEmpty()) {
-                        result.add(groupId);
-                    }
+    private GroupTree loadRepositoryRules(RepositorySystemSession session, RemoteRepository remoteRepository) {
+        boolean repositoryFilteringEnabled =
+                ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED + "." + remoteRepository.getId());
+        Path filePath = ruleFile(session, remoteRepository);
+        if (repositoryFilteringEnabled && Files.isReadable(filePath)) {
+            try (Stream<String> lines = Files.lines(filePath, StandardCharsets.UTF_8)) {
+                GroupTree groupTree = new GroupTree("");
+                int rules = groupTree.loadNodes(lines);
+                logger.info("Loaded {} group rules for remote repository {}", rules, remoteRepository.getId());
+                if (logger.isDebugEnabled()) {
+                    groupTree.dump("");
                 }
-                return Collections.unmodifiableSet(result);
+                return groupTree;
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
-        return NOT_PRESENT;
+        return GroupTree.SENTINEL;
     }
-
-    private static final TreeSet<String> NOT_PRESENT = new TreeSet<>();
 
     private class GroupIdFilter implements RemoteRepositoryFilter {
         private final RepositorySystemSession session;
@@ -221,12 +227,12 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
         }
 
         private Result acceptGroupId(RemoteRepository remoteRepository, String groupId) {
-            Set<String> groupIds = cacheRules(session, remoteRepository);
-            if (NOT_PRESENT == groupIds) {
+            GroupTree groupTree = cacheRules(session, remoteRepository);
+            if (GroupTree.SENTINEL == groupTree) {
                 return NOT_PRESENT_RESULT;
             }
 
-            if (groupIds.contains(groupId)) {
+            if (groupTree.acceptedGroupId(groupId)) {
                 return new SimpleResult(true, "G:" + groupId + " allowed from " + remoteRepository);
             } else {
                 return new SimpleResult(false, "G:" + groupId + " NOT allowed from " + remoteRepository);
@@ -234,6 +240,9 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
         }
     }
 
+    /**
+     * Filter result when filter "stands aside" as it had no input.
+     */
     private static final RemoteRepositoryFilter.Result NOT_PRESENT_RESULT =
             new SimpleResult(true, "GroupId file not present");
 
@@ -248,25 +257,19 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
      * On-close handler that saves recorded rules, if any.
      */
     private void saveRecordedLines() {
-        if (changedRules.isEmpty()) {
-            return;
-        }
-
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (Map.Entry<Path, Set<String>> entry : rules.entrySet()) {
-            Path filePath = entry.getKey();
-            if (changedRules.get(filePath) != Boolean.TRUE) {
-                continue;
-            }
-            Set<String> recordedLines = entry.getValue();
-            if (!recordedLines.isEmpty()) {
+        for (Map.Entry<RemoteRepository, Path> entry : ruleFiles.entrySet()) {
+            Set<String> recorded = recordedRules.get(entry.getKey());
+            if (recorded != null && !recorded.isEmpty()) {
                 try {
-                    TreeSet<String> result = new TreeSet<>();
-                    result.addAll(loadRepositoryRules(filePath));
-                    result.addAll(recordedLines);
-
-                    LOGGER.info("Saving {} groupIds to '{}'", result.size(), filePath);
-                    FileUtils.writeFileWithBackup(filePath, p -> Files.write(p, result));
+                    ArrayList<String> result = new ArrayList<>();
+                    if (Files.isReadable(entry.getValue())) {
+                        result.addAll(Files.readAllLines(entry.getValue()));
+                    }
+                    result.add("# Recorded entries");
+                    result.addAll(recorded);
+                    logger.info("Saving {} groupIds to '{}'", result.size(), entry.getValue());
+                    FileUtils.writeFileWithBackup(entry.getValue(), p -> Files.write(p, result));
                 } catch (IOException e) {
                     exceptions.add(e);
                 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -181,11 +181,11 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         boolean repositoryFilteringEnabled =
                 ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED + "." + remoteRepository.getId());
         if (repositoryFilteringEnabled) {
-            Path filePath = resolvePrefixesFromRemoteRepository(session, remoteRepository);
+            Path filePath = resolvePrefixesFromLocalConfiguration(session, baseDir, remoteRepository);
             if (filePath == null) {
-                filePath = baseDir.resolve(PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX);
+                filePath = resolvePrefixesFromRemoteRepository(session, remoteRepository);
             }
-            if (Files.isReadable(filePath)) {
+            if (filePath != null) {
                 logger.debug(
                         "Loading prefixes for remote repository {} from file '{}'", remoteRepository.getId(), filePath);
                 try (Stream<String> lines = Files.lines(filePath, StandardCharsets.UTF_8)) {
@@ -204,6 +204,16 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         }
         logger.debug("Prefix file for remote repository {} disabled", remoteRepository);
         return PrefixTree.SENTINEL;
+    }
+
+    private Path resolvePrefixesFromLocalConfiguration(
+            RepositorySystemSession session, Path baseDir, RemoteRepository remoteRepository) {
+        Path filePath = baseDir.resolve(PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX);
+        if (Files.isReadable(filePath)) {
+            return filePath;
+        } else {
+            return null;
+        }
     }
 
     private Path resolvePrefixesFromRemoteRepository(

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -129,7 +129,7 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
 
     @Override
     protected boolean isEnabled(RepositorySystemSession session) {
-        return ConfigUtils.getBoolean(session, false, CONFIG_PROP_ENABLED);
+        return ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED);
     }
 
     private boolean isRepositoryFilteringEnabled(RepositorySystemSession session, RemoteRepository remoteRepository) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -22,23 +22,25 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.filter.ruletree.PrefixTree;
+import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.MetadataRequest;
+import org.eclipse.aether.resolution.MetadataResult;
 import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
@@ -48,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Remote repository filter source filtering on path prefixes. It is backed by a file that lists all allowed path
@@ -81,6 +82,8 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
     private static final String CONFIG_PROPS_PREFIX =
             RemoteRepositoryFilterSourceSupport.CONFIG_PROPS_PREFIX + NAME + ".";
 
+    private static final String PREFIX_FILE_PATH = ".meta/prefixes.txt";
+
     /**
      * Is filter enabled?
      *
@@ -105,16 +108,20 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
 
     static final String PREFIXES_FILE_SUFFIX = ".txt";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PrefixesRemoteRepositoryFilterSource.class);
+    private final Logger logger = LoggerFactory.getLogger(PrefixesRemoteRepositoryFilterSource.class);
+
+    private final RepositorySystem repositorySystem;
 
     private final RepositoryLayoutProvider repositoryLayoutProvider;
 
-    private final ConcurrentHashMap<RemoteRepository, Node> prefixes;
+    private final ConcurrentHashMap<RemoteRepository, PrefixTree> prefixes;
 
     private final ConcurrentHashMap<RemoteRepository, RepositoryLayout> layouts;
 
     @Inject
-    public PrefixesRemoteRepositoryFilterSource(RepositoryLayoutProvider repositoryLayoutProvider) {
+    public PrefixesRemoteRepositoryFilterSource(
+            RepositorySystem repositorySystem, RepositoryLayoutProvider repositoryLayoutProvider) {
+        this.repositorySystem = requireNonNull(repositorySystem);
         this.repositoryLayoutProvider = requireNonNull(repositoryLayoutProvider);
         this.prefixes = new ConcurrentHashMap<>();
         this.layouts = new ConcurrentHashMap<>();
@@ -123,6 +130,10 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
     @Override
     protected boolean isEnabled(RepositorySystemSession session) {
         return ConfigUtils.getBoolean(session, false, CONFIG_PROP_ENABLED);
+    }
+
+    private boolean isRepositoryFilteringEnabled(RepositorySystemSession session, RemoteRepository remoteRepository) {
+        return ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED + "." + remoteRepository.getId());
     }
 
     @Override
@@ -148,49 +159,60 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         });
     }
 
-    /**
-     * Caches prefixes instances for remote repository.
-     */
-    private Node cacheNode(Path basedir, RemoteRepository remoteRepository) {
-        return prefixes.computeIfAbsent(remoteRepository, r -> loadRepositoryPrefixes(basedir, remoteRepository));
+    private PrefixTree cachePrefixTree(
+            RepositorySystemSession session, Path basedir, RemoteRepository remoteRepository) {
+        return prefixes.computeIfAbsent(remoteRepository, r -> loadPrefixTree(session, basedir, remoteRepository));
     }
 
-    /**
-     * Loads prefixes file and preprocesses it into {@link Node} instance.
-     */
-    private Node loadRepositoryPrefixes(Path baseDir, RemoteRepository remoteRepository) {
-        Path filePath = baseDir.resolve(PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX);
-        if (Files.isReadable(filePath)) {
-            try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
-                LOGGER.debug(
-                        "Loading prefixes for remote repository {} from file '{}'", remoteRepository.getId(), filePath);
-                Node root = new Node("");
-                String prefix;
-                int lines = 0;
-                while ((prefix = reader.readLine()) != null) {
-                    if (!prefix.startsWith("#") && !prefix.trim().isEmpty()) {
-                        lines++;
-                        Node currentNode = root;
-                        for (String element : elementsOf(prefix)) {
-                            currentNode = currentNode.addSibling(element);
-                        }
-                    }
-                }
-                LOGGER.info("Loaded {} prefixes for remote repository {}", lines, remoteRepository.getId());
-                return root;
-            } catch (FileNotFoundException e) {
-                // strange: we tested for it above, still, we should not fail
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+    private PrefixTree loadPrefixTree(
+            RepositorySystemSession session, Path baseDir, RemoteRepository remoteRepository) {
+        boolean repositoryFilteringEnabled =
+                ConfigUtils.getBoolean(session, true, CONFIG_PROP_ENABLED + "." + remoteRepository.getId());
+        if (repositoryFilteringEnabled) {
+            Path filePath = resolvePrefixesFromRemoteRepository(session, remoteRepository);
+            if (filePath == null) {
+                filePath = baseDir.resolve(PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX);
             }
+            if (Files.isReadable(filePath)) {
+                logger.debug(
+                        "Loading prefixes for remote repository {} from file '{}'", remoteRepository.getId(), filePath);
+                try (Stream<String> lines = Files.lines(filePath, StandardCharsets.UTF_8)) {
+                    PrefixTree prefixTree = new PrefixTree("");
+                    int rules = prefixTree.loadNodes(lines);
+                    logger.info("Loaded {} prefixes for remote repository {}", rules, remoteRepository.getId());
+                    return prefixTree;
+                } catch (FileNotFoundException e) {
+                    // strange: we tested for it above, still, we should not fail
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            logger.debug("Prefix file for remote repository {} not found at '{}'", remoteRepository, filePath);
+            return PrefixTree.SENTINEL;
         }
-        LOGGER.debug("Prefix file for remote repository {} not found at '{}'", remoteRepository, filePath);
-        return NOT_PRESENT_NODE;
+        logger.debug("Prefix file for remote repository {} disabled", remoteRepository);
+        return PrefixTree.SENTINEL;
+    }
+
+    private Path resolvePrefixesFromRemoteRepository(
+            RepositorySystemSession session, RemoteRepository remoteRepository) {
+        MetadataRequest request =
+                new MetadataRequest(new DefaultMetadata(PREFIX_FILE_PATH, Metadata.Nature.RELEASE_OR_SNAPSHOT));
+        request.setRepository(remoteRepository);
+        request.setDeleteLocalCopyIfMissing(true);
+        request.setFavorLocalRepository(true);
+        MetadataResult result = repositorySystem
+                .resolveMetadata(session, Collections.singleton(request))
+                .get(0);
+        if (result.isResolved()) {
+            return result.getMetadata().getPath();
+        } else {
+            return null;
+        }
     }
 
     private class PrefixesFilter implements RemoteRepositoryFilter {
         private final RepositorySystemSession session;
-
         private final Path basedir;
 
         private PrefixesFilter(RepositorySystemSession session, Path basedir) {
@@ -221,68 +243,18 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         }
 
         private Result acceptPrefix(RemoteRepository remoteRepository, String path) {
-            Node root = cacheNode(basedir, remoteRepository);
-            if (NOT_PRESENT_NODE == root) {
+            PrefixTree prefixTree = cachePrefixTree(session, basedir, remoteRepository);
+            if (PrefixTree.SENTINEL == prefixTree) {
                 return NOT_PRESENT_RESULT;
             }
-            List<String> prefix = new ArrayList<>();
-            final List<String> pathElements = elementsOf(path);
-            Node currentNode = root;
-            for (String pathElement : pathElements) {
-                prefix.add(pathElement);
-                currentNode = currentNode.getSibling(pathElement);
-                if (currentNode == null || currentNode.isLeaf()) {
-                    break;
-                }
-            }
-            if (currentNode != null && currentNode.isLeaf()) {
-                return new SimpleResult(
-                        true, "Prefix " + String.join("/", prefix) + " allowed from " + remoteRepository);
+            if (prefixTree.acceptedPath(path)) {
+                return new SimpleResult(true, "Path " + path + " allowed from " + remoteRepository);
             } else {
-                return new SimpleResult(
-                        false, "Prefix " + String.join("/", prefix) + " NOT allowed from " + remoteRepository);
+                return new SimpleResult(false, "Prefix " + path + " NOT allowed from " + remoteRepository);
             }
         }
     }
-
-    private static final Node NOT_PRESENT_NODE = new Node("not-present-node");
 
     private static final RemoteRepositoryFilter.Result NOT_PRESENT_RESULT =
             new SimpleResult(true, "Prefix file not present");
-
-    private static class Node {
-        private final String name;
-
-        private final HashMap<String, Node> siblings;
-
-        private Node(String name) {
-            this.name = name;
-            this.siblings = new HashMap<>();
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public boolean isLeaf() {
-            return siblings.isEmpty();
-        }
-
-        public Node addSibling(String name) {
-            Node sibling = siblings.get(name);
-            if (sibling == null) {
-                sibling = new Node(name);
-                siblings.put(name, sibling);
-            }
-            return sibling;
-        }
-
-        public Node getSibling(String name) {
-            return siblings.get(name);
-        }
-    }
-
-    private static List<String> elementsOf(final String path) {
-        return Arrays.stream(path.split("/")).filter(e -> !e.isEmpty()).collect(toList());
-    }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
@@ -54,7 +54,7 @@ public abstract class RemoteRepositoryFilterSourceSupport implements RemoteRepos
     /**
      * Returns {@code true} if session configuration contains this name set to {@code true}.
      * <p>
-     * Default is {@code false}.
+     * Default is {@code true}.
      */
     protected abstract boolean isEnabled(RepositorySystemSession session);
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/GroupTree.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/GroupTree.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter.ruletree;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Group tree for Maven groupIDs.
+ * This class parses a text file that has a directive on each line. Directive examples:
+ * <ul>
+ *     <li>ignored/formatting - each line starting with {@code '#'} (hash) or being empty/blank is ignored.</li>
+ *     <li>modifier {@code !} is negation (disallow; by def entry allows). If present must be first character.</li>
+ *     <li>modifier {@code =} is limiter (to given G; by def is "G and below"). If present, must be first character. If negation present, must be second character.</li>
+ *     <li>a valid Maven groupID ie "org.apache.maven".</li>
+ * </ul>
+ * By default, a G entry ie {@code org.apache.maven} means "allow {@code org.apache.maven} G and all Gs below
+ * (so {@code org.apache.maven.plugins} etc. are all allowed).
+ *
+ * Examples:
+ * <pre>
+ * {@code
+ * # this is my group filter list
+ *
+ * org.apache.maven
+ * !=org.apache.maven.foo
+ * !org.apache.maven.indexer
+ * =org.apache.bar
+ * }
+ * </pre>
+ *
+ * File meaning: "allow all {@code org.apache.maven} and below", "disallow {@code org.apache.maven.foo} groupId ONLY"
+ * (hence {@code org.apache.maven.foo.bar} is allowed due first line), "disallow {@code org.apache.maven.indexer} and below"
+ * and "allow {@code org.apache.bar} groupID ONLY".
+ *
+ * <p>
+ * In case of conflicting rules, parsing happens by "first wins", so line closer to first line in file "wins", and conflicting
+ * line is ignored.
+ */
+public class GroupTree extends Node {
+    public static final GroupTree SENTINEL = new GroupTree("sentinel");
+
+    private static final String MOD_EXCLUSION = "!";
+    private static final String MOD_STOP = "=";
+
+    private static List<String> elementsOfGroup(final String groupId) {
+        return Arrays.stream(groupId.split("\\.")).filter(e -> !e.isEmpty()).collect(toList());
+    }
+
+    public GroupTree(String name) {
+        super(name, false, null);
+    }
+
+    public int loadNodes(Stream<String> linesStream) {
+        AtomicInteger counter = new AtomicInteger(0);
+        linesStream.forEach(line -> {
+            if (loadNode(line)) {
+                counter.incrementAndGet();
+            }
+        });
+        return counter.get();
+    }
+
+    public boolean loadNode(String line) {
+        if (!line.startsWith("#") && !line.trim().isEmpty()) {
+            Node currentNode = this;
+            boolean allow = true;
+            if (line.startsWith(MOD_EXCLUSION)) {
+                allow = false;
+                line = line.substring(MOD_EXCLUSION.length());
+            }
+            boolean stop = false;
+            if (line.startsWith(MOD_STOP)) {
+                stop = true;
+                line = line.substring(MOD_STOP.length());
+            }
+            List<String> groupElements = elementsOfGroup(line);
+            for (String groupElement : groupElements.subList(0, groupElements.size() - 1)) {
+                currentNode = currentNode.addSibling(groupElement, false, null);
+            }
+            currentNode.addSibling(groupElements.get(groupElements.size() - 1), stop, allow);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean acceptedGroupId(String groupId) {
+        final List<String> current = new ArrayList<>();
+        final List<String> groupElements = elementsOfGroup(groupId);
+        Boolean accepted = null;
+        Node currentNode = this;
+        for (String groupElement : groupElements) {
+            current.add(groupElement);
+            currentNode = currentNode.getSibling(groupElement);
+            if (currentNode == null) {
+                break;
+            }
+            if (currentNode.isStop() && groupElements.equals(current)) {
+                accepted = currentNode.isAllow();
+            } else if (!currentNode.isStop()) {
+                accepted = currentNode.isAllow();
+            }
+        }
+        return accepted != null && accepted;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/Node.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/Node.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter.ruletree;
+
+import java.util.HashMap;
+
+/**
+ * A tree structure with rules.
+ */
+class Node {
+    private final String name;
+    private final boolean stop;
+    private final Boolean allow;
+    private final HashMap<String, Node> siblings;
+
+    protected Node(String name, boolean stop, Boolean allow) {
+        this.name = name;
+        this.stop = stop;
+        this.allow = allow;
+        this.siblings = new HashMap<>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isLeaf() {
+        return siblings.isEmpty();
+    }
+
+    public boolean isStop() {
+        return stop;
+    }
+
+    public Boolean isAllow() {
+        return allow;
+    }
+
+    protected Node addSibling(String name, boolean stop, Boolean allow) {
+        return siblings.computeIfAbsent(name, n -> new Node(n, stop, allow));
+    }
+
+    protected Node getSibling(String name) {
+        return siblings.get(name);
+    }
+
+    @Override
+    public String toString() {
+        return (allow != null ? (allow ? "+" : "-") : "?") + (stop ? "=" : "") + name;
+    }
+
+    public void dump(String prefix) {
+        System.out.println(prefix + this);
+        for (Node node : siblings.values()) {
+            node.dump(prefix + "  ");
+        }
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTree.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTree.java
@@ -26,7 +26,20 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Prefix tree for paths: if you step on a path that exists, you are good to go.
+ * Prefix tree for paths: if you step on a path prefix that exists, you are good to go.
+ * This class parses a text file that has a prefix on each line:
+ * <ul>
+ *     <li>ignored/formatting - each line starting with {@code '#'} (hash) or being empty/blank is ignored.</li>
+ *     <li>a path prefix  ie "/org/apache/maven".</li>
+ * </ul>
+ * By default, artifact is allowed if layout converted path of it has a matching prefix in this file.
+ *
+ * Example prefix files:
+ * <ul>
+ *     <li><a href="https://repo.maven.apache.org/maven2/.meta/prefixes.txt">Maven Central</a></li>
+ *     <li><a href="https://repository.apache.org/content/repositories/releases/.meta/prefixes.txt">ASF Releases</a></li>
+ *     <li><a href="https://repo.eclipse.org/content/repositories/tycho/.meta/prefixes.txt">Eclipse Tycho</a></li>
+ * </ul>
  */
 public class PrefixTree extends Node {
     public static final PrefixTree SENTINEL = new PrefixTree("sentinel");
@@ -42,15 +55,22 @@ public class PrefixTree extends Node {
     public int loadNodes(Stream<String> linesStream) {
         AtomicInteger counter = new AtomicInteger(0);
         linesStream.forEach(line -> {
-            if (!line.startsWith("#") && !line.trim().isEmpty()) {
+            if (loadNode(line)) {
                 counter.incrementAndGet();
-                Node currentNode = this;
-                for (String element : elementsOfPath(line)) {
-                    currentNode = currentNode.addSibling(element, false, null);
-                }
             }
         });
         return counter.get();
+    }
+
+    public boolean loadNode(String line) {
+        if (!line.startsWith("#") && !line.trim().isEmpty()) {
+            Node currentNode = this;
+            for (String element : elementsOfPath(line)) {
+                currentNode = currentNode.addSibling(element, false, null);
+            }
+            return true;
+        }
+        return false;
     }
 
     public boolean acceptedPath(String path) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTree.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTree.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter.ruletree;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Prefix tree for paths: if you step on a path that exists, you are good to go.
+ */
+public class PrefixTree extends Node {
+    public static final PrefixTree SENTINEL = new PrefixTree("sentinel");
+
+    private static List<String> elementsOfPath(final String path) {
+        return Arrays.stream(path.split("/")).filter(e -> !e.isEmpty()).collect(toList());
+    }
+
+    public PrefixTree(String name) {
+        super(name, false, null);
+    }
+
+    public int loadNodes(Stream<String> linesStream) {
+        AtomicInteger counter = new AtomicInteger(0);
+        linesStream.forEach(line -> {
+            if (!line.startsWith("#") && !line.trim().isEmpty()) {
+                counter.incrementAndGet();
+                Node currentNode = this;
+                for (String element : elementsOfPath(line)) {
+                    currentNode = currentNode.addSibling(element, false, null);
+                }
+            }
+        });
+        return counter.get();
+    }
+
+    public boolean acceptedPath(String path) {
+        final List<String> pathElements = elementsOfPath(path);
+        Node currentNode = this;
+        for (String pathElement : pathElements) {
+            currentNode = currentNode.getSibling(pathElement);
+            if (currentNode == null || currentNode.isLeaf()) {
+                break;
+            }
+        }
+        return currentNode != null && currentNode.isLeaf();
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
@@ -45,9 +45,10 @@ public class GroupIdRemoteRepositoryFilterSourceTest extends RemoteRepositoryFil
     }
 
     @Override
-    protected void enableSource(DefaultRepositorySystemSession session) {
+    protected void enableSource(DefaultRepositorySystemSession session, boolean enabled) {
         session.setConfigProperty(
-                "aether.remoteRepositoryFilter." + GroupIdRemoteRepositoryFilterSource.NAME, Boolean.TRUE.toString());
+                "aether.remoteRepositoryFilter." + GroupIdRemoteRepositoryFilterSource.NAME,
+                Boolean.valueOf(enabled).toString());
     }
 
     protected void allowArtifact(
@@ -61,7 +62,7 @@ public class GroupIdRemoteRepositoryFilterSourceTest extends RemoteRepositoryFil
             artifactResult.setArtifact(resolvedArtifact);
             artifactResult.setRepository(remoteRepository);
             List<ArtifactResult> artifactResults = Collections.singletonList(artifactResult);
-            enableSource(newSession);
+            enableSource(newSession, true);
             newSession.setConfigProperty(
                     "aether.remoteRepositoryFilter." + GroupIdRemoteRepositoryFilterSource.NAME + ".record",
                     Boolean.TRUE.toString());

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
@@ -74,8 +74,7 @@ public class PrefixesRemoteRepositoryFilterSourceTest extends RemoteRepositoryFi
             DefaultRepositorySystemSession session, RemoteRepository remoteRepository, Artifact artifact) {
         try {
             Path baseDir = session.getLocalRepository()
-                    .getBasedir()
-                    .toPath()
+                    .getBasePath()
                     .resolve(PrefixesRemoteRepositoryFilterSource.LOCAL_REPO_PREFIX_DIR);
             Path groupId = baseDir.resolve(PrefixesRemoteRepositoryFilterSource.PREFIXES_FILE_PREFIX
                     + remoteRepository.getId()

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
@@ -27,9 +27,9 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.impl.MetadataResolver;
 import org.eclipse.aether.internal.impl.DefaultArtifactPredicateFactory;
 import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
@@ -52,14 +52,14 @@ public class PrefixesRemoteRepositoryFilterSourceTest extends RemoteRepositoryFi
             DefaultRepositorySystemSession session, RemoteRepository remoteRepository) {
         // in test we do not resolve; just reply failed resolution
         MetadataResult failed = new MetadataResult(new MetadataRequest());
-        RepositorySystem repositorySystem = mock(RepositorySystem.class);
-        when(repositorySystem.resolveMetadata(any(RepositorySystemSession.class), any(Collection.class)))
+        MetadataResolver metadataResolver = mock(MetadataResolver.class);
+        when(metadataResolver.resolveMetadata(any(RepositorySystemSession.class), any(Collection.class)))
                 .thenReturn(Collections.singletonList(failed));
         DefaultRepositoryLayoutProvider layoutProvider = new DefaultRepositoryLayoutProvider(Collections.singletonMap(
                 Maven2RepositoryLayoutFactory.NAME,
                 new Maven2RepositoryLayoutFactory(
                         checksumsSelector(), new DefaultArtifactPredicateFactory(checksumsSelector()))));
-        return new PrefixesRemoteRepositoryFilterSource(repositorySystem, layoutProvider);
+        return new PrefixesRemoteRepositoryFilterSource(() -> metadataResolver, layoutProvider);
     }
 
     @Override

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSourceTest.java
@@ -50,9 +50,10 @@ public class PrefixesRemoteRepositoryFilterSourceTest extends RemoteRepositoryFi
     }
 
     @Override
-    protected void enableSource(DefaultRepositorySystemSession session) {
+    protected void enableSource(DefaultRepositorySystemSession session, boolean enabled) {
         session.setConfigProperty(
-                "aether.remoteRepositoryFilter." + PrefixesRemoteRepositoryFilterSource.NAME, Boolean.TRUE.toString());
+                "aether.remoteRepositoryFilter." + PrefixesRemoteRepositoryFilterSource.NAME,
+                Boolean.valueOf(enabled).toString());
     }
 
     @Override

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceTestSupport.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceTestSupport.java
@@ -54,13 +54,14 @@ public abstract class RemoteRepositoryFilterSourceTestSupport {
     protected abstract RemoteRepositoryFilterSource getRemoteRepositoryFilterSource(
             DefaultRepositorySystemSession session, RemoteRepository remoteRepository);
 
-    protected abstract void enableSource(DefaultRepositorySystemSession session);
+    protected abstract void enableSource(DefaultRepositorySystemSession session, boolean enabled);
 
     protected abstract void allowArtifact(
             DefaultRepositorySystemSession session, RemoteRepository remoteRepository, Artifact artifact);
 
     @Test
     void notEnabled() {
+        enableSource(session, false);
         RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter(session);
         assertNull(filter);
     }
@@ -68,7 +69,7 @@ public abstract class RemoteRepositoryFilterSourceTestSupport {
     @Test
     void acceptedArtifact() {
         allowArtifact(session, remoteRepository, acceptedArtifact);
-        enableSource(session);
+        enableSource(session, true);
 
         RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter(session);
         assertNotNull(filter);
@@ -82,7 +83,7 @@ public abstract class RemoteRepositoryFilterSourceTestSupport {
     @Test
     void notAcceptedArtifact() {
         allowArtifact(session, remoteRepository, acceptedArtifact);
-        enableSource(session);
+        enableSource(session, true);
 
         RemoteRepositoryFilter filter = subject.getRemoteRepositoryFilter(session);
         assertNotNull(filter);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/ruletree/GroupTreeTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/ruletree/GroupTreeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter.ruletree;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UT for {@link GroupTree}.
+ */
+public class GroupTreeTest {
+    @Test
+    void smoke() {
+        GroupTree groupTree = new GroupTree("root");
+        groupTree.loadNodes(Stream.of(
+                "# comment",
+                "",
+                "org.apache.maven",
+                "!=org.apache.maven.foo",
+                "!org.apache.maven.bar",
+                "=org.apache.baz"));
+        assertTrue(groupTree.acceptedGroupId("org.apache.maven"));
+        assertTrue(groupTree.acceptedGroupId("org.apache.maven.aaa"));
+
+        assertFalse(groupTree.acceptedGroupId("org.apache.maven.foo"));
+        assertTrue(groupTree.acceptedGroupId("org.apache.maven.foo.aaa"));
+
+        assertFalse(groupTree.acceptedGroupId("org.apache.maven.bar"));
+        assertFalse(groupTree.acceptedGroupId("org.apache.maven.bar.aaa"));
+
+        assertTrue(groupTree.acceptedGroupId("org.apache.baz"));
+        assertFalse(groupTree.acceptedGroupId("org.apache.baz.aaa"));
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTreeTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/ruletree/PrefixTreeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.filter.ruletree;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UT for {@link PrefixTree}.
+ */
+public class PrefixTreeTest {
+    @Test
+    void smoke() {
+        PrefixTree prefixTree = new PrefixTree("root");
+        prefixTree.loadNodes(Stream.of("# comment", "", "/org/apache/maven"));
+        assertTrue(prefixTree.acceptedPath("/org/apache/maven"));
+        assertTrue(prefixTree.acceptedPath("/org/apache/maven/aaa"));
+
+        assertFalse(prefixTree.acceptedPath("/org/apache/baz"));
+        assertFalse(prefixTree.acceptedPath("/org/apache/baz/aaa"));
+    }
+}

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -128,6 +128,13 @@
       <version>3.0.1</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- just build time -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -522,7 +522,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle()));
         result.put(
                 PrefixesRemoteRepositoryFilterSource.NAME,
-                new PrefixesRemoteRepositoryFilterSource(getRepositoryLayoutProvider()));
+                new PrefixesRemoteRepositoryFilterSource(this::getMetadataResolver, getRepositoryLayoutProvider()));
         return result;
     }
 

--- a/maven-resolver-supplier-mvn4/pom.xml
+++ b/maven-resolver-supplier-mvn4/pom.xml
@@ -123,6 +123,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <!-- just build time -->
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -526,7 +526,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle()));
         result.put(
                 PrefixesRemoteRepositoryFilterSource.NAME,
-                new PrefixesRemoteRepositoryFilterSource(getRepositoryLayoutProvider()));
+                new PrefixesRemoteRepositoryFilterSource(this::getMetadataResolver, getRepositoryLayoutProvider()));
         return result;
     }
 

--- a/src/site/markdown/remote-repository-filtering.md
+++ b/src/site/markdown/remote-repository-filtering.md
@@ -116,7 +116,8 @@ As this file is (automatically) published by MC and MRMs, and using them is the 
 discovered and cached (just like any artifact from given remote repository).
 
 Manual authoring of these files, while possible, is not recommended. The best is to keep them up to date by
-downloading the published files from the remote repositories.
+downloading the published files from the remote repositories. In ideal circumstances no user intervention is needed
+as remote repository should publish prefix file and discovery should discover it.
 
 Many MRMs and Maven Central itself publish these files. Some prefixes file examples:
 * Maven Central [prefixes.txt](https://repo.maven.apache.org/maven2/.meta/prefixes.txt)


### PR DESCRIPTION
High level new features and changes:
* (change) filtering is **enabled by default**
* (new) filtering can be suppressed on per-repository basis by appending configuration key with `.repoId=false`.
* (change) both filters enhanced to become really usable.

## GroupId filter

Is enabled by default (but remains dormant if user does not provides input). It becomes active only when user provides input for it.

Input vastly improved and now supports modifiers as well (Resolver 1.x modus operandi was `=org.apache` ONLY). Hence, upgrading from Resolver 1.x to Resolver 2.x leads to "broadened" filtering but that is fine is was user usually wants (Resolver 1.x had to enumerate all Gs for nested G, ie `org.apache.maven`, `org.apache.maven.plugins` etc... same effect with Resolver 2.x is one liner: `org.apache.maven` (as it means now "and below"). Added support for negation (`!`) and limiter (`=`). Example groupId filter file:

```
# My file                   (1)
                            (2)
org.apache.maven            (3)
!=org.apache.maven.foo      (4)
!org.apache.maven.indexer   (5)
=org.apache.bar             (6)
```
Lines 1, 2 ignored. Line 3 "allow `org.apache.maven` and below". Line 4 "not allow `org.apache.maven.foo` only". Line 5 "not allow `org.apache.maven.indexer` and below". Line 6 "allow `org.apache.bar` only".

## Prefix filter

Is enabled by default and improved to try to auto-discover prefix file published by remote repository. If prefix file is discovered, common resolver means are used to resolve and cache the prefix file in user local repository. If discovery fails, user provided prefix file is attempted (and used, if found). Finally, if no input, filter will not interfere. Order of precedence:
* user provided prefix file (if found, will be used, no discovery happens)
* auto discovery

Caching is now possible with fix done in https://github.com/apache/maven-resolver/pull/1491