### PR TITLE
Demote JDK transport

### DIFF
--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporterFactory.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporterFactory.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 public final class ApacheTransporterFactory implements HttpTransporterFactory {
     public static final String NAME = "apache";
 
-    private float priority = 5.0f;
+    private float priority = 10.0f;
 
     private final ChecksumExtractor checksumExtractor;
 

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
@@ -40,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 public final class JdkTransporterFactory implements HttpTransporterFactory {
     public static final String NAME = "jdk";
 
-    private float priority = 10.0f;
+    private float priority = 5.0f;
 
     private final ChecksumExtractor checksumExtractor;
 

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-8/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporterFactory.java
@@ -44,7 +44,7 @@ public final class JdkTransporterFactory implements HttpTransporterFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdkTransporterFactory.class);
 
-    private float priority = 10.0f;
+    private float priority = 5.0f;
 
     @Inject
     public JdkTransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {


### PR DESCRIPTION
Originally we have this order of transports w/ priorities (present/absent in maven core):
* wagon -1.0 (present)
* apache 5.0 (present)
* jdk 10.0 (present) ("default" transport)
* jetty 15.p (absent) (if user added it via extension or lib/ext it "wins")

But lately we see that JDK one advantage of HTTP/2 support (that is already disabled due various issues) is shaded due several disadvantages (no support for HTTPS proxies, unstable, and unreliable)

Hence, I propose to "demote" it (maybe even remove it from Maven core):
* wagon -1.0 (present)
* jdk 5.0 (present; and maybe remove it from maven core)
* apache 10.0 (present; new "default" transport)
* jetty 15.0 (absent)

This makes Maven 4 not have "modern" HTTP transport by default, but apache transport is well battle tested and robust, with one issue: lack of HTTP/2 support (that does improve download speeds).