### PR TITLE
Profiling: most hot spots and possibly wasted thread.

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/scope/ScopeManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/scope/ScopeManager.java
@@ -52,7 +52,7 @@ public interface ScopeManager {
     Optional<DependencyScope> getDependencyScope(String id);
 
     /**
-     * Returns the "universe" (all) of dependency scopes.
+     * Returns the "universe" (all) of dependency scopes as immutable collection.
      */
     Collection<DependencyScope> getDependencyScopeUniverse();
 
@@ -64,7 +64,7 @@ public interface ScopeManager {
     Optional<ResolutionScope> getResolutionScope(String id);
 
     /**
-     * Returns the "universe" (all) of resolution scopes.
+     * Returns the "universe" (all) of resolution scopes as immutable collection.
      */
     Collection<ResolutionScope> getResolutionScopeUniverse();
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/ScopeManagerImpl.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/ScopeManagerImpl.java
@@ -64,7 +64,9 @@ public final class ScopeManagerImpl implements InternalScopeManager {
     private final BuildScopeSource buildScopeSource;
     private final AtomicReference<SystemDependencyScopeImpl> systemDependencyScope;
     private final Map<String, DependencyScopeImpl> dependencyScopes;
+    private final Collection<DependencyScope> dependencyScopesUniverse;
     private final Map<String, ResolutionScopeImpl> resolutionScopes;
+    private final Collection<ResolutionScope> resolutionScopesUniverse;
 
     public ScopeManagerImpl(ScopeManagerConfiguration configuration) {
         this.id = configuration.getId();
@@ -73,7 +75,9 @@ public final class ScopeManagerImpl implements InternalScopeManager {
         this.buildScopeSource = configuration.getBuildScopeSource();
         this.systemDependencyScope = new AtomicReference<>(null);
         this.dependencyScopes = Collections.unmodifiableMap(buildDependencyScopes(configuration));
+        this.dependencyScopesUniverse = Collections.unmodifiableCollection(new HashSet<>(dependencyScopes.values()));
         this.resolutionScopes = Collections.unmodifiableMap(buildResolutionScopes(configuration));
+        this.resolutionScopesUniverse = Collections.unmodifiableCollection(new HashSet<>(resolutionScopes.values()));
     }
 
     private Map<String, DependencyScopeImpl> buildDependencyScopes(ScopeManagerConfiguration configuration) {
@@ -111,7 +115,7 @@ public final class ScopeManagerImpl implements InternalScopeManager {
 
     @Override
     public Collection<DependencyScope> getDependencyScopeUniverse() {
-        return new HashSet<>(dependencyScopes.values());
+        return dependencyScopesUniverse;
     }
 
     @Override
@@ -125,7 +129,7 @@ public final class ScopeManagerImpl implements InternalScopeManager {
 
     @Override
     public Collection<ResolutionScope> getResolutionScopeUniverse() {
-        return new HashSet<>(resolutionScopes.values());
+        return resolutionScopesUniverse;
     }
 
     @Override
@@ -408,7 +412,6 @@ public final class ScopeManagerImpl implements InternalScopeManager {
     }
 
     private class ResolutionScopeImpl implements ResolutionScope {
-
         private final String id;
         private final Mode mode;
         private final Set<BuildScopeQuery> wantedPresence;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
@@ -69,11 +69,9 @@ public class GenericVersionScheme extends VersionSchemeSupport {
 
     static {
         // Register shutdown hook to print statistics if enabled
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if (isStatisticsEnabled()) {
-                printGlobalStatistics();
-            }
-        }));
+        if (isStatisticsEnabled()) {
+            Runtime.getRuntime().addShutdownHook(new Thread(GenericVersionScheme::printGlobalStatistics));
+        }
     }
 
     public GenericVersionScheme() {


### PR DESCRIPTION
Profiling, the most obvious ones. The scope manager method is HOT, as now we started using scope universe in validation that itself is very hot. These are immutable collections, so no reason to create them in ctor instead per each call.
