### PR TITLE
GH-1646 bugfix for filter support in ADNC

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/AbstractDependencyNodeConsumerVisitor.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/AbstractDependencyNodeConsumerVisitor.java
@@ -81,7 +81,7 @@ abstract class AbstractDependencyNodeConsumerVisitor implements DependencyVisito
     protected abstract boolean doVisitLeave(DependencyNode node);
 
     protected boolean acceptNode(DependencyNode node) {
-        return filter.accept(node, path);
+        return filter.accept(node, path.head());
     }
 
     protected void consumeNode(DependencyNode node) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/Stack.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/visitor/Stack.java
@@ -19,6 +19,8 @@
 package org.eclipse.aether.util.graph.visitor;
 
 import java.util.AbstractList;
+import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
 
@@ -68,5 +70,16 @@ class Stack<E> extends AbstractList<E> implements RandomAccess {
     @Override
     public int size() {
         return size;
+    }
+
+    /**
+     * Returns a view as list sans top element.
+     */
+    public List<E> head() {
+        if (size < 2) {
+            return Collections.emptyList();
+        } else {
+            return subList(0, size - 1);
+        }
     }
 }


### PR DESCRIPTION
The path contained current node, violating the DependencyFilter contract that expected parents only of current node.

Also a minor cleanup re deprecated method use.

Fixes #1646
