### PR TITLE
GH-1609 Bad metadata naming

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -24,6 +24,7 @@ import java.util.TreeSet;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.named.NamedLockKey;
 
@@ -103,18 +104,46 @@ public class GAVNameMapper implements NameMapper {
                 + suffix;
     }
 
+    private static final String MAVEN_METADATA = "maven-metadata.xml";
+
     private static String getMetadataName(Metadata metadata, String prefix, String separator, String suffix) {
-        String name = prefix;
-        if (!metadata.getGroupId().isEmpty()) {
-            name += metadata.getGroupId();
-            if (!metadata.getArtifactId().isEmpty()) {
-                name += separator + metadata.getArtifactId();
-                if (!metadata.getVersion().isEmpty()) {
-                    name += separator + metadata.getVersion();
+        if (metadata.getType().contains("/")) {
+            String metadataType = metadata.getType();
+            int slash = metadataType.indexOf('/');
+            return metadataType.substring(0, slash)
+                    + separator
+                    + getMetadataName(
+                            new DefaultMetadata(
+                                    metadata.getGroupId(),
+                                    metadata.getArtifactId(),
+                                    metadata.getVersion(),
+                                    metadataType.substring(slash + 1),
+                                    metadata.getNature(),
+                                    metadata.getProperties(),
+                                    metadata.getPath()),
+                            prefix,
+                            separator,
+                            suffix);
+        } else {
+            String name = prefix;
+            if (!metadata.getGroupId().isEmpty()) {
+                name += metadata.getGroupId();
+                if (!metadata.getArtifactId().isEmpty()) {
+                    name += separator + metadata.getArtifactId();
+                    if (!metadata.getVersion().isEmpty()) {
+                        name += separator + metadata.getVersion();
+                    }
+                }
+                if (!MAVEN_METADATA.equals(metadata.getType())) {
+                    name += separator + metadata.getType();
+                }
+            } else {
+                if (!MAVEN_METADATA.equals(metadata.getType())) {
+                    name += metadata.getType();
                 }
             }
+            return name + suffix;
         }
-        return name + suffix;
     }
 
     public static NameMapper gav() {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -26,6 +26,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.named.NamedLockKey;
+import org.eclipse.aether.util.PathUtils;
 
 import static java.util.Objects.requireNonNull;
 
@@ -106,10 +107,6 @@ public class GAVNameMapper implements NameMapper {
     private static final String MAVEN_METADATA = "maven-metadata.xml";
 
     private static String getMetadataName(Metadata metadata, String prefix, String separator, String suffix) {
-        String type = metadata.getType();
-        if (type.contains("/")) {
-            type = type.replaceAll("/", "_");
-        }
         String name = prefix;
         if (!metadata.getGroupId().isEmpty()) {
             name += metadata.getGroupId();
@@ -119,12 +116,12 @@ public class GAVNameMapper implements NameMapper {
                     name += separator + metadata.getVersion();
                 }
             }
-            if (!MAVEN_METADATA.equals(type)) {
-                name += separator + type;
+            if (!MAVEN_METADATA.equals(metadata.getType())) {
+                name += separator + PathUtils.stringToPathSegment(metadata.getType());
             }
         } else {
-            if (!MAVEN_METADATA.equals(type)) {
-                name += type;
+            if (!MAVEN_METADATA.equals(metadata.getType())) {
+                name += PathUtils.stringToPathSegment(metadata.getType());
             }
         }
         return name + suffix;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -24,7 +24,6 @@ import java.util.TreeSet;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.named.NamedLockKey;
 
@@ -107,43 +106,28 @@ public class GAVNameMapper implements NameMapper {
     private static final String MAVEN_METADATA = "maven-metadata.xml";
 
     private static String getMetadataName(Metadata metadata, String prefix, String separator, String suffix) {
-        if (metadata.getType().contains("/")) {
-            String metadataType = metadata.getType();
-            int slash = metadataType.indexOf('/');
-            return metadataType.substring(0, slash)
-                    + separator
-                    + getMetadataName(
-                            new DefaultMetadata(
-                                    metadata.getGroupId(),
-                                    metadata.getArtifactId(),
-                                    metadata.getVersion(),
-                                    metadataType.substring(slash + 1),
-                                    metadata.getNature(),
-                                    metadata.getProperties(),
-                                    metadata.getPath()),
-                            prefix,
-                            separator,
-                            suffix);
-        } else {
-            String name = prefix;
-            if (!metadata.getGroupId().isEmpty()) {
-                name += metadata.getGroupId();
-                if (!metadata.getArtifactId().isEmpty()) {
-                    name += separator + metadata.getArtifactId();
-                    if (!metadata.getVersion().isEmpty()) {
-                        name += separator + metadata.getVersion();
-                    }
-                }
-                if (!MAVEN_METADATA.equals(metadata.getType())) {
-                    name += separator + metadata.getType();
-                }
-            } else {
-                if (!MAVEN_METADATA.equals(metadata.getType())) {
-                    name += metadata.getType();
+        String type = metadata.getType();
+        if (type.contains("/")) {
+            type = type.replaceAll("/", "_");
+        }
+        String name = prefix;
+        if (!metadata.getGroupId().isEmpty()) {
+            name += metadata.getGroupId();
+            if (!metadata.getArtifactId().isEmpty()) {
+                name += separator + metadata.getArtifactId();
+                if (!metadata.getVersion().isEmpty()) {
+                    name += separator + metadata.getVersion();
                 }
             }
-            return name + suffix;
+            if (!MAVEN_METADATA.equals(type)) {
+                name += separator + type;
+            }
+        } else {
+            if (!MAVEN_METADATA.equals(type)) {
+                name += type;
+            }
         }
+        return name + suffix;
     }
 
     public static NameMapper gav() {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
@@ -31,12 +31,13 @@ import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BasedirNameMapperTest extends NameMapperTestSupport {
+public class BasedirHashingNameMapperTest extends NameMapperTestSupport {
     private final String PS = "/"; // we work with URIs now, not OS file paths
 
-    BasedirNameMapper mapper = new BasedirNameMapper(GAVNameMapper.fileGav());
+    BasedirNameMapper mapper = new BasedirNameMapper(new HashingNameMapper(GAVNameMapper.gav()));
 
     @Test
     void nullsAndEmptyInputs() {
@@ -63,8 +64,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/artifact~group~artifact~1.0.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -75,8 +76,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/my/locks/artifact~group~artifact~1.0.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + "my" + PS + "locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -90,9 +91,7 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         DefaultArtifact artifact = new DefaultArtifact("group:artifact:1.0");
         Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(1, names.size());
-        assertEquals(
-                "file:///my/locks/artifact~group~artifact~1.0.lock",
-                names.iterator().next().name());
+        assertEquals(names.iterator().next().name(), customBaseDir + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -103,8 +102,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/artifact~group~artifact~1.0.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "46e98183d232f1e16f863025080c7f2b9797fd10");
     }
 
     @Test
@@ -116,8 +115,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/metadata~group~artifact.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "293b3990971f4b4b02b220620d2538eaac5f221b");
     }
 
     @Test
@@ -129,8 +128,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/.meta~metadata~prefixes-central.txt.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "9db0329a628e4c74539c04d3f624b76b78bf5ff3");
     }
 
     @Test
@@ -141,8 +140,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/metadata~something.xml.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "e75ca04110613537eeb805ac3cc3a3bb4b3b999a");
     }
 
     @Test
@@ -154,8 +153,8 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/metadata~groupId~artifactId~something.xml.lock",
-                names.iterator().next().name());
+                names.iterator().next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "3ebd7051578a145a78fc67adeaccdcdc5a914b28");
     }
 
     @Test
@@ -167,15 +166,15 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
                 new DefaultMetadata("bgroup", "artifact", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
         Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), singletonList(metadata));
 
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         Iterator<NamedLockKey> namesIterator = names.iterator();
 
         // they are sorted as well
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/artifact~agroup~artifact~1.0.lock",
-                namesIterator.next().name());
+                namesIterator.next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "d36504431d00d1c6e4d1c34258f2bf0a004de085");
         assertEquals(
-                "file:///home/maven/.m2/repository/.locks/metadata~bgroup~artifact.lock",
-                namesIterator.next().name());
+                namesIterator.next().name(),
+                basedir.toUri() + PS + ".locks" + PS + "fbcebba60d7eb931eca634f6ca494a8a1701b638");
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
@@ -129,7 +129,7 @@ public class BasedirHashingNameMapperTest extends NameMapperTestSupport {
         assertEquals(1, names.size());
         assertEquals(
                 names.iterator().next().name(),
-                basedir.toUri() + PS + ".locks" + PS + "9db0329a628e4c74539c04d3f624b76b78bf5ff3");
+                basedir.toUri() + PS + ".locks" + PS + "35d0f75862d98c112ff7c69340c2edb941ab84c0");
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirHashingNameMapperTest.java
@@ -129,7 +129,7 @@ public class BasedirHashingNameMapperTest extends NameMapperTestSupport {
         assertEquals(1, names.size());
         assertEquals(
                 names.iterator().next().name(),
-                basedir.toUri() + PS + ".locks" + PS + "35d0f75862d98c112ff7c69340c2edb941ab84c0");
+                basedir.toUri() + PS + ".locks" + PS + "520e2ba3a365db8cd804bcc40df38e1a52987e0f");
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -139,7 +139,7 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                getPrefix() + ".meta~metadata~prefixes-central.txt.lock",
+                getPrefix() + "metadata~.meta_prefixes-central.txt.lock",
                 names.iterator().next().name());
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -41,11 +41,11 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
     private String getPrefix() throws IOException {
         Path basedir = DirectoryUtils.resolveDirectory(
                 session, BasedirNameMapper.DEFAULT_LOCKS_DIR, BasedirNameMapper.CONFIG_PROP_LOCKS_DIR, false);
-        String basedirPath = basedir.toAbsolutePath().toString();
+        String basedirPath = basedir.toAbsolutePath().toUri().toASCIIString();
         if (!basedirPath.endsWith("/")) {
             basedirPath = basedirPath + "/";
         }
-        return "file://" + basedirPath;
+        return basedirPath;
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -139,7 +139,7 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                getPrefix() + "metadata~.meta_prefixes-central.txt.lock",
+                getPrefix() + "metadata~.meta-SLASH-prefixes-central.txt.lock",
                 names.iterator().next().name());
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -70,6 +70,36 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
     }
 
     @Test
+    void prefixMetadata() {
+        DefaultMetadata metadata =
+                new DefaultMetadata("", "", ".meta/prefixes-central.txt", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        assertEquals(
+                ".meta~metadata~prefixes-central.txt.lock",
+                names.iterator().next().name());
+    }
+
+    @Test
+    void rootSomeMetadata() {
+        DefaultMetadata metadata = new DefaultMetadata("", "", "something.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        assertEquals("metadata~something.xml.lock", names.iterator().next().name());
+    }
+
+    @Test
+    void nonRootSomeMetadata() {
+        DefaultMetadata metadata =
+                new DefaultMetadata("groupId", "artifactId", "something.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        assertEquals(
+                "metadata~groupId~artifactId~something.xml.lock",
+                names.iterator().next().name());
+    }
+
+    @Test
     void oneAndOne() {
         DefaultArtifact artifact = new DefaultArtifact("agroup:artifact:1.0");
         DefaultMetadata metadata =

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -76,7 +76,7 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                "metadata~.meta_prefixes-central.txt.lock",
+                "metadata~.meta-SLASH-prefixes-central.txt.lock",
                 names.iterator().next().name());
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -76,7 +76,7 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
         assertEquals(1, names.size());
         assertEquals(
-                ".meta~metadata~prefixes-central.txt.lock",
+                "metadata~.meta_prefixes-central.txt.lock",
                 names.iterator().next().name());
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A reusable utility class for file paths.
+ *
+ * @since 2.0.13
+ */
+public final class PathUtils {
+    private PathUtils() {
+        // hide constructor
+    }
+
+    private static final Map<String, String> ILLEGAL_PATH_SEGMENT_REPLACEMENTS;
+
+    static {
+        HashMap<String, String> illegalPathSegmentReplacements = new HashMap<>();
+        illegalPathSegmentReplacements.put("\\", "-BACKSLASH-");
+        illegalPathSegmentReplacements.put("/", "-SLASH-");
+        illegalPathSegmentReplacements.put(":", "-COLON-");
+        illegalPathSegmentReplacements.put("\"", "-QUOTE-");
+        illegalPathSegmentReplacements.put("<", "-LT-");
+        illegalPathSegmentReplacements.put(">", "-GT-");
+        illegalPathSegmentReplacements.put("|", "-PIPE-");
+        illegalPathSegmentReplacements.put("?", "-QMARK-");
+        illegalPathSegmentReplacements.put("*", "-ASTERISK-");
+        ILLEGAL_PATH_SEGMENT_REPLACEMENTS = Collections.unmodifiableMap(illegalPathSegmentReplacements);
+    }
+
+    /**
+     * Method that makes sure that passed in string is valid "path segment" string. It achieves it by potentially
+     * changing it, replacing illegal characters in it with legal ones.
+     * <p>
+     * Note: this method considers empty string as "valid path segment", it is caller duty to ensure empty string
+     * is not used as path segment alone.
+     * <p>
+     * This method is simplistic on purpose, and if frequently used, best if results are cached (per session)
+     */
+    public static String stringToPathSegment(String string) {
+        requireNonNull(string);
+        StringBuilder result = new StringBuilder(string);
+        for (Map.Entry<String, String> entry : ILLEGAL_PATH_SEGMENT_REPLACEMENTS.entrySet()) {
+            String illegal = entry.getKey();
+            int pos = result.indexOf(illegal);
+            while (pos >= 0) {
+                result.replace(pos, pos + illegal.length(), entry.getValue());
+                pos = result.indexOf(illegal);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class PathUtilsTest {
+    @Test
+    void stringToPathSegment_fixes() {
+        UnaryOperator<String> safeId = PathUtils::stringToPathSegment;
+        String good = "good";
+        String bad = "bad:id";
+
+        String goodFixedId = safeId.apply(good);
+        assertEquals(good, goodFixedId);
+
+        String badFixedId = safeId.apply(bad);
+        assertNotEquals(bad, badFixedId);
+        assertEquals("bad-COLON-id", badFixedId);
+    }
+
+    @Test
+    void stringToPathSegment_allCharsBad() {
+        String veryBad = "\\/:\"<>|?*";
+        String badFixedId = PathUtils.stringToPathSegment(veryBad);
+        assertNotEquals(veryBad, badFixedId);
+        assertEquals("-BACKSLASH--SLASH--COLON--QUOTE--LT--GT--PIPE--QMARK--ASTERISK-", badFixedId);
+    }
+}

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/repository/RepositoryIdHelperTest.java
@@ -33,33 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class RepositoryIdHelperTest {
     @Test
-    void fixes() {
-        Function<RemoteRepository, String> safeId = RepositoryIdHelper::idToPathSegment;
-        RemoteRepository good = new RemoteRepository.Builder("good", "default", "https://somewhere.com").build();
-        RemoteRepository bad = new RemoteRepository.Builder("bad:id", "default", "https://somewhere.com").build();
-
-        String goodId = good.getId();
-        String goodFixedId = safeId.apply(good);
-        assertEquals(goodId, goodFixedId);
-
-        String badId = bad.getId();
-        String badFixedId = safeId.apply(bad);
-        assertNotEquals(badId, badFixedId);
-        assertEquals("bad-COLON-id", badFixedId);
-    }
-
-    @Test
-    void allCharsBad() {
-        // hopefully we have no such IDs
-        RemoteRepository veryBad =
-                new RemoteRepository.Builder("\\/:\"<>|?*", "default", "https://somewhere.com").build();
-        String badId = veryBad.getId();
-        String badFixedId = RepositoryIdHelper.idToPathSegment(veryBad);
-        assertNotEquals(badId, badFixedId);
-        assertEquals("-BACKSLASH--SLASH--COLON--QUOTE--LT--GT--PIPE--QMARK--ASTERISK-", badFixedId);
-    }
-
-    @Test
     void caching() {
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(s -> false);
         session.setCache(new DefaultRepositoryCache()); // session has cache set


### PR DESCRIPTION
It caused in certain cases that lock names for different metadata collapsed onto same name, and hence, congestion with possible timeouts on resource happened. In case of metadata, `Metadata#getType` was totally ignored, which turns out was wrong, as today we have more types than the simple `maven-metadata.xml`.

Fix: We already had means to make sure "string is valid for path segment", but it was buried in `RepositoryIdHelper`. Pull it out, and make it reusable, as this is essentially very same use case. Also, this extra work really "punishes" only non maven metadata, and that is okay (right now we have only repository prefix and archetype catalog files in play).

Fixes #1609