### PR TITLE
ConflictResolver improvements, preparations

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictIdSorter.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictIdSorter.java
@@ -41,9 +41,9 @@ import static java.util.Objects.requireNonNull;
  * transformer will query the key {@link TransformationContextKeys#CONFLICT_IDS} in the transformation context for an
  * existing mapping of nodes to their conflicts ids. In absence of this map, the transformer will automatically invoke
  * the {@link ConflictMarker} to calculate the conflict ids. When this transformer has executed, the transformation
- * context holds a {@code List<Object>} that denotes the topologically sorted conflict ids. The list will be stored
+ * context holds a {@code List<String>} that denotes the topologically sorted conflict ids. The list will be stored
  * using the key {@link TransformationContextKeys#SORTED_CONFLICT_IDS}. In addition, the transformer will store a
- * {@code Collection<Collection<Object>>} using the key {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} that
+ * {@code Collection<Collection<String>>} using the key {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} that
  * describes cycles among conflict ids.
  */
 public final class ConflictIdSorter implements DependencyGraphTransformer {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictIdSorter.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictIdSorter.java
@@ -53,28 +53,29 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
             throws RepositoryException {
         requireNonNull(node, "node cannot be null");
         requireNonNull(context, "context cannot be null");
-        Map<?, ?> conflictIds = (Map<?, ?>) context.get(TransformationContextKeys.CONFLICT_IDS);
+        Map<DependencyNode, String> conflictIds =
+                (Map<DependencyNode, String>) context.get(TransformationContextKeys.CONFLICT_IDS);
         if (conflictIds == null) {
             ConflictMarker marker = new ConflictMarker();
             marker.transformGraph(node, context);
 
-            conflictIds = (Map<?, ?>) context.get(TransformationContextKeys.CONFLICT_IDS);
+            conflictIds = (Map<DependencyNode, String>) context.get(TransformationContextKeys.CONFLICT_IDS);
         }
 
         @SuppressWarnings("unchecked")
         Map<String, Object> stats = (Map<String, Object>) context.get(TransformationContextKeys.STATS);
         long time1 = System.nanoTime();
 
-        Map<Object, ConflictId> ids = new LinkedHashMap<>(256);
+        Map<String, ConflictId> ids = new LinkedHashMap<>(256);
 
         ConflictId id = null;
-        Object key = conflictIds.get(node);
+        String key = conflictIds.get(node);
         if (key != null) {
             id = new ConflictId(key, 0);
             ids.put(key, id);
         }
 
-        Map<DependencyNode, Object> visited = new IdentityHashMap<>(conflictIds.size());
+        Map<DependencyNode, Boolean> visited = new IdentityHashMap<>(conflictIds.size());
 
         buildConflictIdDAG(ids, node, id, 0, visited, conflictIds);
 
@@ -94,12 +95,12 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
     }
 
     private void buildConflictIdDAG(
-            Map<Object, ConflictId> ids,
+            Map<String, ConflictId> ids,
             DependencyNode node,
             ConflictId id,
             int depth,
-            Map<DependencyNode, Object> visited,
-            Map<?, ?> conflictIds) {
+            Map<DependencyNode, Boolean> visited,
+            Map<DependencyNode, String> conflictIds) {
         if (visited.put(node, Boolean.TRUE) != null) {
             return;
         }
@@ -107,7 +108,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
         depth++;
 
         for (DependencyNode child : node.getChildren()) {
-            Object key = conflictIds.get(child);
+            String key = conflictIds.get(child);
             ConflictId childId = ids.get(key);
             if (childId == null) {
                 childId = new ConflictId(key, depth);
@@ -125,7 +126,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
     }
 
     private int topsortConflictIds(Collection<ConflictId> conflictIds, DependencyGraphTransformationContext context) {
-        List<Object> sorted = new ArrayList<>(conflictIds.size());
+        List<String> sorted = new ArrayList<>(conflictIds.size());
 
         RootQueue roots = new RootQueue(conflictIds.size() / 2);
         for (ConflictId id : conflictIds) {
@@ -159,7 +160,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
             processRoots(sorted, roots);
         }
 
-        Collection<Collection<Object>> cycles = Collections.emptySet();
+        Collection<Collection<String>> cycles = Collections.emptySet();
         if (cycle) {
             cycles = findCycles(conflictIds);
         }
@@ -170,7 +171,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
         return cycles.size();
     }
 
-    private void processRoots(List<Object> sorted, RootQueue roots) {
+    private void processRoots(List<String> sorted, RootQueue roots) {
         while (!roots.isEmpty()) {
             ConflictId root = roots.remove();
 
@@ -185,11 +186,11 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
         }
     }
 
-    private Collection<Collection<Object>> findCycles(Collection<ConflictId> conflictIds) {
-        Collection<Collection<Object>> cycles = new HashSet<>();
+    private Collection<Collection<String>> findCycles(Collection<ConflictId> conflictIds) {
+        Collection<Collection<String>> cycles = new HashSet<>();
 
-        Map<Object, Integer> stack = new HashMap<>(128);
-        Map<ConflictId, Object> visited = new IdentityHashMap<>(conflictIds.size());
+        Map<String, Integer> stack = new HashMap<>(128);
+        Map<ConflictId, Boolean> visited = new IdentityHashMap<>(conflictIds.size());
         for (ConflictId id : conflictIds) {
             findCycles(id, visited, stack, cycles);
         }
@@ -199,14 +200,14 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
 
     private void findCycles(
             ConflictId id,
-            Map<ConflictId, Object> visited,
-            Map<Object, Integer> stack,
-            Collection<Collection<Object>> cycles) {
+            Map<ConflictId, Boolean> visited,
+            Map<String, Integer> stack,
+            Collection<Collection<String>> cycles) {
         Integer depth = stack.put(id.key, stack.size());
         if (depth != null) {
             stack.put(id.key, depth);
-            Collection<Object> cycle = new HashSet<>();
-            for (Map.Entry<Object, Integer> entry : stack.entrySet()) {
+            Collection<String> cycle = new HashSet<>();
+            for (Map.Entry<String, Integer> entry : stack.entrySet()) {
                 if (entry.getValue() >= depth) {
                     cycle.add(entry.getKey());
                 }
@@ -224,7 +225,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
 
     static final class ConflictId {
 
-        final Object key;
+        final String key;
 
         Collection<ConflictId> children = Collections.emptySet();
 
@@ -232,7 +233,7 @@ public final class ConflictIdSorter implements DependencyGraphTransformer {
 
         int minDepth;
 
-        ConflictId(Object key, int depth) {
+        ConflictId(String key, int depth) {
             this.key = key;
             this.minDepth = depth;
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictMarker.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictMarker.java
@@ -38,7 +38,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A dependency graph transformer that identifies conflicting dependencies. When this transformer has executed, the
- * transformation context holds a {@code Map<DependencyNode, Object>} where dependency nodes that belong to the same
+ * transformation context holds a {@code Map<DependencyNode, String>} where dependency nodes that belong to the same
  * conflict group will have an equal conflict identifier. This map is stored using the key
  * {@link TransformationContextKeys#CONFLICT_IDS}.
  */

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictResolver.java
@@ -520,7 +520,7 @@ public final class ConflictResolver implements DependencyGraphTransformer {
          * The set of nodes on the DFS stack to detect cycles, technically keyed by the node's child list to match the
          * dirty graph structure produced by the dependency collector for cycles.
          */
-        final Map<List<DependencyNode>, Object> stack;
+        final Map<List<DependencyNode>, Boolean> stack;
 
         /**
          * The stack of parent nodes.

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/SimpleConflictMarker.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/SimpleConflictMarker.java
@@ -40,8 +40,8 @@ class SimpleConflictMarker implements DependencyGraphTransformer {
         requireNonNull(node, "node cannot be null");
         requireNonNull(context, "context cannot be null");
         @SuppressWarnings("unchecked")
-        Map<DependencyNode, Object> conflictIds =
-                (Map<DependencyNode, Object>) context.get(TransformationContextKeys.CONFLICT_IDS);
+        Map<DependencyNode, String> conflictIds =
+                (Map<DependencyNode, String>) context.get(TransformationContextKeys.CONFLICT_IDS);
         if (conflictIds == null) {
             conflictIds = new IdentityHashMap<>();
             context.put(TransformationContextKeys.CONFLICT_IDS, conflictIds);
@@ -52,7 +52,7 @@ class SimpleConflictMarker implements DependencyGraphTransformer {
         return node;
     }
 
-    private void mark(DependencyNode node, Map<DependencyNode, Object> conflictIds) {
+    private void mark(DependencyNode node, Map<DependencyNode, String> conflictIds) {
         Dependency dependency = node.getDependency();
         if (dependency != null) {
             Artifact artifact = dependency.getArtifact();


### PR DESCRIPTION
Improvements to conflict resolver, step one: cleanup and return type safety. This codebase is last that is 100% equal between Resolver 1 and Resolver 2, and was quite "dirty" at least what type safety matters. On may places `Object` was used as type. This PR merely cleans this up, and also revealed one interesting fast: at runtime Maven used `Integer` as conflictID while in tests `String` (for easier debug). This is now aligned, and `String` is used, but at runtime it is still integer counter String representation that is interned (to retain pooled numbers behavior). 

Minor improvements added to `Key` class that now memorizes `hashCode` instead to over and over recalculate it.

After this cleanup we should be able to more easily comprehend and improve conflict resolution.
