### PR TITLE
Fix JDK transport mr JAR sources

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk/pom.xml
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk/pom.xml
@@ -109,6 +109,7 @@
               <includeArtifactIds>maven-resolver-transport-jdk-8</includeArtifactIds>
               <excludeClassifiers>sources</excludeClassifiers>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <excludes>META-INF/maven/**</excludes>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
In case of release, the `sources` JAR contained classes. 

Now, it contains the "notable" (jdk-11) sources, as Java 8 sources are really just a "placeholder" to politely say "we do not work on Java 8" (JDK HttpClient is not available).

Fixes #1595 