### PR TITLE
Resolver 2 provides scope manager for mvn3

### DIFF
--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/Maven3ScopeManagerConfiguration.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/Maven3ScopeManagerConfiguration.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.supplier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.impl.scope.BuildScopeMatrixSource;
+import org.eclipse.aether.impl.scope.BuildScopeSource;
+import org.eclipse.aether.impl.scope.CommonBuilds;
+import org.eclipse.aether.impl.scope.InternalScopeManager;
+import org.eclipse.aether.impl.scope.ScopeManagerConfiguration;
+import org.eclipse.aether.internal.impl.scope.ScopeManagerDump;
+import org.eclipse.aether.scope.DependencyScope;
+import org.eclipse.aether.scope.ResolutionScope;
+
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.all;
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.byBuildPath;
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.byProjectPath;
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.select;
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.singleton;
+import static org.eclipse.aether.impl.scope.BuildScopeQuery.union;
+
+/**
+ * Maven3 scope configurations. Configures scope manager to support Maven3 scopes.
+ *
+ * @since 2.0.11
+ */
+public final class Maven3ScopeManagerConfiguration implements ScopeManagerConfiguration {
+    public static final Maven3ScopeManagerConfiguration INSTANCE = new Maven3ScopeManagerConfiguration();
+    public static final String DS_COMPILE = "compile";
+    public static final String DS_RUNTIME = "runtime";
+    public static final String DS_PROVIDED = "provided";
+    public static final String DS_SYSTEM = "system";
+    public static final String DS_TEST = "test";
+    public static final String RS_NONE = "none";
+    public static final String RS_MAIN_COMPILE = "main-compile";
+    public static final String RS_MAIN_COMPILE_PLUS_RUNTIME = "main-compilePlusRuntime";
+    public static final String RS_MAIN_RUNTIME = "main-runtime";
+    public static final String RS_MAIN_RUNTIME_PLUS_SYSTEM = "main-runtimePlusSystem";
+    public static final String RS_TEST_COMPILE = "test-compile";
+    public static final String RS_TEST_RUNTIME = "test-runtime";
+
+    private Maven3ScopeManagerConfiguration() {}
+
+    @Override
+    public String getId() {
+        return "Maven3";
+    }
+
+    @Override
+    public boolean isStrictDependencyScopes() {
+        return false;
+    }
+
+    @Override
+    public boolean isStrictResolutionScopes() {
+        return false;
+    }
+
+    @Override
+    public BuildScopeSource getBuildScopeSource() {
+        return new BuildScopeMatrixSource(
+                Collections.singletonList(CommonBuilds.PROJECT_PATH_MAIN),
+                Arrays.asList(CommonBuilds.BUILD_PATH_COMPILE, CommonBuilds.BUILD_PATH_RUNTIME),
+                CommonBuilds.MAVEN_TEST_BUILD_SCOPE);
+    }
+
+    @Override
+    public Collection<DependencyScope> buildDependencyScopes(InternalScopeManager internalScopeManager) {
+        ArrayList<DependencyScope> result = new ArrayList<>();
+        result.add(internalScopeManager.createDependencyScope(DS_COMPILE, true, all()));
+        result.add(internalScopeManager.createDependencyScope(
+                DS_RUNTIME, true, byBuildPath(CommonBuilds.BUILD_PATH_RUNTIME)));
+        result.add(internalScopeManager.createDependencyScope(
+                DS_PROVIDED,
+                false,
+                union(
+                        byBuildPath(CommonBuilds.BUILD_PATH_COMPILE),
+                        select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_RUNTIME))));
+        result.add(internalScopeManager.createDependencyScope(
+                DS_TEST, false, byProjectPath(CommonBuilds.PROJECT_PATH_TEST)));
+        result.add(internalScopeManager.createSystemDependencyScope(
+                DS_SYSTEM, false, all(), ArtifactProperties.LOCAL_PATH));
+        return result;
+    }
+
+    @Override
+    public Collection<ResolutionScope> buildResolutionScopes(InternalScopeManager internalScopeManager) {
+        Collection<DependencyScope> allDependencyScopes = internalScopeManager.getDependencyScopeUniverse();
+        Collection<DependencyScope> nonTransitiveDependencyScopes =
+                allDependencyScopes.stream().filter(s -> !s.isTransitive()).collect(Collectors.toSet());
+        DependencyScope system =
+                internalScopeManager.getDependencyScope(DS_SYSTEM).orElse(null);
+
+        ArrayList<ResolutionScope> result = new ArrayList<>();
+        result.add(internalScopeManager.createResolutionScope(
+                RS_NONE,
+                InternalScopeManager.Mode.REMOVE,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                allDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_MAIN_COMPILE,
+                InternalScopeManager.Mode.ELIMINATE,
+                singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_COMPILE),
+                Collections.singletonList(system),
+                nonTransitiveDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_MAIN_COMPILE_PLUS_RUNTIME,
+                InternalScopeManager.Mode.ELIMINATE,
+                byProjectPath(CommonBuilds.PROJECT_PATH_MAIN),
+                Collections.singletonList(system),
+                nonTransitiveDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_MAIN_RUNTIME,
+                InternalScopeManager.Mode.ELIMINATE,
+                singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_RUNTIME),
+                Collections.emptySet(),
+                nonTransitiveDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_MAIN_RUNTIME_PLUS_SYSTEM,
+                InternalScopeManager.Mode.ELIMINATE,
+                singleton(CommonBuilds.PROJECT_PATH_MAIN, CommonBuilds.BUILD_PATH_RUNTIME),
+                Collections.singletonList(system),
+                nonTransitiveDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_TEST_COMPILE,
+                InternalScopeManager.Mode.ELIMINATE,
+                select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_COMPILE),
+                Collections.singletonList(system),
+                nonTransitiveDependencyScopes));
+        result.add(internalScopeManager.createResolutionScope(
+                RS_TEST_RUNTIME,
+                InternalScopeManager.Mode.ELIMINATE,
+                select(CommonBuilds.PROJECT_PATH_TEST, CommonBuilds.BUILD_PATH_RUNTIME),
+                Collections.singletonList(system),
+                nonTransitiveDependencyScopes));
+        return result;
+    }
+
+    // ===
+
+    public static void main(String... args) {
+        ScopeManagerDump.dump(Maven3ScopeManagerConfiguration.INSTANCE);
+    }
+}

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -32,19 +32,19 @@ import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.DependencyTraverser;
+import org.eclipse.aether.internal.impl.scope.ManagedDependencyContextRefiner;
+import org.eclipse.aether.internal.impl.scope.ManagedScopeDeriver;
+import org.eclipse.aether.internal.impl.scope.ManagedScopeSelector;
 import org.eclipse.aether.internal.impl.scope.OptionalDependencySelector;
 import org.eclipse.aether.internal.impl.scope.ScopeDependencySelector;
+import org.eclipse.aether.internal.impl.scope.ScopeManagerImpl;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.util.artifact.DefaultArtifactTypeRegistry;
-import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
 import org.eclipse.aether.util.graph.transformer.ConfigurableVersionSelector;
-import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
-import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
-import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
 import org.eclipse.aether.util.graph.transformer.PathConflictResolver;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.graph.traverser.FatArtifactTraverser;
@@ -65,9 +65,11 @@ import static java.util.Objects.requireNonNull;
  */
 public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected final RepositorySystem repositorySystem;
+    protected final ScopeManagerImpl scopeManager;
 
     public SessionBuilderSupplier(RepositorySystem repositorySystem) {
         this.repositorySystem = requireNonNull(repositorySystem);
+        this.scopeManager = new ScopeManagerImpl(Maven3ScopeManagerConfiguration.INSTANCE);
     }
 
     protected void configureSessionBuilder(SessionBuilder session) {
@@ -77,6 +79,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
             key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
             session.setSystemProperty(key, value);
         });
+        session.setScopeManager(scopeManager);
         session.setDependencyTraverser(getDependencyTraverser());
         session.setDependencyManager(getDependencyManager());
         session.setDependencySelector(getDependencySelector());
@@ -90,12 +93,15 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     }
 
     protected DependencyManager getDependencyManager() {
-        return new ClassicDependencyManager(false, null);
+        return new ClassicDependencyManager(false, scopeManager);
     }
 
     protected DependencySelector getDependencySelector() {
         return new AndDependencySelector(
-                ScopeDependencySelector.legacy(null, Arrays.asList(JavaScopes.TEST, JavaScopes.PROVIDED)),
+                ScopeDependencySelector.legacy(
+                        null,
+                        Arrays.asList(
+                                Maven3ScopeManagerConfiguration.DS_TEST, Maven3ScopeManagerConfiguration.DS_PROVIDED)),
                 OptionalDependencySelector.fromDirect(),
                 new ExclusionDependencySelector());
     }
@@ -103,9 +109,9 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected DependencyGraphTransformer getDependencyGraphTransformer() {
         return new ChainedDependencyGraphTransformer(
                 new PathConflictResolver(
-                        new ConfigurableVersionSelector(), new JavaScopeSelector(),
-                        new SimpleOptionalitySelector(), new JavaScopeDeriver()),
-                new JavaDependencyContextRefiner());
+                        new ConfigurableVersionSelector(), new ManagedScopeSelector(scopeManager),
+                        new SimpleOptionalitySelector(), new ManagedScopeDeriver(scopeManager)),
+                new ManagedDependencyContextRefiner(scopeManager));
     }
 
     protected ArtifactTypeRegistry getArtifactTypeRegistry() {

--- a/maven-resolver-supplier-mvn3/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
+++ b/maven-resolver-supplier-mvn3/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
@@ -26,11 +26,15 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.impl.Deployer;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.util.graph.visitor.DependencyGraphDumper;
 import org.eclipse.aether.version.Version;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +60,29 @@ public class RepositorySystemSupplierTest {
             // As of 2023-11-14, Maven Central has 36 versions of this artifact (and it will just grow)
             assertTrue(versions.size() >= 36);
             System.out.println("Available " + versions.size() + " versions: " + versions);
+        }
+    }
+
+    @Test
+    void smokeV2Feature() throws Exception {
+        try (RepositorySystem system = new RepositorySystemSupplier().get();
+                CloseableSession session = new SessionBuilderSupplier(system)
+                        .get()
+                        .withLocalRepositoryBaseDirectories(new File("target/local-repo").toPath())
+                        .build()) {
+            CollectRequest collectRequest = new CollectRequest();
+            collectRequest.setResolutionScope(session.getScopeManager()
+                    .getResolutionScope(Maven3ScopeManagerConfiguration.RS_TEST_RUNTIME)
+                    .orElseThrow(AssertionError::new));
+            collectRequest.setRoot(
+                    new Dependency(new DefaultArtifact("org.apache.maven:maven-resolver-provider:3.6.1"), ""));
+            collectRequest.setRepositories(Collections.singletonList(
+                    new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2/")
+                            .build()));
+
+            CollectResult collectResult = system.collectDependencies(session, collectRequest);
+
+            collectResult.getRoot().accept(new DependencyGraphDumper(System.out::println));
         }
     }
 


### PR DESCRIPTION
As Maven3 is now mature, set in stone, so Resolver 2 can do it. 
Same for Maven4 is not possible (is like chicken-egg situation).

Presence of scope manager allows now new v 2.0 features like "resolving by ResolutionScope", so no need for manual setting up selection of session and filter parameters to achieve wanted effect: just say what scope you want and bam, there it is.