### PR TITLE
SmartExecutor: on classic pools TCCL must be delegated

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
@@ -82,12 +82,17 @@ public interface SmartExecutor extends AutoCloseable {
 
         @Override
         public <T> CompletableFuture<T> submit(Callable<T> callable) {
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
             CompletableFuture<T> future = new CompletableFuture<>();
             executor.submit(() -> {
+                ClassLoader old = Thread.currentThread().getContextClassLoader();
+                Thread.currentThread().setContextClassLoader(tccl);
                 try {
                     future.complete(callable.call());
                 } catch (Exception e) {
                     future.completeExceptionally(e);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(old);
                 }
             });
             return future;


### PR DESCRIPTION
When Maven/Resolver runs on older than Java 21, the classic thread pools are used, and TCCL must be delegated now that they are reused across session, otherwise lookup issues occurs as Plexus DI will filter components based on it.

As Maven ITs shows, on Java 17 the DAV related ITs fail. They load the DAV Wagon as build extension (from POM). This means that BF used pool is instantiated way before, and pooled threads TCCL are not "aware" of (later) loaded up build extension (IT failes are "no DAV transport available", while the extension _is loaded up_).

With this change locally the ITs pass OK on Java 17, while on Java 21 (where VTs are used) this was never an issue, as we use "one VT per task" and VT is dropped once done (they are not pooled).

Before SmartExecutors, this was not a problem in BF collector, as pools were created "in situ" and then thrown away, that was sub-optimal.