### PR TITLE
Javadoc fixes

### DIFF
--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileUtils.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileUtils.java
@@ -158,7 +158,7 @@ public class TestFileUtils {
      *
      * @return the temporary directory
      * @throws IOException if an I/O error occurs
-     * @deprecated use {@code @TempDir) (JUnit 5) Or {@code TemporaryFolder} (JUnit 4) instead
+     * @deprecated use {@code @TempDir} (JUnit 5) or {@code TemporaryFolder} (JUnit 4) instead
      */
     @Deprecated
     public static File createTempDir(String suffix) throws IOException {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -51,7 +51,7 @@ import static java.util.Objects.requireNonNull;
  *
  * <h2>Managed Properties</h2>
  * <ul>
- * <li><strong>Version & Scope:</strong> Handled by ModelBuilder for own dependency management
+ * <li><strong>Version &amp; Scope:</strong> Handled by ModelBuilder for own dependency management
  *     (think "effective POM"). This implementation ensures these are not applied to the same
  *     node that provided the rules, to not override ModelBuilder's work.</li>
  * <li><strong>Optional:</strong> Not handled by ModelBuilder; managed here.</li>


### PR DESCRIPTION
PR #1581 left some typos in, that makes javadoc puke:
```
[ERROR] /home/cstamas/Worx/apache-maven/maven-resolver/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileUtils.java:161: error: unterminated inline tag
[ERROR]      * @deprecated use {@code @TempDir) (JUnit 5) Or {@code TemporaryFolder} (JUnit 4) instead
```

PR #1589 used forbidden chars.