### PR TITLE
Update to Maven 4.0.0-rc-4 and cleanup p-u usage

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -38,6 +38,22 @@
     <javaVersion>17</javaVersion>
   </properties>
 
+  <dependencyManagement>
+    <!-- we need to keep these aligned with Maven4; override mgmt from top level POM -->
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>4.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-xml</artifactId>
+        <version>4.1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -122,12 +122,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-xml</artifactId>
-      <version>3.0.1</version>
-      <scope>runtime</scope>
-    </dependency>
     <!-- just build time -->
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -68,13 +68,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>4.0.2</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-xml</artifactId>
-      <version>3.0.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <jettyVersion>10.0.25</jettyVersion>
     <!-- used by supplier and demo only -->
     <maven3Version>3.9.11</maven3Version>
-    <maven4Version>4.0.0-rc-3</maven4Version>
+    <maven4Version>4.0.0-rc-4</maven4Version>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
     <!-- MRESOLVER-422: keep this in sync with Javadoc plugin configuration (but cannot directly, as this below is range) -->
     <minimalJavaBuildVersion>[21,)</minimalJavaBuildVersion>
@@ -245,12 +245,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>4.0.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-xml</artifactId>
-        <version>4.1.0</version>
+        <version>3.6.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Update demos to use Maven 4.0.0-rc-4.

At the same time, cleanup plexus-utils usage:
* on top we use 3.6.0
* Wagon uses it but at runtime Resolver/Maven will provide it
* Tools (docgen) uses it, but is happy with 3.6.0
* Demo snippets aligned with updated Maven 4 version

Unsure what would be the best here, as demos must to override management from top level POM.