### PR TITLE
Rewritten ConflictResolver

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ConflictResolver.java
@@ -317,10 +317,7 @@ public final class ConflictResolver implements DependencyGraphTransformer {
                     switch (state.verbosity) {
                         case NONE:
                             // remove this dn; discard all children from winner consideration as well
-                            this.parent.children.remove(this);
-                            this.parent.dn.setChildren(new ArrayList<>(this.parent.dn.getChildren()));
-                            this.parent.dn.getChildren().remove(this.dn);
-                            this.children.clear();
+                            unlink(Integer.MAX_VALUE);
                             break;
                         case STANDARD:
                             // if same ArtifactId, just record the facts, otherwise remove this dn children as well
@@ -373,6 +370,19 @@ public final class ConflictResolver implements DependencyGraphTransformer {
             } else if (!this.dn.getChildren().isEmpty()) {
                 this.dn.setChildren(Collections.emptyList());
             }
+        }
+
+        private void unlink(int levels) {
+            int newLevels = levels - 1;
+            if (newLevels >= 0) {
+                for (CRNode child : new ArrayList<>(children)) {
+                    child.unlink(newLevels);
+                }
+            }
+            this.parent.children.remove(this);
+            this.parent.dn.setChildren(new ArrayList<>(this.parent.dn.getChildren()));
+            this.parent.dn.getChildren().remove(this.dn);
+            this.children.clear();
         }
 
         /**

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConfigurableVersionSelectorTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConfigurableVersionSelectorTest.java
@@ -217,12 +217,21 @@ public class ConfigurableVersionSelectorTest extends AbstractDependencyGraphTran
         assertSame(root, transform(root));
 
         assertEquals(2, root.getChildren().size());
-        assertEquals(1, root.getChildren().get(0).getChildren().size());
+
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        // original:
+        // assertEquals(1, root.getChildren().get(0).getChildren().size());
+        // modified:
+        assertEquals(2, root.getChildren().get(0).getChildren().size());
         DependencyNode winner = root.getChildren().get(0).getChildren().get(0);
         assertEquals("test", winner.getDependency().getScope());
         assertEquals("compile", winner.getData().get(ConflictResolver.NODE_DATA_ORIGINAL_SCOPE));
         assertEquals(false, winner.getData().get(ConflictResolver.NODE_DATA_ORIGINAL_OPTIONALITY));
-        assertEquals(1, root.getChildren().get(1).getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        // original:
+        // assertEquals(1, root.getChildren().get(1).getChildren().size());
+        // modified:
+        assertEquals(2, root.getChildren().get(1).getChildren().size());
         DependencyNode loser = root.getChildren().get(1).getChildren().get(0);
         assertEquals("test", loser.getDependency().getScope());
         assertEquals(0, loser.getChildren().size());

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
@@ -138,11 +138,13 @@ public class ConflictResolverTest {
         DependencyNode ta = versionRangeClash(a, ConflictResolver.Verbosity.STANDARD);
 
         assertSame(a, ta);
-        assertEquals(2, a.getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(3, a.getChildren().size());
         assertSame(b, a.getChildren().get(0));
         assertSame(c2, a.getChildren().get(1));
-        assertEquals(1, b.getChildren().size());
-        assertConflictedButSameAsOriginal(c2, b.getChildren().get(0));
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(2, b.getChildren().size());
+        assertConflictedButSameAsOriginal(c2, b.getChildren().get(1));
     }
 
     @Test
@@ -158,11 +160,12 @@ public class ConflictResolverTest {
 
         DependencyNode ta = versionRangeClash(a, ConflictResolver.Verbosity.FULL);
 
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
         assertSame(a, ta);
         assertEquals(3, a.getChildren().size());
         assertSame(b, a.getChildren().get(0));
-        assertConflictedButSameAsOriginal(c1, a.getChildren().get(1));
-        assertSame(c2, a.getChildren().get(2));
+        assertConflictedButSameAsOriginal(c1, a.getChildren().get(2));
+        assertSame(c2, a.getChildren().get(1));
         assertEquals(2, b.getChildren().size());
         assertConflictedButSameAsOriginal(c1, b.getChildren().get(0));
         assertConflictedButSameAsOriginal(c2, b.getChildren().get(1));
@@ -202,10 +205,12 @@ public class ConflictResolverTest {
         DependencyNode ta = versionRangeClash(a, ConflictResolver.Verbosity.STANDARD);
 
         assertSame(a, ta);
-        assertEquals(2, a.getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(3, a.getChildren().size());
         assertSame(b, a.getChildren().get(0));
         assertSame(c2, a.getChildren().get(1));
-        assertEquals(1, b.getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(2, b.getChildren().size());
         assertConflictedButSameAsOriginal(c2, b.getChildren().get(0));
     }
 
@@ -266,11 +271,13 @@ public class ConflictResolverTest {
         DependencyNode ta = versionRangeClash(a, ConflictResolver.Verbosity.STANDARD);
 
         assertSame(a, ta);
-        assertEquals(2, a.getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(3, a.getChildren().size());
         assertSame(b, a.getChildren().get(0));
         assertSame(c2, a.getChildren().get(1));
-        assertEquals(1, b.getChildren().size());
-        assertConflictedButSameAsOriginal(c2, b.getChildren().get(0));
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(2, b.getChildren().size());
+        assertConflictedButSameAsOriginal(c2, b.getChildren().get(1));
     }
 
     @Test
@@ -294,13 +301,15 @@ public class ConflictResolverTest {
         DependencyNode ta = versionRangeClash(a, ConflictResolver.Verbosity.STANDARD);
 
         assertSame(a, ta);
-        assertEquals(3, a.getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(4, a.getChildren().size());
         assertSame(b, a.getChildren().get(0));
         assertSame(c2, a.getChildren().get(1));
         assertSame(d2, a.getChildren().get(2));
-        assertEquals(2, b.getChildren().size());
-        assertConflictedButSameAsOriginal(c2, b.getChildren().get(0));
-        assertConflictedButSameAsOriginal(d1, b.getChildren().get(1));
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        assertEquals(3, b.getChildren().size());
+        assertConflictedButSameAsOriginal(c1, b.getChildren().get(0));
+        assertConflictedButSameAsOriginal(d1, b.getChildren().get(2));
     }
 
     @Test

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelectorTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelectorTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.eclipse.aether.collection.UnsolvableVersionConflictException;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.internal.test.util.DependencyGraphParser;
-import org.eclipse.aether.util.graph.visitor.DependencyGraphDumper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelectorTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/NearestVersionSelectorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.eclipse.aether.collection.UnsolvableVersionConflictException;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.internal.test.util.DependencyGraphParser;
+import org.eclipse.aether.util.graph.visitor.DependencyGraphDumper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -189,6 +190,16 @@ public class NearestVersionSelectorTest extends AbstractDependencyGraphTransform
     }
 
     @Test
+    void testExpectedSubtreeOnDescriptorDependenciesEmptyLeft() throws Exception {
+        DependencyNode root = parseResource("expectedSubtreeOnDescriptorDependenciesEmptyLeft.txt");
+
+        assertSame(root, transform(root));
+
+        // h is not lost
+        assertEquals(5, find(root, "h").size());
+    }
+
+    @Test
     void testVerboseMode() throws Exception {
         DependencyNode root = parseResource("verbose.txt");
 
@@ -196,12 +207,20 @@ public class NearestVersionSelectorTest extends AbstractDependencyGraphTransform
         assertSame(root, transform(root));
 
         assertEquals(2, root.getChildren().size());
-        assertEquals(1, root.getChildren().get(0).getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        // original:
+        // assertEquals(1, root.getChildren().get(0).getChildren().size());
+        // modified:
+        assertEquals(2, root.getChildren().get(0).getChildren().size());
         DependencyNode winner = root.getChildren().get(0).getChildren().get(0);
         assertEquals("test", winner.getDependency().getScope());
         assertEquals("compile", winner.getData().get(ConflictResolver.NODE_DATA_ORIGINAL_SCOPE));
         assertEquals(false, winner.getData().get(ConflictResolver.NODE_DATA_ORIGINAL_OPTIONALITY));
-        assertEquals(1, root.getChildren().get(1).getChildren().size());
+        // TODO: IMO original code was wrong: this is VERBOSE mode when we do not remove losers
+        // original:
+        // assertEquals(1, root.getChildren().get(1).getChildren().size());
+        // modified:
+        assertEquals(2, root.getChildren().get(1).getChildren().size());
         DependencyNode loser = root.getChildren().get(1).getChildren().get(0);
         assertEquals("test", loser.getDependency().getScope());
         assertEquals(0, loser.getChildren().size());

--- a/maven-resolver-util/src/test/resources/transformer/version-resolver/expectedSubtreeOnDescriptorDependenciesEmptyLeft.txt
+++ b/maven-resolver-util/src/test/resources/transformer/version-resolver/expectedSubtreeOnDescriptorDependenciesEmptyLeft.txt
@@ -1,0 +1,11 @@
+gid:a:jar:ver
++- gid:b:jar:ver compile
+|  \- gid:d:jar:1 compile
++- gid:c:jar:ver compile
+|  \- gid:d:jar:2 compile
+|     \- gid:g:jar:1 compile
+|        \- gid:h:jar:1 compile
+\- gid:e:jar:ver compile
+|  +- gid:f:jar:ver compile
+|  |  +- gid:g:jar:2 compile
+|  |  |  \- gid:h:jar:2 compile

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,7 @@
                     <exclude>org.eclipse.aether.ConfigurationProperties#PERSISTED_CHECKSUMS</exclude>
                     <exclude>org.eclipse.aether.ConfigurationProperties#DEFAULT_PERSISTED_CHECKSUMS</exclude>
                     <!-- ConflictResolver (these API classes should not be created by clients; ctor changes) -->
+                    <!-- TODO: this as is is wrong: i don't want to ignore whole class, just ctor changes (unsure is it possible?) -->
                     <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictItem</exclude>
                     <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictContext</exclude>
                   </excludes>
@@ -459,6 +460,7 @@
                     <exclude>org.eclipse.aether.ConfigurationProperties#PERSISTED_CHECKSUMS</exclude>
                     <exclude>org.eclipse.aether.ConfigurationProperties#DEFAULT_PERSISTED_CHECKSUMS</exclude>
                     <!-- ConflictResolver (these API classes should not be created by clients; ctor changes) -->
+                    <!-- TODO: this as is is wrong: i don't want to ignore whole class, just ctor changes (unsure is it possible?) -->
                     <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictItem</exclude>
                     <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictContext</exclude>
                   </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,9 @@
                     <!-- MRESOLVER-440 Move properties to their place and cleanup -->
                     <exclude>org.eclipse.aether.ConfigurationProperties#PERSISTED_CHECKSUMS</exclude>
                     <exclude>org.eclipse.aether.ConfigurationProperties#DEFAULT_PERSISTED_CHECKSUMS</exclude>
+                    <!-- ConflictResolver (these API classes should not be created by clients; ctor changes) -->
+                    <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictItem</exclude>
+                    <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictContext</exclude>
                   </excludes>
                   <ignoreMissingClasses>true</ignoreMissingClasses>
                   <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
@@ -455,6 +458,9 @@
                     <!-- MRESOLVER-440 Move properties to their place and cleanup -->
                     <exclude>org.eclipse.aether.ConfigurationProperties#PERSISTED_CHECKSUMS</exclude>
                     <exclude>org.eclipse.aether.ConfigurationProperties#DEFAULT_PERSISTED_CHECKSUMS</exclude>
+                    <!-- ConflictResolver (these API classes should not be created by clients; ctor changes) -->
+                    <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictItem</exclude>
+                    <exclude>org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictContext</exclude>
                   </excludes>
                   <ignoreMissingClasses>true</ignoreMissingClasses>
                   <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>


### PR DESCRIPTION
The ConflictResolver class was last bit that was identical between Resolver 1.x and 2.x and it had a nasty property: in "worst case" it has performance of O(N^2) where N=partition count, that in some projects (see projects generated with https://github.com/maven-turbo-reactor/maven-multiproject-generator) is same as module count and can be huge.

Moreover, Maven 4 does "one extra" collection, hence conflict resolution on `install` to build consumer POM. This impacted Maven performance a lot, see https://github.com/apache/maven/issues/2481

This PR rewrites the ConflictResolver and among other things fixes some weird issues how Resolver 1.x handled "verbose" mode: the promise of verbose mode (see ConflictResolver 1.x class Javadoc): "[verbose mode] ... where the graph is still  turned into a tree but **all nodes participating in a conflict are retained**" (highlighted part is NOT true for Resolver 1.x).

Hence the UT changes. Only verbose mode related UT changes happened! 

There is one UT added that comes from BF/DF resolver UTs too.

TBD