### PR TITLE
Go back to atomic

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -132,7 +132,7 @@ public final class FileUtils {
                     if (IS_WINDOWS) {
                         copy(tempFile, file);
                     } else {
-                        Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+                        Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE);
                     }
                 }
                 Files.deleteIfExists(tempFile);

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/FileUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/FileUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FileUtilsTest {
+    @Test
+    void smoke(@TempDir Path tmp) throws IOException {
+        Path target = tmp.resolve("target.txt");
+        Files.write(target, "Hello world".getBytes(StandardCharsets.UTF_8));
+        assertEquals("Hello world", new String(Files.readAllBytes(target), StandardCharsets.UTF_8));
+
+        try (FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile(target)) {
+            Files.write(tempFile.getPath(), "Hello other world".getBytes(StandardCharsets.UTF_8));
+            tempFile.move();
+        }
+        assertEquals("Hello other world", new String(Files.readAllBytes(target), StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
This change was done due Windows, but later the execution path was split for Windows to use oldie pre-NIO2 code to copy as for some reason that works on Windows.

On other platforms, insist on ATOMIC, still make use able to override it, in case atomic is not a viable option.