### PR TITLE
Stop proliferation of static helper IO methods

### DIFF
--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory.java
@@ -32,6 +32,7 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
 import org.eclipse.aether.spi.connector.transport.TransporterProvider;
 import org.eclipse.aether.spi.io.ChecksumProcessor;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoRepositoryConnectorException;
 
 import static java.util.Objects.requireNonNull;
@@ -50,6 +51,8 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
 
     private final ChecksumPolicyProvider checksumPolicyProvider;
 
+    private final PathProcessor pathProcessor;
+
     private final ChecksumProcessor checksumProcessor;
 
     private final Map<String, ProvidedChecksumsSource> providedChecksumsSources;
@@ -61,11 +64,13 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
             TransporterProvider transporterProvider,
             RepositoryLayoutProvider layoutProvider,
             ChecksumPolicyProvider checksumPolicyProvider,
+            PathProcessor pathProcessor,
             ChecksumProcessor checksumProcessor,
             Map<String, ProvidedChecksumsSource> providedChecksumsSources) {
         this.transporterProvider = requireNonNull(transporterProvider, "transporter provider cannot be null");
         this.layoutProvider = requireNonNull(layoutProvider, "repository layout provider cannot be null");
         this.checksumPolicyProvider = requireNonNull(checksumPolicyProvider, "checksum policy provider cannot be null");
+        this.pathProcessor = requireNonNull(pathProcessor, "path processor cannot be null");
         this.checksumProcessor = requireNonNull(checksumProcessor, "checksum processor cannot be null");
         this.providedChecksumsSources =
                 requireNonNull(providedChecksumsSources, "provided checksum sources cannot be null");
@@ -99,6 +104,7 @@ public final class BasicRepositoryConnectorFactory implements RepositoryConnecto
                 transporterProvider,
                 layoutProvider,
                 checksumPolicyProvider,
+                pathProcessor,
                 checksumProcessor,
                 providedChecksumsSources);
     }

--- a/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
+++ b/maven-resolver-connector-basic/src/main/java/org/eclipse/aether/connector/basic/ChecksumValidator.java
@@ -31,8 +31,8 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayout.ChecksumLocation;
 import org.eclipse.aether.spi.io.ChecksumProcessor;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.ChecksumFailureException;
-import org.eclipse.aether.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +56,8 @@ final class ChecksumValidator {
 
     private final Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories;
 
+    private final PathProcessor pathProcessor;
+
     private final ChecksumProcessor checksumProcessor;
 
     private final ChecksumFetcher checksumFetcher;
@@ -68,9 +70,11 @@ final class ChecksumValidator {
 
     private final Map<Path, String> checksumExpectedValues;
 
+    @SuppressWarnings("checkstyle:parameternumber")
     ChecksumValidator(
             Path dataPath,
             Collection<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
+            PathProcessor pathProcessor,
             ChecksumProcessor checksumProcessor,
             ChecksumFetcher checksumFetcher,
             ChecksumPolicy checksumPolicy,
@@ -78,6 +82,7 @@ final class ChecksumValidator {
             Collection<ChecksumLocation> checksumLocations) {
         this.dataPath = dataPath;
         this.checksumAlgorithmFactories = checksumAlgorithmFactories;
+        this.pathProcessor = pathProcessor;
         this.checksumProcessor = checksumProcessor;
         this.checksumFetcher = checksumFetcher;
         this.checksumPolicy = checksumPolicy;
@@ -156,7 +161,7 @@ final class ChecksumValidator {
                 continue;
             }
             Path checksumFile = getChecksumPath(checksumLocation.getChecksumAlgorithmFactory());
-            try (FileUtils.TempFile tempFile = FileUtils.newTempFile()) {
+            try (PathProcessor.TempFile tempFile = pathProcessor.newTempFile()) {
                 Path tmp = tempFile.getPath();
                 try {
                     if (!checksumFetcher.fetchChecksum(checksumLocation.getLocation(), tmp)) {

--- a/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumValidatorTest.java
+++ b/maven-resolver-connector-basic/src/test/java/org/eclipse/aether/connector/basic/ChecksumValidatorTest.java
@@ -36,6 +36,7 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicy.ChecksumKind;
 import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.ChecksumFailureException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -189,6 +190,7 @@ public class ChecksumValidatorTest {
         return new ChecksumValidator(
                 dataFile.toPath(),
                 checksumAlgorithmFactories,
+                new PathProcessorSupport(),
                 new TestChecksumProcessor(),
                 fetcher,
                 policy,

--- a/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
+++ b/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
@@ -37,7 +37,7 @@ import dev.sigstore.encryption.certificates.Certificates;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.generator.sigstore.internal.FulcioOidHelper;
 import org.eclipse.aether.spi.artifact.generator.ArtifactGenerator;
-import org.eclipse.aether.util.FileUtils;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.util.artifact.SubArtifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,13 +45,18 @@ import org.slf4j.LoggerFactory;
 final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
     private static final String ARTIFACT_EXTENSION = ".sigstore.json";
     private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final PathProcessor pathProcessor;
     private final ArrayList<Artifact> artifacts;
     private final Predicate<Artifact> signableArtifactPredicate;
     private final boolean publicStaging;
     private final ArrayList<Path> signatureTempFiles;
 
     SigstoreSignatureArtifactGenerator(
-            Collection<Artifact> artifacts, Predicate<Artifact> signableArtifactPredicate, boolean publicStaging) {
+            PathProcessor pathProcessor,
+            Collection<Artifact> artifacts,
+            Predicate<Artifact> signableArtifactPredicate,
+            boolean publicStaging) {
+        this.pathProcessor = pathProcessor;
         this.artifacts = new ArrayList<>(artifacts);
         this.signableArtifactPredicate = signableArtifactPredicate;
         this.publicStaging = publicStaging;
@@ -107,7 +112,7 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
                                 + FulcioOidHelper.getIssuerV2(cert)
                                 + " IdP)");
 
-                        FileUtils.writeFile(signatureTempFile, p -> Files.writeString(p, bundle.toJson()));
+                        pathProcessor.write(signatureTempFile, bundle.toJson());
 
                         long duration = System.currentTimeMillis() - start;
                         logger.debug("  > Rekor entry "

--- a/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGeneratorFactory.java
+++ b/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGeneratorFactory.java
@@ -31,6 +31,7 @@ import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.spi.artifact.ArtifactPredicateFactory;
 import org.eclipse.aether.spi.artifact.generator.ArtifactGenerator;
 import org.eclipse.aether.spi.artifact.generator.ArtifactGeneratorFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.util.ConfigUtils;
 
 @Singleton
@@ -40,10 +41,13 @@ public final class SigstoreSignatureArtifactGeneratorFactory implements Artifact
     public static final String NAME = "sigstore";
 
     private final ArtifactPredicateFactory artifactPredicateFactory;
+    private final PathProcessor pathProcessor;
 
     @Inject
-    public SigstoreSignatureArtifactGeneratorFactory(ArtifactPredicateFactory artifactPredicateFactory) {
+    public SigstoreSignatureArtifactGeneratorFactory(
+            ArtifactPredicateFactory artifactPredicateFactory, PathProcessor pathProcessor) {
         this.artifactPredicateFactory = artifactPredicateFactory;
+        this.pathProcessor = pathProcessor;
     }
 
     @Override
@@ -68,7 +72,7 @@ public final class SigstoreSignatureArtifactGeneratorFactory implements Artifact
                 SigstoreConfigurationKeys.CONFIG_PROP_PUBLIC_STAGING);
 
         return new SigstoreSignatureArtifactGenerator(
-                artifacts, artifactPredicateFactory.newInstance(session)::hasChecksums, publicStaging);
+                pathProcessor, artifacts, artifactPredicateFactory.newInstance(session)::hasChecksums, publicStaging);
     }
 
     @Override

--- a/maven-resolver-generator-sigstore/src/test/java/org/eclipse/aether/generator/sigstore/SigstoreSignerFactoryTest.java
+++ b/maven-resolver-generator-sigstore/src/test/java/org/eclipse/aether/generator/sigstore/SigstoreSignerFactoryTest.java
@@ -34,6 +34,7 @@ import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.spi.artifact.ArtifactPredicate;
 import org.eclipse.aether.spi.artifact.ArtifactPredicateFactory;
 import org.eclipse.aether.spi.artifact.generator.ArtifactGenerator;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +58,7 @@ public class SigstoreSignerFactoryTest {
         when(artifactPredicateFactory.newInstance(any(RepositorySystemSession.class)))
                 .thenReturn(artifactPredicate);
 
-        return new SigstoreSignatureArtifactGeneratorFactory(artifactPredicateFactory);
+        return new SigstoreSignatureArtifactGeneratorFactory(artifactPredicateFactory, new PathProcessorSupport());
     }
 
     private RepositorySystemSession createSession() {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultPathProcessor.java
@@ -21,95 +21,11 @@ package org.eclipse.aether.internal.impl;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileTime;
-
-import org.eclipse.aether.spi.io.PathProcessor;
-import org.eclipse.aether.util.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 
 /**
- * A utility class helping with file-based operations.
+ * Exposing path processor (from SPI).
  */
 @Singleton
 @Named
-public class DefaultPathProcessor implements PathProcessor {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
-    @Override
-    public void setLastModified(Path path, long value) throws IOException {
-        try {
-            Files.setLastModifiedTime(path, FileTime.fromMillis(value));
-        } catch (FileSystemException e) {
-            // MRESOLVER-536: Java uses generic FileSystemException for some weird cases,
-            // but some subclasses like AccessDeniedEx should be re-thrown
-            if (e instanceof AccessDeniedException) {
-                throw e;
-            }
-            logger.trace("Failed to set last modified date: {}", path, e);
-        }
-    }
-
-    @Override
-    public void write(Path target, String data) throws IOException {
-        FileUtils.writeFile(target, p -> Files.write(p, data.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    @Override
-    public void write(Path target, InputStream source) throws IOException {
-        FileUtils.writeFile(target, p -> Files.copy(source, p, StandardCopyOption.REPLACE_EXISTING));
-    }
-
-    @Override
-    public long copy(Path source, Path target, ProgressListener listener) throws IOException {
-        try (InputStream in = new BufferedInputStream(Files.newInputStream(source));
-                FileUtils.CollocatedTempFile tempTarget = FileUtils.newTempFile(target);
-                OutputStream out = new BufferedOutputStream(Files.newOutputStream(tempTarget.getPath()))) {
-            long result = copy(out, in, listener);
-            tempTarget.move();
-            return result;
-        }
-    }
-
-    private long copy(OutputStream os, InputStream is, ProgressListener listener) throws IOException {
-        long total = 0L;
-        byte[] buffer = new byte[1024 * 32];
-        while (true) {
-            int bytes = is.read(buffer);
-            if (bytes < 0) {
-                break;
-            }
-
-            os.write(buffer, 0, bytes);
-
-            total += bytes;
-
-            if (listener != null && bytes > 0) {
-                try {
-                    listener.progressed(ByteBuffer.wrap(buffer, 0, bytes));
-                } catch (Exception e) {
-                    // too bad
-                }
-            }
-        }
-
-        return total;
-    }
-
-    @Override
-    public void move(Path source, Path target) throws IOException {
-        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
-    }
-}
+public class DefaultPathProcessor extends PathProcessorSupport {}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -38,7 +38,9 @@ import org.eclipse.aether.impl.UpdateCheckManager;
 import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.Filters;
-import org.eclipse.aether.internal.test.util.*;
+import org.eclipse.aether.internal.test.util.TestFileUtils;
+import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
@@ -61,6 +63,7 @@ import org.eclipse.aether.resolution.VersionResult;
 import org.eclipse.aether.spi.connector.ArtifactDownload;
 import org.eclipse.aether.spi.connector.MetadataDownload;
 import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.eclipse.aether.transfer.ArtifactTransferException;
 import org.eclipse.aether.util.repository.SimpleResolutionErrorPolicy;
@@ -110,7 +113,7 @@ public class DefaultArtifactResolverTest {
     private DefaultArtifactResolver setupArtifactResolver(
             VersionResolver versionResolver, UpdateCheckManager updateCheckManager) {
         return new DefaultArtifactResolver(
-                new TestPathProcessor(),
+                new PathProcessorSupport(),
                 new StubRepositoryEventDispatcher(),
                 versionResolver,
                 updateCheckManager,

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultDeployerTest.java
@@ -36,7 +36,6 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.deployment.DeploymentException;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
-import org.eclipse.aether.internal.test.util.TestPathProcessor;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.MergeableMetadata;
@@ -48,6 +47,7 @@ import org.eclipse.aether.spi.connector.ArtifactUpload;
 import org.eclipse.aether.spi.connector.MetadataDownload;
 import org.eclipse.aether.spi.connector.MetadataUpload;
 import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.MetadataNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -85,7 +85,7 @@ public class DefaultDeployerTest {
         connectorProvider = new StubRepositoryConnectorProvider();
 
         deployer = new DefaultDeployer(
-                new TestPathProcessor(),
+                new PathProcessorSupport(),
                 new StubRepositoryEventDispatcher(),
                 connectorProvider,
                 new StubRemoteRepositoryManager(),

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultInstallerTest.java
@@ -32,10 +32,13 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.installation.InstallRequest;
 import org.eclipse.aether.installation.InstallResult;
 import org.eclipse.aether.installation.InstallationException;
-import org.eclipse.aether.internal.test.util.*;
+import org.eclipse.aether.internal.test.util.TestFileUtils;
+import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.Metadata.Nature;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -84,7 +87,7 @@ public class DefaultInstallerTest {
         localArtifactFile = new File(session.getLocalRepository().getBasedir(), localArtifactPath);
 
         installer = new DefaultInstaller(
-                new TestPathProcessor(),
+                new PathProcessorSupport(),
                 new StubRepositoryEventDispatcher(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
@@ -31,6 +31,7 @@ import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 public class SummaryFileTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport {
     @Override
     protected FileTrustedChecksumsSourceSupport prepareSubject(RepositorySystemLifecycle lifecycle) {
-        return new SummaryFileTrustedChecksumsSource(new DefaultLocalPathComposer(), lifecycle);
+        return new SummaryFileTrustedChecksumsSource(
+                new DefaultLocalPathComposer(), lifecycle, new PathProcessorSupport());
     }
 
     @Override

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSourceTest.java
@@ -30,6 +30,7 @@ import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 
 /**
  * UT for {@link GroupIdRemoteRepositoryFilterSource}.
@@ -40,8 +41,8 @@ public class GroupIdRemoteRepositoryFilterSourceTest extends RemoteRepositoryFil
     @Override
     protected GroupIdRemoteRepositoryFilterSource getRemoteRepositoryFilterSource(
             DefaultRepositorySystemSession session, RemoteRepository remoteRepository) {
-        return groupIdRemoteRepositoryFilterSource =
-                new GroupIdRemoteRepositoryFilterSource(new DefaultRepositorySystemLifecycle());
+        return groupIdRemoteRepositoryFilterSource = new GroupIdRemoteRepositoryFilterSource(
+                new DefaultRepositorySystemLifecycle(), new PathProcessorSupport());
     }
 
     @Override

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.aether.spi.io;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -56,7 +57,7 @@ public interface PathProcessor {
      * and can be multiple, ranging from "file not found" to cases when FS does not support the setting the mtime.
      * @since 2.0.0
      */
-    void setLastModified(Path path, long value) throws IOException;
+    boolean setLastModified(Path path, long value) throws IOException;
 
     /**
      * Returns size of file, if exists.
@@ -93,6 +94,28 @@ public interface PathProcessor {
      * @throws IOException If an I/O error occurs.
      */
     void write(Path target, InputStream source) throws IOException;
+
+    /**
+     * Writes the given data to a file. UTF-8 is assumed as encoding for the data. Creates the necessary directories for
+     * the target file. In case of an error, the created directories will be left on the file system.
+     *
+     * @param target The file to write to, must not be {@code null}. This file will be overwritten.
+     * @param data The data to write, may be {@code null}.
+     * @throws IOException If an I/O error occurs.
+     * @since 2.0.13
+     */
+    void writeWithBackup(Path target, String data) throws IOException;
+
+    /**
+     * Writes the given stream to a file. Creates the necessary directories for the target file. In case of an error,
+     * the created directories will be left on the file system.
+     *
+     * @param target The file to write to, must not be {@code null}. This file will be overwritten.
+     * @param source The stream to write to the file, must not be {@code null}.
+     * @throws IOException If an I/O error occurs.
+     * @since 2.0.13
+     */
+    void writeWithBackup(Path target, InputStream source) throws IOException;
 
     /**
      * Moves the specified source file to the given target file. If the target file already exists, it is overwritten.
@@ -149,7 +172,68 @@ public interface PathProcessor {
      * @see PathProcessor#copy(Path, Path, ProgressListener)
      */
     interface ProgressListener {
-
         void progressed(ByteBuffer buffer) throws IOException;
     }
+
+    // Temporary files
+
+    /**
+     * A temporary file, that is removed when closed.
+     *
+     * @since 2.0.13
+     */
+    interface TempFile extends Closeable {
+        /**
+         * Returns the path of the created temp file.
+         */
+        Path getPath();
+    }
+
+    /**
+     * A collocated temporary file, that resides next to a "target" file, and is removed when closed.
+     *
+     * @since 2.0.13
+     */
+    interface CollocatedTempFile extends TempFile {
+        /**
+         * Upon close, atomically moves temp file to target file it is collocated with overwriting target (if exists).
+         * Invocation of this method merely signals that caller ultimately wants temp file to replace the target
+         * file, but when this method returns, the move operation did not yet happen, it will happen when this
+         * instance is closed.
+         * <p>
+         * Invoking this method <em>without writing to temp file</em> {@link #getPath()} (thus, not creating a temp
+         * file to be moved) is considered a bug, a mistake of the caller. Caller of this method should ensure
+         * that this method is invoked ONLY when the temp file is created and moving it to its final place is
+         * required.
+         */
+        void move() throws IOException;
+    }
+
+    /**
+     * Creates a {@link TempFile} instance and backing temporary file on file system. It will be located in the default
+     * temporary-file directory. Returned instance should be handled in try-with-resource construct and created
+     * temp file is removed (if exists) when returned instance is closed.
+     * <p>
+     * This method uses {@link Files#createTempFile(String, String, java.nio.file.attribute.FileAttribute[])} to create
+     * the temporary file on file system.
+     *
+     * @since 2.0.13
+     */
+    TempFile newTempFile() throws IOException;
+
+    /**
+     * Creates a {@link CollocatedTempFile} instance for given file without backing file. The path will be located in
+     * same directory where given file is, and will reuse its name for generated (randomized) name. Returned instance
+     * should be handled in try-with-resource and created temp path is removed (if exists) when returned instance is
+     * closed. The {@link CollocatedTempFile#move()} makes possible to atomically replace passed in file with the
+     * processed content written into a file backing the {@link CollocatedTempFile} instance.
+     * <p>
+     * The {@code file} nor it's parent directories have to exist. The parent directories are created if needed.
+     * <p>
+     * This method uses {@link Path#resolve(String)} to create the temporary file path in passed in file parent
+     * directory, but it does NOT create backing file on file system.
+     *
+     * @since 2.0.13
+     */
+    CollocatedTempFile newTempFile(Path file) throws IOException;
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessorSupport.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/io/PathProcessorSupport.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.spi.io;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utility class serving as base of {@link PathProcessor} implementations. This class can be extended or replaced
+ * (as component) when needed. Also, this class is published in Resolver implementation for path processor interface.
+ *
+ * @since 2.0.13
+ */
+public class PathProcessorSupport implements PathProcessor {
+    /**
+     * Logic borrowed from Commons-Lang3: we really need only this, to decide do we NIO2 file ops or not.
+     * For some reason non-NIO2 works better on Windows.
+     */
+    protected static final boolean IS_WINDOWS =
+            System.getProperty("os.name", "unknown").startsWith("Windows");
+
+    /**
+     * Escape hatch if atomic move is not desired on system we run on.
+     */
+    protected static final boolean ATOMIC_MOVE =
+            Boolean.parseBoolean(System.getProperty(PathProcessor.class.getName() + "ATOMIC_MOVE", "true"));
+
+    @Override
+    public boolean setLastModified(Path path, long value) throws IOException {
+        try {
+            Files.setLastModifiedTime(path, FileTime.fromMillis(value));
+            return true;
+        } catch (FileSystemException e) {
+            // MRESOLVER-536: Java uses generic FileSystemException for some weird cases,
+            // but some subclasses like AccessDeniedEx should be re-thrown
+            if (e instanceof AccessDeniedException) {
+                throw e;
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public void write(Path target, String data) throws IOException {
+        writeFile(target, p -> Files.write(p, data.getBytes(StandardCharsets.UTF_8)), false);
+    }
+
+    @Override
+    public void write(Path target, InputStream source) throws IOException {
+        writeFile(target, p -> Files.copy(source, p, StandardCopyOption.REPLACE_EXISTING), false);
+    }
+
+    @Override
+    public void writeWithBackup(Path target, String data) throws IOException {
+        writeFile(target, p -> Files.write(p, data.getBytes(StandardCharsets.UTF_8)), true);
+    }
+
+    @Override
+    public void writeWithBackup(Path target, InputStream source) throws IOException {
+        writeFile(target, p -> Files.copy(source, p, StandardCopyOption.REPLACE_EXISTING), true);
+    }
+
+    /**
+     * A file writer, that accepts a {@link Path} to write some content to. Note: the file denoted by path may exist,
+     * hence implementation have to ensure it is able to achieve its goal ("replace existing" option or equivalent
+     * should be used).
+     */
+    @FunctionalInterface
+    public interface FileWriter {
+        void write(Path path) throws IOException;
+    }
+
+    /**
+     * Utility method to write out file to disk in "atomic" manner, with optional backups (".bak") if needed. This
+     * ensures that no other thread or process will be able to read not fully written files. Finally, this method
+     * may create the needed parent directories, if the passed in target parents does not exist.
+     *
+     * @param target   that is the target file (must be an existing or non-existing file, the path must have parent)
+     * @param writer   the writer that will accept a {@link Path} to write content to
+     * @param doBackup if {@code true}, and target file is about to be overwritten, a ".bak" file with old contents will
+     *                 be created/overwritten
+     * @throws IOException if at any step IO problem occurs
+     */
+    public void writeFile(Path target, FileWriter writer, boolean doBackup) throws IOException {
+        requireNonNull(target, "target is null");
+        requireNonNull(writer, "writer is null");
+        Path parent = requireNonNull(target.getParent(), "target must have parent");
+
+        try (CollocatedTempFile tempFile = newTempFile(target)) {
+            writer.write(tempFile.getPath());
+            if (doBackup && Files.isRegularFile(target)) {
+                Files.copy(target, parent.resolve(target.getFileName() + ".bak"), StandardCopyOption.REPLACE_EXISTING);
+            }
+            tempFile.move();
+        }
+    }
+
+    @Override
+    public long copy(Path source, Path target, ProgressListener listener) throws IOException {
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(source));
+                CollocatedTempFile tempTarget = newTempFile(target);
+                OutputStream out = new BufferedOutputStream(Files.newOutputStream(tempTarget.getPath()))) {
+            long result = copy(out, in, listener);
+            tempTarget.move();
+            return result;
+        }
+    }
+
+    private long copy(OutputStream os, InputStream is, ProgressListener listener) throws IOException {
+        long total = 0L;
+        byte[] buffer = new byte[1024 * 32];
+        while (true) {
+            int bytes = is.read(buffer);
+            if (bytes < 0) {
+                break;
+            }
+
+            os.write(buffer, 0, bytes);
+
+            total += bytes;
+
+            if (listener != null && bytes > 0) {
+                try {
+                    listener.progressed(ByteBuffer.wrap(buffer, 0, bytes));
+                } catch (Exception e) {
+                    // too bad
+                }
+            }
+        }
+
+        return total;
+    }
+
+    @Override
+    public void move(Path source, Path target) throws IOException {
+        final StandardCopyOption[] copyOption = ATOMIC_MOVE
+                ? new StandardCopyOption[] {
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.COPY_ATTRIBUTES
+                }
+                : new StandardCopyOption[] {StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES};
+        if (IS_WINDOWS) {
+            classicCopy(source, target);
+        } else {
+            Files.move(source, target, copyOption);
+        }
+        Files.deleteIfExists(source);
+    }
+
+    // Temp files
+
+    @Override
+    public TempFile newTempFile() throws IOException {
+        Path tempFile = Files.createTempFile("resolver", "tmp");
+        return new TempFile() {
+            @Override
+            public Path getPath() {
+                return tempFile;
+            }
+
+            @Override
+            public void close() throws IOException {
+                Files.deleteIfExists(tempFile);
+            }
+        };
+    }
+
+    @Override
+    public CollocatedTempFile newTempFile(Path file) throws IOException {
+        Path parent = requireNonNull(file.getParent(), "file must have parent");
+        Files.createDirectories(parent);
+        Path tempFile = parent.resolve(file.getFileName() + "."
+                + Long.toUnsignedString(ThreadLocalRandom.current().nextLong()) + ".tmp");
+        return new CollocatedTempFile() {
+            private final AtomicBoolean wantsMove = new AtomicBoolean(false);
+            private final StandardCopyOption[] copyOption = ATOMIC_MOVE
+                    ? new StandardCopyOption[] {StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING}
+                    : new StandardCopyOption[] {StandardCopyOption.REPLACE_EXISTING};
+
+            @Override
+            public Path getPath() {
+                return tempFile;
+            }
+
+            @Override
+            public void move() {
+                wantsMove.set(true);
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (wantsMove.get()) {
+                    if (IS_WINDOWS) {
+                        classicCopy(tempFile, file);
+                    } else {
+                        Files.move(tempFile, file, copyOption);
+                    }
+                }
+                Files.deleteIfExists(tempFile);
+            }
+        };
+    }
+
+    /**
+     * On Windows we use pre-NIO2 way to copy files, as for some reason it works. Beat me why.
+     */
+    protected void classicCopy(Path source, Path target) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(1024 * 32);
+        byte[] array = buffer.array();
+        try (InputStream is = Files.newInputStream(source);
+                OutputStream os = Files.newOutputStream(target)) {
+            while (true) {
+                int bytes = is.read(array);
+                if (bytes < 0) {
+                    break;
+                }
+                os.write(array, 0, bytes);
+            }
+        }
+    }
+}

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -519,7 +519,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         HashMap<String, RemoteRepositoryFilterSource> result = new HashMap<>();
         result.put(
                 GroupIdRemoteRepositoryFilterSource.NAME,
-                new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle()));
+                new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle(), getPathProcessor()));
         result.put(
                 PrefixesRemoteRepositoryFilterSource.NAME,
                 new PrefixesRemoteRepositoryFilterSource(
@@ -586,7 +586,8 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 new SparseDirectoryTrustedChecksumsSource(getChecksumProcessor(), getLocalPathComposer()));
         result.put(
                 SummaryFileTrustedChecksumsSource.NAME,
-                new SummaryFileTrustedChecksumsSource(getLocalPathComposer(), getRepositorySystemLifecycle()));
+                new SummaryFileTrustedChecksumsSource(
+                        getLocalPathComposer(), getRepositorySystemLifecycle(), getPathProcessor()));
         return result;
     }
 
@@ -687,6 +688,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 getTransporterProvider(),
                 getRepositoryLayoutProvider(),
                 getChecksumPolicyProvider(),
+                getPathProcessor(),
                 getChecksumProcessor(),
                 getProvidedChecksumsSources());
     }

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -523,7 +523,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         HashMap<String, RemoteRepositoryFilterSource> result = new HashMap<>();
         result.put(
                 GroupIdRemoteRepositoryFilterSource.NAME,
-                new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle()));
+                new GroupIdRemoteRepositoryFilterSource(getRepositorySystemLifecycle(), getPathProcessor()));
         result.put(
                 PrefixesRemoteRepositoryFilterSource.NAME,
                 new PrefixesRemoteRepositoryFilterSource(
@@ -590,7 +590,8 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 new SparseDirectoryTrustedChecksumsSource(getChecksumProcessor(), getLocalPathComposer()));
         result.put(
                 SummaryFileTrustedChecksumsSource.NAME,
-                new SummaryFileTrustedChecksumsSource(getLocalPathComposer(), getRepositorySystemLifecycle()));
+                new SummaryFileTrustedChecksumsSource(
+                        getLocalPathComposer(), getRepositorySystemLifecycle(), getPathProcessor()));
         return result;
     }
 
@@ -691,6 +692,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
                 getTransporterProvider(),
                 getRepositoryLayoutProvider(),
                 getChecksumPolicyProvider(),
+                getPathProcessor(),
                 getChecksumProcessor(),
                 getProvidedChecksumsSources());
     }

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestPathProcessor.java
@@ -18,46 +18,12 @@
  */
 package org.eclipse.aether.internal.test.util;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-
-import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 
 /**
  * A simple file processor implementation to help satisfy component requirements during tests.
+ *
+ * @deprecated This class is deprecated and is unused in Resolver. Use {@link PathProcessorSupport} instead.
  */
-public class TestPathProcessor implements PathProcessor {
-
-    private final TestFileProcessor testFileProcessor = new TestFileProcessor();
-
-    @Override
-    public void setLastModified(Path path, long value) throws IOException {
-        Files.setLastModifiedTime(path, FileTime.fromMillis(value));
-    }
-
-    public void mkdirs(Path directory) {
-        if (directory == null) {
-            return;
-        }
-        testFileProcessor.mkdirs(directory.toFile());
-    }
-
-    public void write(Path file, String data) throws IOException {
-        testFileProcessor.write(file.toFile(), data);
-    }
-
-    public void write(Path target, InputStream source) throws IOException {
-        testFileProcessor.write(target.toFile(), source);
-    }
-
-    public long copy(Path source, Path target, ProgressListener listener) throws IOException {
-        return testFileProcessor.copy(source.toFile(), target.toFile(), null);
-    }
-
-    public void move(Path source, Path target) throws IOException {
-        testFileProcessor.move(source.toFile(), target.toFile());
-    }
-}
+@Deprecated
+public class TestPathProcessor extends PathProcessorSupport {}

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -100,7 +100,6 @@ import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.util.ConfigUtils;
-import org.eclipse.aether.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -683,7 +682,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                     extractChecksums(response);
                 }
             } else {
-                try (FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile(dataFile)) {
+                try (PathProcessor.CollocatedTempFile tempFile = pathProcessor.newTempFile(dataFile)) {
                     task.setDataPath(tempFile.getPath(), resume);
                     if (resume && Files.isRegularFile(dataFile)) {
                         try (InputStream inputStream = Files.newInputStream(dataFile)) {

--- a/maven-resolver-transport-apache/src/test/java/org/eclipse/aether/transport/apache/ApacheTransporterTest.java
+++ b/maven-resolver-transport-apache/src/test/java/org/eclipse/aether/transport/apache/ApacheTransporterTest.java
@@ -27,11 +27,11 @@ import org.apache.http.pool.PoolStats;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
-import org.eclipse.aether.internal.test.util.TestPathProcessor;
 import org.eclipse.aether.internal.test.util.http.HttpTransporterTest;
 import org.eclipse.aether.internal.test.util.http.RecordingTransportListener;
 import org.eclipse.aether.spi.connector.transport.GetTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ApacheTransporterTest extends HttpTransporterTest {
 
     public ApacheTransporterTest() {
-        super(() -> new ApacheTransporterFactory(standardChecksumExtractor(), new TestPathProcessor()));
+        super(() -> new ApacheTransporterFactory(standardChecksumExtractor(), new PathProcessorSupport()));
     }
 
     @Override

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk-11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -76,7 +76,6 @@ import org.eclipse.aether.spi.connector.transport.http.HttpTransporterException;
 import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.util.ConfigUtils;
-import org.eclipse.aether.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -335,7 +334,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
                     utilGet(task, is, true, length, downloadResumed);
                 }
             } else {
-                try (FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile(dataFile)) {
+                try (PathProcessor.CollocatedTempFile tempFile = pathProcessor.newTempFile(dataFile)) {
                     task.setDataPath(tempFile.getPath(), downloadResumed);
                     if (downloadResumed && Files.isRegularFile(dataFile)) {
                         try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(dataFile))) {
@@ -395,7 +394,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
             request = request.expectContinue(expectContinue);
         }
         headers.forEach(request::setHeader);
-        try (FileUtils.TempFile tempFile = FileUtils.newTempFile()) {
+        try (PathProcessor.TempFile tempFile = pathProcessor.newTempFile()) {
             utilPut(task, Files.newOutputStream(tempFile.getPath()), true);
             request.PUT(HttpRequest.BodyPublishers.ofFile(tempFile.getPath()));
 

--- a/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/JettyTransporter.java
+++ b/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/JettyTransporter.java
@@ -55,7 +55,6 @@ import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.util.ConfigUtils;
-import org.eclipse.aether.util.FileUtils;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.api.Authentication;
@@ -315,7 +314,7 @@ final class JettyTransporter extends AbstractTransporter implements HttpTranspor
                 utilGet(task, is, true, length, downloadResumed);
             }
         } else {
-            try (FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile(dataFile)) {
+            try (PathProcessor.CollocatedTempFile tempFile = pathProcessor.newTempFile(dataFile)) {
                 task.setDataPath(tempFile.getPath(), downloadResumed);
                 if (downloadResumed && Files.isRegularFile(dataFile)) {
                     try (InputStream inputStream = Files.newInputStream(dataFile)) {

--- a/maven-resolver-transport-jetty/src/test/java/org/eclipse/aether/transport/jetty/JettyTransporterTest.java
+++ b/maven-resolver-transport-jetty/src/test/java/org/eclipse/aether/transport/jetty/JettyTransporterTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.aether.transport.jetty;
 
-import org.eclipse.aether.internal.test.util.TestPathProcessor;
 import org.eclipse.aether.internal.test.util.http.HttpTransporterTest;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +59,6 @@ class JettyTransporterTest extends HttpTransporterTest {
     protected void testPut_Authenticated_ExpectContinueRejected_ExplicitlyConfiguredHeader() {}
 
     public JettyTransporterTest() {
-        super(() -> new JettyTransporterFactory(standardChecksumExtractor(), new TestPathProcessor()));
+        super(() -> new JettyTransporterFactory(standardChecksumExtractor(), new PathProcessorSupport()));
     }
 }

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterFactory.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterFactory.java
@@ -27,6 +27,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.util.ConfigUtils;
 
@@ -47,9 +48,13 @@ public final class MinioTransporterFactory implements TransporterFactory {
 
     private final Map<String, ObjectNameMapperFactory> objectNameMapperFactories;
 
+    private final PathProcessor pathProcessor;
+
     @Inject
-    public MinioTransporterFactory(Map<String, ObjectNameMapperFactory> objectNameMapperFactories) {
+    public MinioTransporterFactory(
+            Map<String, ObjectNameMapperFactory> objectNameMapperFactories, PathProcessor pathProcessor) {
         this.objectNameMapperFactories = requireNonNull(objectNameMapperFactories, "objectNameMapperFactories");
+        this.pathProcessor = requireNonNull(pathProcessor, "pathProcessor");
     }
 
     @Override
@@ -96,6 +101,6 @@ public final class MinioTransporterFactory implements TransporterFactory {
             throw new IllegalArgumentException("Unknown object name mapper configured '" + objectNameMapperConf
                     + "' for repository " + repository.getId());
         }
-        return new MinioTransporter(session, adjusted, objectNameMapperFactory);
+        return new MinioTransporter(session, adjusted, objectNameMapperFactory, pathProcessor);
     }
 }

--- a/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/MinioTransporterFactoryTest.java
+++ b/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/MinioTransporterFactoryTest.java
@@ -28,6 +28,7 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transport.minio.internal.FixedBucketObjectNameMapperFactory;
 import org.eclipse.aether.transport.minio.internal.RepositoryIdObjectNameMapperFactory;
@@ -55,7 +56,7 @@ class MinioTransporterFactoryTest {
         factories.put(RepositoryIdObjectNameMapperFactory.NAME, new RepositoryIdObjectNameMapperFactory());
         factories.put(FixedBucketObjectNameMapperFactory.NAME, new FixedBucketObjectNameMapperFactory());
 
-        factory = new MinioTransporterFactory(factories);
+        factory = new MinioTransporterFactory(factories, new PathProcessorSupport());
         session = new DefaultRepositorySystemSession(h -> true);
         repository = new RemoteRepository.Builder("repo", "default", "minio+http://localhost")
                 .setAuthentication(new AuthenticationBuilder()

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -87,6 +87,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-testing</artifactId>
       <version>1.6.0</version>

--- a/maven-resolver-transport-wagon/src/main/java/org/eclipse/aether/transport/wagon/WagonTransporterFactory.java
+++ b/maven-resolver-transport-wagon/src/main/java/org/eclipse/aether/transport/wagon/WagonTransporterFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.transfer.NoTransporterException;
 
 import static java.util.Objects.requireNonNull;
@@ -42,12 +43,16 @@ public final class WagonTransporterFactory implements TransporterFactory {
 
     private final WagonConfigurator wagonConfigurator;
 
+    private final PathProcessor pathProcessor;
+
     private float priority = -1.0f;
 
     @Inject
-    public WagonTransporterFactory(WagonProvider wagonProvider, WagonConfigurator wagonConfigurator) {
+    public WagonTransporterFactory(
+            WagonProvider wagonProvider, WagonConfigurator wagonConfigurator, PathProcessor pathProcessor) {
         this.wagonProvider = wagonProvider;
         this.wagonConfigurator = wagonConfigurator;
+        this.pathProcessor = pathProcessor;
     }
 
     @Override
@@ -72,6 +77,6 @@ public final class WagonTransporterFactory implements TransporterFactory {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
 
-        return new WagonTransporter(wagonProvider, wagonConfigurator, repository, session);
+        return new WagonTransporter(wagonProvider, wagonConfigurator, repository, session, pathProcessor);
     }
 }

--- a/maven-resolver-transport-wagon/src/test/java/org/eclipse/aether/transport/wagon/AbstractWagonTransporterTest.java
+++ b/maven-resolver-transport-wagon/src/test/java/org/eclipse/aether/transport/wagon/AbstractWagonTransporterTest.java
@@ -39,6 +39,7 @@ import org.eclipse.aether.spi.connector.transport.PeekTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.NoTransporterException;
 import org.eclipse.aether.transfer.TransferCancelledException;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
@@ -99,7 +100,8 @@ public abstract class AbstractWagonTransporterTest {
                     public void configure(Wagon wagon, Object configuration) {
                         ((Configurable) wagon).setConfiguration(configuration);
                     }
-                });
+                },
+                new PathProcessorSupport());
         id = UUID.randomUUID().toString().replace("-", "");
         fs = MemWagonUtils.getFilesystem(id);
         fs.put("file.txt", "test");

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -35,7 +35,9 @@ import static java.util.Objects.requireNonNull;
  * A utility class to write files.
  *
  * @since 1.9.0
+ * @deprecated Do not use this class; is not used in Resolver (see corresponding processor components in {@code org.eclipse.aether.spi.io} package).
  */
+@Deprecated
 public final class FileUtils {
     /**
      * Logic borrowed from Commons-Lang3: we really need only this, to decide do we NIO2 file ops or not.
@@ -55,6 +57,7 @@ public final class FileUtils {
     private FileUtils() {
         // hide constructor
     }
+
     /**
      * A temporary file, that is removed when closed.
      */


### PR DESCRIPTION
Originall, the PathProcessor (before FileProcessor) was main component dealing with IO, restore this state.

The proliferation of static IO helpers is just bad, as it does not allow (easy) overriding as it is the case of components.