### PR TITLE
Repository ID handling improvement

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
@@ -24,7 +24,7 @@ import javax.inject.Singleton;
 import java.util.function.Function;
 
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.util.repository.RepositoryIdHelper;
 
 /**
@@ -66,7 +66,7 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
                 String snapshotsPrefix,
-                Function<RemoteRepository, String> idToPathSegmentFunction) {
+                Function<ArtifactRepository, String> idToPathSegmentFunction) {
             super(
                     split,
                     localPrefix,

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
@@ -66,7 +66,7 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
                 String snapshotsPrefix,
-                Function<RemoteRepository, String> safeIdToPathSegment) {
+                Function<RemoteRepository, String> idToPathSegmentFunction) {
             super(
                     split,
                     localPrefix,
@@ -77,7 +77,7 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                     splitRemoteRepositoryLast,
                     releasesPrefix,
                     snapshotsPrefix,
-                    safeIdToPathSegment);
+                    idToPathSegmentFunction);
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory.java
@@ -21,7 +21,11 @@ package org.eclipse.aether.internal.impl;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.util.function.Function;
+
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.repository.RepositoryIdHelper;
 
 /**
  * Default local path prefix composer factory: it fully reuses {@link LocalPathPrefixComposerFactorySupport} class
@@ -43,7 +47,8 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                 isSplitRemoteRepository(session),
                 isSplitRemoteRepositoryLast(session),
                 getReleasesPrefix(session),
-                getSnapshotsPrefix(session));
+                getSnapshotsPrefix(session),
+                RepositoryIdHelper.cachedIdToPathSegment(session));
     }
 
     /**
@@ -60,7 +65,8 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                 boolean splitRemoteRepository,
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
-                String snapshotsPrefix) {
+                String snapshotsPrefix,
+                Function<RemoteRepository, String> safeIdToPathSegment) {
             super(
                     split,
                     localPrefix,
@@ -70,7 +76,8 @@ public final class DefaultLocalPathPrefixComposerFactory extends LocalPathPrefix
                     splitRemoteRepository,
                     splitRemoteRepositoryLast,
                     releasesPrefix,
-                    snapshotsPrefix);
+                    snapshotsPrefix,
+                    safeIdToPathSegment);
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
@@ -71,7 +72,7 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
     EnhancedLocalRepositoryManager(
             Path basedir,
             LocalPathComposer localPathComposer,
-            Function<RemoteRepository, String> idToPathSegmentFunction,
+            Function<ArtifactRepository, String> idToPathSegmentFunction,
             String trackingFilename,
             TrackingFileManager trackingFileManager,
             LocalPathPrefixComposer localPathPrefixComposer) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -71,11 +71,11 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
     EnhancedLocalRepositoryManager(
             Path basedir,
             LocalPathComposer localPathComposer,
-            Function<RemoteRepository, String> remoteRepositorySafeId,
+            Function<RemoteRepository, String> idToPathSegmentFunction,
             String trackingFilename,
             TrackingFileManager trackingFileManager,
             LocalPathPrefixComposer localPathPrefixComposer) {
-        super(basedir, "enhanced", localPathComposer, remoteRepositorySafeId);
+        super(basedir, "enhanced", localPathComposer, idToPathSegmentFunction);
         this.trackingFilename = requireNonNull(trackingFilename);
         this.trackingFileManager = requireNonNull(trackingFileManager);
         this.localPathPrefixComposer = requireNonNull(localPathPrefixComposer);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Function;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -70,10 +71,11 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
     EnhancedLocalRepositoryManager(
             Path basedir,
             LocalPathComposer localPathComposer,
+            Function<RemoteRepository, String> remoteRepositorySafeId,
             String trackingFilename,
             TrackingFileManager trackingFileManager,
             LocalPathPrefixComposer localPathPrefixComposer) {
-        super(basedir, "enhanced", localPathComposer);
+        super(basedir, "enhanced", localPathComposer, remoteRepositorySafeId);
         this.trackingFilename = requireNonNull(trackingFilename);
         this.trackingFileManager = requireNonNull(trackingFileManager);
         this.localPathPrefixComposer = requireNonNull(localPathPrefixComposer);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
@@ -29,6 +29,7 @@ import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.repository.RepositoryIdHelper;
 
 import static java.util.Objects.requireNonNull;
 
@@ -93,6 +94,7 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
             return new EnhancedLocalRepositoryManager(
                     repository.getBasePath(),
                     localPathComposer,
+                    RepositoryIdHelper.cachedIdToPathSegment(session),
                     trackingFilename,
                     trackingFileManager,
                     localPathPrefixComposerFactory.createComposer(session));

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
@@ -243,7 +243,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
 
         protected final String snapshotsPrefix;
 
-        protected final Function<RemoteRepository, String> safeIdToPathSegment;
+        protected final Function<RemoteRepository, String> idToPathSegmentFunction;
 
         protected LocalPathPrefixComposerSupport(
                 boolean split,
@@ -255,7 +255,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
                 String snapshotsPrefix,
-                Function<RemoteRepository, String> safeIdToPathSegment) {
+                Function<RemoteRepository, String> idToPathSegmentFunction) {
             this.split = split;
             this.localPrefix = localPrefix;
             this.splitLocal = splitLocal;
@@ -265,7 +265,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             this.splitRemoteRepositoryLast = splitRemoteRepositoryLast;
             this.releasesPrefix = releasesPrefix;
             this.snapshotsPrefix = snapshotsPrefix;
-            this.safeIdToPathSegment = safeIdToPathSegment;
+            this.idToPathSegmentFunction = idToPathSegmentFunction;
         }
 
         @Override
@@ -287,13 +287,13 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + safeIdToPathSegment.apply(repository);
+                result += "/" + idToPathSegmentFunction.apply(repository);
             }
             if (splitRemote) {
                 result += "/" + (artifact.isSnapshot() ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + safeIdToPathSegment.apply(repository);
+                result += "/" + idToPathSegmentFunction.apply(repository);
             }
             return result;
         }
@@ -317,13 +317,13 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + safeIdToPathSegment.apply(repository);
+                result += "/" + idToPathSegmentFunction.apply(repository);
             }
             if (splitRemote) {
                 result += "/" + (isSnapshot(metadata) ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + safeIdToPathSegment.apply(repository);
+                result += "/" + idToPathSegmentFunction.apply(repository);
             }
             return result;
         }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.ConfigUtils;
 
@@ -243,7 +244,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
 
         protected final String snapshotsPrefix;
 
-        protected final Function<RemoteRepository, String> idToPathSegmentFunction;
+        protected final Function<ArtifactRepository, String> idToPathSegmentFunction;
 
         protected LocalPathPrefixComposerSupport(
                 boolean split,
@@ -255,7 +256,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
                 String snapshotsPrefix,
-                Function<RemoteRepository, String> idToPathSegmentFunction) {
+                Function<ArtifactRepository, String> idToPathSegmentFunction) {
             this.split = split;
             this.localPrefix = localPrefix;
             this.splitLocal = splitLocal;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.util.function.Function;
+
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
@@ -241,6 +243,8 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
 
         protected final String snapshotsPrefix;
 
+        protected final Function<RemoteRepository, String> safeIdToPathSegment;
+
         protected LocalPathPrefixComposerSupport(
                 boolean split,
                 String localPrefix,
@@ -250,7 +254,8 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
                 boolean splitRemoteRepository,
                 boolean splitRemoteRepositoryLast,
                 String releasesPrefix,
-                String snapshotsPrefix) {
+                String snapshotsPrefix,
+                Function<RemoteRepository, String> safeIdToPathSegment) {
             this.split = split;
             this.localPrefix = localPrefix;
             this.splitLocal = splitLocal;
@@ -260,6 +265,7 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             this.splitRemoteRepositoryLast = splitRemoteRepositoryLast;
             this.releasesPrefix = releasesPrefix;
             this.snapshotsPrefix = snapshotsPrefix;
+            this.safeIdToPathSegment = safeIdToPathSegment;
         }
 
         @Override
@@ -281,13 +287,13 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repository.getId();
+                result += "/" + safeIdToPathSegment.apply(repository);
             }
             if (splitRemote) {
                 result += "/" + (artifact.isSnapshot() ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repository.getId();
+                result += "/" + safeIdToPathSegment.apply(repository);
             }
             return result;
         }
@@ -311,13 +317,13 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repository.getId();
+                result += "/" + safeIdToPathSegment.apply(repository);
             }
             if (splitRemote) {
                 result += "/" + (isSnapshot(metadata) ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repository.getId();
+                result += "/" + safeIdToPathSegment.apply(repository);
             }
             return result;
         }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
@@ -107,7 +107,7 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
             StringBuilder buffer = new StringBuilder(128);
 
-            buffer.append(repository.getId());
+            buffer.append(remoteRepositorySafeId.apply(repository));
 
             buffer.append('-');
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -49,10 +50,17 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
     private final LocalPathComposer localPathComposer;
 
-    SimpleLocalRepositoryManager(Path basePath, String type, LocalPathComposer localPathComposer) {
+    private final Function<RemoteRepository, String> remoteRepositorySafeId;
+
+    SimpleLocalRepositoryManager(
+            Path basePath,
+            String type,
+            LocalPathComposer localPathComposer,
+            Function<RemoteRepository, String> remoteRepositorySafeId) {
         requireNonNull(basePath, "base directory cannot be null");
         repository = new LocalRepository(basePath.toAbsolutePath(), type);
         this.localPathComposer = requireNonNull(localPathComposer);
+        this.remoteRepositorySafeId = requireNonNull(remoteRepositorySafeId);
     }
 
     @Override
@@ -117,9 +125,7 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
             key = buffer.toString();
         } else {
-            // repository serves static contents, its id is sufficient as key
-
-            key = repository.getId();
+            key = remoteRepositorySafeId.apply(repository);
         }
 
         return key;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
@@ -50,17 +50,17 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
     private final LocalPathComposer localPathComposer;
 
-    private final Function<RemoteRepository, String> remoteRepositorySafeId;
+    private final Function<RemoteRepository, String> idToPathSegmentFunction;
 
     SimpleLocalRepositoryManager(
             Path basePath,
             String type,
             LocalPathComposer localPathComposer,
-            Function<RemoteRepository, String> remoteRepositorySafeId) {
+            Function<RemoteRepository, String> idToPathSegmentFunction) {
         requireNonNull(basePath, "base directory cannot be null");
         repository = new LocalRepository(basePath.toAbsolutePath(), type);
         this.localPathComposer = requireNonNull(localPathComposer);
-        this.remoteRepositorySafeId = requireNonNull(remoteRepositorySafeId);
+        this.idToPathSegmentFunction = requireNonNull(idToPathSegmentFunction);
     }
 
     @Override
@@ -107,7 +107,7 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
             StringBuilder buffer = new StringBuilder(128);
 
-            buffer.append(remoteRepositorySafeId.apply(repository));
+            buffer.append(idToPathSegmentFunction.apply(repository));
 
             buffer.append('-');
 
@@ -125,7 +125,7 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
             key = buffer.toString();
         } else {
-            key = remoteRepositorySafeId.apply(repository);
+            key = idToPathSegmentFunction.apply(repository);
         }
 
         return key;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
@@ -50,13 +51,13 @@ class SimpleLocalRepositoryManager implements LocalRepositoryManager {
 
     private final LocalPathComposer localPathComposer;
 
-    private final Function<RemoteRepository, String> idToPathSegmentFunction;
+    private final Function<ArtifactRepository, String> idToPathSegmentFunction;
 
     SimpleLocalRepositoryManager(
             Path basePath,
             String type,
             LocalPathComposer localPathComposer,
-            Function<RemoteRepository, String> idToPathSegmentFunction) {
+            Function<ArtifactRepository, String> idToPathSegmentFunction) {
         requireNonNull(basePath, "base directory cannot be null");
         repository = new LocalRepository(basePath.toAbsolutePath(), type);
         this.localPathComposer = requireNonNull(localPathComposer);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory.java
@@ -27,6 +27,7 @@ import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
+import org.eclipse.aether.util.repository.RepositoryIdHelper;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +61,11 @@ public class SimpleLocalRepositoryManagerFactory implements LocalRepositoryManag
         requireNonNull(repository, "repository cannot be null");
 
         if ("".equals(repository.getContentType()) || "simple".equals(repository.getContentType())) {
-            return new SimpleLocalRepositoryManager(repository.getBasePath(), "simple", localPathComposer);
+            return new SimpleLocalRepositoryManager(
+                    repository.getBasePath(),
+                    "simple",
+                    localPathComposer,
+                    RepositoryIdHelper.cachedIdToPathSegment(session));
         } else {
             throw new NoLocalRepositoryManagerException(repository);
         }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
@@ -48,6 +48,7 @@ import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
 import org.eclipse.aether.spi.resolution.ArtifactResolverPostProcessor;
 import org.eclipse.aether.util.ConfigUtils;
 import org.eclipse.aether.util.FileUtils;
+import org.eclipse.aether.util.repository.RepositoryIdHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,9 +180,11 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
     }
 
     private Path ruleFile(RepositorySystemSession session, RemoteRepository remoteRepository) {
-        return ruleFiles.computeIfAbsent(
-                remoteRepository, r -> getBasedir(session, LOCAL_REPO_PREFIX_DIR, CONFIG_PROP_BASEDIR, false)
-                        .resolve(GROUP_ID_FILE_PREFIX + remoteRepository.getId() + GROUP_ID_FILE_SUFFIX));
+        return ruleFiles.computeIfAbsent(remoteRepository, r -> getBasedir(
+                        session, LOCAL_REPO_PREFIX_DIR, CONFIG_PROP_BASEDIR, false)
+                .resolve(GROUP_ID_FILE_PREFIX
+                        + RepositoryIdHelper.cachedIdToPathSegment(session).apply(remoteRepository)
+                        + GROUP_ID_FILE_SUFFIX));
     }
 
     private GroupTree cacheRules(RepositorySystemSession session, RemoteRepository remoteRepository) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -48,6 +48,7 @@ import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
 import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.repository.RepositoryIdHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -210,6 +211,18 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         return PrefixTree.SENTINEL;
     }
 
+    private Path resolvePrefixesFromLocalConfiguration(
+            RepositorySystemSession session, Path baseDir, RemoteRepository remoteRepository) {
+        Path filePath = baseDir.resolve(PREFIXES_FILE_PREFIX
+                + RepositoryIdHelper.cachedIdToPathSegment(session).apply(remoteRepository)
+                + PREFIXES_FILE_SUFFIX);
+        if (Files.isReadable(filePath)) {
+            return filePath;
+        } else {
+            return null;
+        }
+    }
+
     private boolean isPrefixFile(Path path) {
         if (path == null || !Files.isRegularFile(path)) {
             return false;
@@ -220,16 +233,6 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
             return false;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-    }
-
-    private Path resolvePrefixesFromLocalConfiguration(
-            RepositorySystemSession session, Path baseDir, RemoteRepository remoteRepository) {
-        Path filePath = baseDir.resolve(PREFIXES_FILE_PREFIX + remoteRepository.getId() + PREFIXES_FILE_SUFFIX);
-        if (Files.isReadable(filePath)) {
-            return filePath;
-        } else {
-            return null;
         }
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -107,6 +107,7 @@ public class EnhancedLocalRepositoryManagerTest {
         return new EnhancedLocalRepositoryManager(
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
+                RemoteRepository::getId,
                 "_remote.repositories",
                 trackingFileManager,
                 new DefaultLocalPathPrefixComposerFactory().createComposer(session));

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -33,6 +33,7 @@ import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.Metadata.Nature;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
@@ -107,7 +108,7 @@ public class EnhancedLocalRepositoryManagerTest {
         return new EnhancedLocalRepositoryManager(
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
-                RemoteRepository::getId,
+                ArtifactRepository::getId,
                 "_remote.repositories",
                 trackingFileManager,
                 new DefaultLocalPathPrefixComposerFactory().createComposer(session));

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class EnhancedSplitLocalRepositoryManagerTest extends EnhancedLocalReposi
         return new EnhancedLocalRepositoryManager(
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
-                RemoteRepository::getId,
+                ArtifactRepository::getId,
                 "_remote.repositories",
                 trackingFileManager,
                 new DefaultLocalPathPrefixComposerFactory().createComposer(session));

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
@@ -33,6 +33,7 @@ public class EnhancedSplitLocalRepositoryManagerTest extends EnhancedLocalReposi
         return new EnhancedLocalRepositoryManager(
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
+                RemoteRepository::getId,
                 "_remote.repositories",
                 trackingFileManager,
                 new DefaultLocalPathPrefixComposerFactory().createComposer(session));

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
@@ -48,7 +48,8 @@ public class SimpleLocalRepositoryManagerTest {
 
     @BeforeEach
     void setup() throws IOException {
-        manager = new SimpleLocalRepositoryManager(basedir.toPath(), "simple", new DefaultLocalPathComposer());
+        manager = new SimpleLocalRepositoryManager(
+                basedir.toPath(), "simple", new DefaultLocalPathComposer(), RemoteRepository::getId);
         session = TestUtils.newSession();
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerTest.java
@@ -26,6 +26,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
 import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -49,7 +50,7 @@ public class SimpleLocalRepositoryManagerTest {
     @BeforeEach
     void setup() throws IOException {
         manager = new SimpleLocalRepositoryManager(
-                basedir.toPath(), "simple", new DefaultLocalPathComposer(), RemoteRepository::getId);
+                basedir.toPath(), "simple", new DefaultLocalPathComposer(), ArtifactRepository::getId);
         session = TestUtils.newSession();
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
@@ -18,9 +18,9 @@
  */
 package org.eclipse.aether.util.repository;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -41,10 +41,21 @@ import static java.util.Objects.requireNonNull;
 public final class RepositoryIdHelper {
     private RepositoryIdHelper() {}
 
-    private static final List<String> ILLEGAL_REPO_ID_CHARS = Collections.unmodifiableList(
-            Arrays.asList("\\", "/", ":", "\"", "<", ">", "|", "?", "*")); // copied from Maven
-    private static final List<String> REPLACEMENT_REPO_ID_CHARS =
-            Collections.unmodifiableList(Arrays.asList("X", "X", "X", "X", "X", "X", "X", "X", "X"));
+    private static final Map<String, String> ILLEGAL_REPO_ID_REPLACEMENTS;
+
+    static {
+        HashMap<String, String> illegalReposIdReplacements = new HashMap<>();
+        illegalReposIdReplacements.put("\\", "BACKSLASH");
+        illegalReposIdReplacements.put("/", "SLASH");
+        illegalReposIdReplacements.put(":", "COLON");
+        illegalReposIdReplacements.put("\"", "QUOTE");
+        illegalReposIdReplacements.put("<", "LT");
+        illegalReposIdReplacements.put(">", "GT");
+        illegalReposIdReplacements.put("|", "PIPE");
+        illegalReposIdReplacements.put("?", "QMARK");
+        illegalReposIdReplacements.put("*", "ASTERISK");
+        ILLEGAL_REPO_ID_REPLACEMENTS = Collections.unmodifiableMap(illegalReposIdReplacements);
+    }
 
     /**
      * Returns same instance of (session cached) function for session.
@@ -92,11 +103,11 @@ public final class RepositoryIdHelper {
     static String idToPathSegment(ArtifactRepository repository) {
         if (repository instanceof RemoteRepository) {
             StringBuilder result = new StringBuilder(repository.getId());
-            for (int illegalIndex = 0; illegalIndex < ILLEGAL_REPO_ID_CHARS.size(); illegalIndex++) {
-                String illegal = ILLEGAL_REPO_ID_CHARS.get(illegalIndex);
+            for (Map.Entry<String, String> entry : ILLEGAL_REPO_ID_REPLACEMENTS.entrySet()) {
+                String illegal = entry.getKey();
                 int pos = result.indexOf(illegal);
                 while (pos >= 0) {
-                    result.replace(pos, pos + illegal.length(), REPLACEMENT_REPO_ID_CHARS.get(illegalIndex));
+                    result.replace(pos, pos + illegal.length(), entry.getValue());
                     pos = result.indexOf(illegal);
                 }
             }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.repository;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.ArtifactRepository;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.WorkspaceRepository;
+import org.eclipse.aether.util.StringDigestUtil;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Helper class for {@link ArtifactRepository#getId()} handling.
+ *
+ * @since 2.0.11
+ */
+public final class RepositoryIdHelper {
+    private RepositoryIdHelper() {}
+
+    private static final String ILLEGAL_REPO_ID_CHARS = "\\/:\"<>|?*";
+    private static final String REPLACEMENT_REPO_ID_CHAR = "X";
+    private static final String CENTRAL_REPOSITORY_ID = "central";
+    private static final Collection<String> CENTRAL_URLS = Collections.unmodifiableList(Arrays.asList(
+            "https://repo.maven.apache.org/maven2",
+            "https://repo1.maven.org/maven2",
+            "https://maven-central.storage-download.googleapis.com/maven2"));
+    private static final Predicate<RemoteRepository> CENTRAL_DIRECT_ONLY =
+            remoteRepository -> CENTRAL_REPOSITORY_ID.equals(remoteRepository.getId())
+                    && "https".equals(remoteRepository.getProtocol().toLowerCase(Locale.ROOT))
+                    && CENTRAL_URLS.stream().anyMatch(remoteUrl -> {
+                        String rurl = remoteRepository.getUrl().toLowerCase(Locale.ROOT);
+                        if (rurl.endsWith("/")) {
+                            rurl = rurl.substring(0, rurl.length() - 1);
+                        }
+                        return rurl.equals(remoteUrl);
+                    })
+                    && remoteRepository.getPolicy(false).isEnabled()
+                    && !remoteRepository.getPolicy(true).isEnabled()
+                    && remoteRepository.getMirroredRepositories().isEmpty()
+                    && !remoteRepository.isRepositoryManager()
+                    && !remoteRepository.isBlocked();
+
+    /**
+     * Provides cached (or uncached, if session has no cache set) for {@link #idToSafePathSegment(RemoteRepository)} function.
+     */
+    @SuppressWarnings("unchecked")
+    public static Function<? extends ArtifactRepository, String> cachedIdToSafePathSegment(
+            RepositorySystemSession session) {
+        if (session.getCache() != null) {
+            return repository -> ((ConcurrentHashMap<ArtifactRepository, String>) session.getCache()
+                            .computeIfAbsent(
+                                    session,
+                                    RepositoryIdHelper.class.getSimpleName() + "-idToSafePathSegment",
+                                    ConcurrentHashMap::new))
+                    .computeIfAbsent(repository, RepositoryIdHelper::idToSafePathSegment);
+        } else {
+            return RepositoryIdHelper::idToSafePathSegment; // uncached
+        }
+    }
+
+    /**
+     * Provides cached (or uncached, if session has no cache set) for {@link #idToPathSegment(RemoteRepository)} function.
+     */
+    @SuppressWarnings("unchecked")
+    public static Function<RemoteRepository, String> cachedIdToPathSegment(RepositorySystemSession session) {
+        if (session.getCache() != null) {
+            return repository -> ((ConcurrentHashMap<RemoteRepository, String>) session.getCache()
+                            .computeIfAbsent(
+                                    session,
+                                    RepositoryIdHelper.class.getSimpleName() + "-idToPathSegment",
+                                    ConcurrentHashMap::new))
+                    .computeIfAbsent(repository, RepositoryIdHelper::idToPathSegment);
+        } else {
+            return RepositoryIdHelper::idToPathSegment; // uncached
+        }
+    }
+
+    /**
+     * This method returns the passed in {@link ArtifactRepository#getId()} value, but it makes them unique to prevent
+     * ID overlap in unrelated builds. Only Maven Central will have return ID "central", while all the other
+     * remote repository will have returned string in form of {@code repo.ID-sha1(repo.url)}.
+     * <p>
+     * This method should be used when code operates with {@link ArtifactRepository}s and uses repository ID as identifier
+     * (like enhanced local repository is, or split repository). Use of ID solely can result in clash and overlaps,
+     * as for example repository with ID "releases" may be defined in multiple builds, but pointing to different
+     * URLs.
+     * <p>
+     * This method is simplistic on purpose, and if frequently used, best if results are cached (per session).
+     */
+    public static String idToSafePathSegment(ArtifactRepository repository) {
+        requireNonNull(repository, "repository");
+        if (repository instanceof LocalRepository) {
+            return repository.getId(); // "local"
+        } else if (repository instanceof WorkspaceRepository) {
+            return repository.getId(); // "workspace"
+        } else if (repository instanceof RemoteRepository) {
+            return idToSafePathSegment((RemoteRepository) repository);
+        } else {
+            throw new IllegalArgumentException("Unknown repository type: " + repository);
+        }
+    }
+
+    /**
+     * This method returns the passed in {@link RemoteRepository#getId()} value, but it makes them unique to prevent
+     * ID overlap in unrelated builds. Only Maven Central will have return ID "central", while all the other
+     * remote repository will have returned string in form of {@code repo.ID-sha1(repo.url)}.
+     * <p>
+     * This method should be used when code operates with {@link RemoteRepository}s and uses repository ID as identifier
+     * (like enhanced local repository is, or split repository). Use of ID solely can result in clash and overlaps,
+     * as for example repository with ID "releases" may be defined in multiple builds, but pointing to different
+     * URLs.
+     * <p>
+     * This method is simplistic on purpose, and if frequently used, best if results are cached (per session).
+     */
+    public static String idToSafePathSegment(RemoteRepository repository) {
+        if (CENTRAL_DIRECT_ONLY.test(repository)) {
+            return repository.getId();
+        } else {
+            return idToPathSegment(repository) + "-" + StringDigestUtil.sha1(repository.getUrl());
+        }
+    }
+
+    /**
+     * This method returns the passed in {@link RemoteRepository#getId()} value, modifying it if needed, making sure that
+     * returned repository ID is "path segment" safe. Ideally, this method should never modify repository ID, as
+     * Maven validation prevents use of illegal FS characters in them, but we found in Maven Central several POMs that
+     * define remote repositories with illegal FS characters in their ID.
+     * <p>
+     * This method is simplistic on purpose, and if frequently used, best if results are cached (per session),
+     * see {@link #cachedIdToPathSegment(RepositorySystemSession)} method.
+     *
+     * @see #cachedIdToPathSegment(RepositorySystemSession)
+     */
+    public static String idToPathSegment(RemoteRepository repository) {
+        StringBuilder result = new StringBuilder(repository.getId());
+        for (int illegalIndex = 0; illegalIndex < ILLEGAL_REPO_ID_CHARS.length(); illegalIndex++) {
+            String illegal = ILLEGAL_REPO_ID_CHARS.substring(illegalIndex, illegalIndex + 1);
+            int pos = result.indexOf(illegal);
+            while (pos >= 0) {
+                result.replace(pos, pos + 1, REPLACEMENT_REPO_ID_CHAR);
+                pos = result.indexOf(illegal);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
@@ -18,6 +18,9 @@
  */
 package org.eclipse.aether.util.repository;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -35,8 +38,10 @@ import static java.util.Objects.requireNonNull;
 public final class RepositoryIdHelper {
     private RepositoryIdHelper() {}
 
-    private static final String ILLEGAL_REPO_ID_CHARS = "\\/:\"<>|?*"; // copied from Maven
-    private static final String REPLACEMENT_REPO_ID_CHAR = "X";
+    private static final List<String> ILLEGAL_REPO_ID_CHARS = Collections.unmodifiableList(
+            Arrays.asList("\\", "/", ":", "\"", "<", ">", "|", "?", "*")); // copied from Maven
+    private static final List<String> REPLACEMENT_REPO_ID_CHARS =
+            Collections.unmodifiableList(Arrays.asList("X", "X", "X", "X", "X", "X", "X", "X", "X"));
 
     /**
      * Provides cached (or uncached, if session has no cache set) for {@link #idToPathSegment(RemoteRepository)} function.
@@ -69,11 +74,11 @@ public final class RepositoryIdHelper {
      */
     public static String idToPathSegment(RemoteRepository repository) {
         StringBuilder result = new StringBuilder(repository.getId());
-        for (int illegalIndex = 0; illegalIndex < ILLEGAL_REPO_ID_CHARS.length(); illegalIndex++) {
-            String illegal = ILLEGAL_REPO_ID_CHARS.substring(illegalIndex, illegalIndex + 1);
+        for (int illegalIndex = 0; illegalIndex < ILLEGAL_REPO_ID_CHARS.size(); illegalIndex++) {
+            String illegal = ILLEGAL_REPO_ID_CHARS.get(illegalIndex);
             int pos = result.indexOf(illegal);
             while (pos >= 0) {
-                result.replace(pos, pos + 1, REPLACEMENT_REPO_ID_CHAR);
+                result.replace(pos, pos + illegal.length(), REPLACEMENT_REPO_ID_CHARS.get(illegalIndex));
                 pos = result.indexOf(illegal);
             }
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
@@ -31,7 +31,9 @@ import org.eclipse.aether.repository.RemoteRepository;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Helper class for {@link ArtifactRepository#getId()} handling.
+ * Helper class for {@link ArtifactRepository#getId()} handling. This class provides helper function (cached or uncached)
+ * to get {@link RemoteRepository#getId()} as it was originally envisioned: as path safe. While POMs are validated
+ * by Maven, there are POMs out there that somehow define repositories with unsafe characters in their id.
  *
  * @since 2.0.11
  */

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/RepositoryIdHelper.java
@@ -44,17 +44,17 @@ public final class RepositoryIdHelper {
     private static final Map<String, String> ILLEGAL_REPO_ID_REPLACEMENTS;
 
     static {
-        HashMap<String, String> illegalReposIdReplacements = new HashMap<>();
-        illegalReposIdReplacements.put("\\", "BACKSLASH");
-        illegalReposIdReplacements.put("/", "SLASH");
-        illegalReposIdReplacements.put(":", "COLON");
-        illegalReposIdReplacements.put("\"", "QUOTE");
-        illegalReposIdReplacements.put("<", "LT");
-        illegalReposIdReplacements.put(">", "GT");
-        illegalReposIdReplacements.put("|", "PIPE");
-        illegalReposIdReplacements.put("?", "QMARK");
-        illegalReposIdReplacements.put("*", "ASTERISK");
-        ILLEGAL_REPO_ID_REPLACEMENTS = Collections.unmodifiableMap(illegalReposIdReplacements);
+        HashMap<String, String> illegalRepoIdReplacements = new HashMap<>();
+        illegalRepoIdReplacements.put("\\", "-BACKSLASH-");
+        illegalRepoIdReplacements.put("/", "-SLASH-");
+        illegalRepoIdReplacements.put(":", "-COLON-");
+        illegalRepoIdReplacements.put("\"", "-QUOTE-");
+        illegalRepoIdReplacements.put("<", "-LT-");
+        illegalRepoIdReplacements.put(">", "-GT-");
+        illegalRepoIdReplacements.put("|", "-PIPE-");
+        illegalRepoIdReplacements.put("?", "-QMARK-");
+        illegalRepoIdReplacements.put("*", "-ASTERISK-");
+        ILLEGAL_REPO_ID_REPLACEMENTS = Collections.unmodifiableMap(illegalRepoIdReplacements);
     }
 
     /**

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
@@ -36,7 +36,7 @@ public class RepositoryIdHelperTest {
     void fixes() {
         Function<RemoteRepository, String> safeId = RepositoryIdHelper::idToPathSegment;
         RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
-        RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();
+        RemoteRepository bad = new RemoteRepository.Builder("bad:id", "default", "https://somewhere.com").build();
 
         String goodId = good.getId();
         String goodFixedId = safeId.apply(good);
@@ -45,7 +45,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badXid", badFixedId);
+        assertEquals("badCOLONid", badFixedId);
     }
 
     @Test
@@ -56,7 +56,7 @@ public class RepositoryIdHelperTest {
         String badId = veryBad.getId();
         String badFixedId = RepositoryIdHelper.idToPathSegment(veryBad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("XXXXXXXXX", badFixedId);
+        assertEquals("BACKSLASHSLASHCOLONQUOTELTGTPIPEQMARKASTERISK", badFixedId);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badXid", badFixedId);
+        assertEquals("badSLASHid", badFixedId);
         assertSame(badFixedId, safeId.apply(bad));
     }
 
@@ -97,7 +97,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badXid", badFixedId);
+        assertEquals("badSLASHid", badFixedId);
         assertNotSame(badFixedId, safeId.apply(bad));
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.repository;
+
+import java.util.function.Function;
+
+import org.eclipse.aether.DefaultRepositoryCache;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class RepositoryIdHelperTest {
+    @Test
+    void fixes() {
+        Function<RemoteRepository, String> safeId = RepositoryIdHelper::idToPathSegment;
+        RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
+        RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();
+
+        String goodId = good.getId();
+        String goodFixedId = safeId.apply(good);
+        assertEquals(goodId, goodFixedId);
+
+        String badId = bad.getId();
+        String badFixedId = safeId.apply(bad);
+        assertNotEquals(badId, badFixedId);
+        assertEquals("badXid", badFixedId);
+    }
+
+    @Test
+    void allCharsBad() {
+        // hopefully we have no such IDs
+        RemoteRepository veryBad =
+                new RemoteRepository.Builder("\\/:\"<>|?*", "default", "https://somewhere.com").build();
+        String badId = veryBad.getId();
+        String badFixedId = RepositoryIdHelper.idToPathSegment(veryBad);
+        assertNotEquals(badId, badFixedId);
+        assertEquals("XXXXXXXXX", badFixedId);
+    }
+
+    @Test
+    void caching() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(s -> false);
+        session.setCache(new DefaultRepositoryCache()); // session has cache set
+        Function<RemoteRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
+
+        RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
+        RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();
+
+        String goodId = good.getId();
+        String goodFixedId = safeId.apply(good);
+        assertEquals(goodId, goodFixedId);
+        assertSame(goodFixedId, safeId.apply(good));
+
+        String badId = bad.getId();
+        String badFixedId = safeId.apply(bad);
+        assertNotEquals(badId, badFixedId);
+        assertEquals("badXid", badFixedId);
+        assertSame(badFixedId, safeId.apply(bad));
+    }
+
+    @Test
+    void nonCaching() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(s -> false);
+        session.setCache(null); // session has no cache set
+        Function<RemoteRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
+
+        RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
+        RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();
+
+        String goodId = good.getId();
+        String goodFixedId = safeId.apply(good);
+        assertEquals(goodId, goodFixedId);
+        assertNotSame(goodFixedId, safeId.apply(good));
+
+        String badId = bad.getId();
+        String badFixedId = safeId.apply(bad);
+        assertNotEquals(badId, badFixedId);
+        assertEquals("badXid", badFixedId);
+        assertNotSame(badFixedId, safeId.apply(bad));
+    }
+}

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
@@ -45,7 +45,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badCOLONid", badFixedId);
+        assertEquals("bad-COLON-id", badFixedId);
     }
 
     @Test
@@ -56,7 +56,7 @@ public class RepositoryIdHelperTest {
         String badId = veryBad.getId();
         String badFixedId = RepositoryIdHelper.idToPathSegment(veryBad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("BACKSLASHSLASHCOLONQUOTELTGTPIPEQMARKASTERISK", badFixedId);
+        assertEquals("-BACKSLASH--SLASH--COLON--QUOTE--LT--GT--PIPE--QMARK--ASTERISK-", badFixedId);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badSLASHid", badFixedId);
+        assertEquals("bad-SLASH-id", badFixedId);
         assertSame(badFixedId, safeId.apply(bad));
     }
 
@@ -97,7 +97,7 @@ public class RepositoryIdHelperTest {
         String badId = bad.getId();
         String badFixedId = safeId.apply(bad);
         assertNotEquals(badId, badFixedId);
-        assertEquals("badSLASHid", badFixedId);
+        assertEquals("bad-SLASH-id", badFixedId);
         assertNotSame(badFixedId, safeId.apply(bad));
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.jupiter.api.Test;
 
@@ -62,7 +63,7 @@ public class RepositoryIdHelperTest {
     void caching() {
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(s -> false);
         session.setCache(new DefaultRepositoryCache()); // session has cache set
-        Function<RemoteRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
+        Function<ArtifactRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
 
         RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
         RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();
@@ -83,7 +84,7 @@ public class RepositoryIdHelperTest {
     void nonCaching() {
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(s -> false);
         session.setCache(null); // session has no cache set
-        Function<RemoteRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
+        Function<ArtifactRepository, String> safeId = RepositoryIdHelper.cachedIdToPathSegment(session);
 
         RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
         RemoteRepository bad = new RemoteRepository.Builder("bad/id", "default", "https://somewhere.com").build();


### PR DESCRIPTION
Many feature blindly assume (as Maven validates this) that `repository.id` is "path segment"-safe string.

Still, we found some fairly recent POMs (like maven-core 3.6.1!) that contain in their transitive hull POMs that contain FS unsafe repository IDs.

These IDs makes features like split repository, or metadata caching go hay-way.

This PR contains fix for these "bad" repository.id-s (by "fixing" them to be as should: FS safe) covering all places where repository.id is to be used as path segment.

Fixes #1564
