### PR TITLE
ScopeManager: do not interfere with session graph transformer

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/scope/InternalScopeManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/scope/InternalScopeManager.java
@@ -21,10 +21,9 @@ package org.eclipse.aether.impl.scope;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.CollectResult;
-import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencySelector;
-import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.scope.DependencyScope;
 import org.eclipse.aether.scope.ResolutionScope;
 import org.eclipse.aether.scope.ScopeManager;
@@ -58,25 +57,14 @@ public interface InternalScopeManager extends ScopeManager {
      * Resolver specific: dependency selector to be used to support this scope (with its dependency
      * and resolution scopes).
      */
-    DependencySelector getDependencySelector(ResolutionScope resolutionScope);
-
-    /**
-     * Resolver specific: dependency graph transformer to be used to support this scope (with its dependency
-     * and resolution scopes).
-     */
-    DependencyGraphTransformer getDependencyGraphTransformer(ResolutionScope resolutionScope);
+    DependencySelector getDependencySelector(RepositorySystemSession session, ResolutionScope resolutionScope);
 
     /**
      * Resolver specific: post-processing to be used to support this scope (with its dependency
      * and resolution scopes).
      */
-    CollectResult postProcess(ResolutionScope resolutionScope, CollectResult collectResult);
-
-    /**
-     * Resolver specific: dependency filter to be used to support this scope (with its dependency
-     * and resolution scopes).
-     */
-    DependencyFilter getDependencyFilter(ResolutionScope resolutionScope);
+    CollectResult postProcess(
+            RepositorySystemSession session, ResolutionScope resolutionScope, CollectResult collectResult);
 
     /**
      * The mode of resolution scope: eliminate (remove all occurrences) or just remove.

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -264,7 +264,7 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         }
 
         if (request.getResolutionScope() != null) {
-            return scopeManager.postProcess(request.getResolutionScope(), result);
+            return scopeManager.postProcess(session, request.getResolutionScope(), result);
         } else {
             return result;
         }
@@ -312,8 +312,7 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         ResolutionScope resolutionScope = collectRequest.getResolutionScope();
         if (resolutionScope != null) {
             requireNonNull(scopeManager, "ScopeManager is not set on session");
-            optimized.setDependencySelector(scopeManager.getDependencySelector(resolutionScope));
-            optimized.setDependencyGraphTransformer(scopeManager.getDependencyGraphTransformer(resolutionScope));
+            optimized.setDependencySelector(scopeManager.getDependencySelector(session, resolutionScope));
         }
         return optimized;
     }

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -32,6 +32,7 @@ import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.DependencyTraverser;
+import org.eclipse.aether.impl.scope.InternalScopeManager;
 import org.eclipse.aether.internal.impl.scope.ManagedDependencyContextRefiner;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeDeriver;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeSelector;
@@ -65,7 +66,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected final RepositorySystem repositorySystem;
-    protected final ScopeManagerImpl scopeManager;
+    protected final InternalScopeManager scopeManager;
 
     public SessionBuilderSupplier(RepositorySystem repositorySystem) {
         this.repositorySystem = requireNonNull(repositorySystem);
@@ -88,12 +89,16 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         session.setArtifactDescriptorPolicy(getArtifactDescriptorPolicy());
     }
 
+    protected InternalScopeManager getScopeManager() {
+        return this.scopeManager;
+    }
+
     protected DependencyTraverser getDependencyTraverser() {
         return new FatArtifactTraverser();
     }
 
     protected DependencyManager getDependencyManager() {
-        return new ClassicDependencyManager(scopeManager);
+        return new ClassicDependencyManager(getScopeManager());
     }
 
     protected DependencySelector getDependencySelector() {
@@ -110,10 +115,10 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         return new ChainedDependencyGraphTransformer(
                 new ConflictResolver(
                         new ConfigurableVersionSelector(),
-                        new ManagedScopeSelector(this.scopeManager),
+                        new ManagedScopeSelector(getScopeManager()),
                         new SimpleOptionalitySelector(),
-                        new ManagedScopeDeriver(this.scopeManager)),
-                new ManagedDependencyContextRefiner(this.scopeManager));
+                        new ManagedScopeDeriver(getScopeManager())),
+                new ManagedDependencyContextRefiner(getScopeManager()));
     }
 
     protected ArtifactTypeRegistry getArtifactTypeRegistry() {

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -95,8 +95,8 @@ public class SessionBuilderSupplier {
 
     public DependencyManager getDependencyManager(boolean transitive) {
         return transitive
-                ? new TransitiveDependencyManager(this.getScopeManager())
-                : new ClassicDependencyManager(this.scopeManager);
+                ? new TransitiveDependencyManager(getScopeManager())
+                : new ClassicDependencyManager(getScopeManager());
     }
 
     protected DependencySelector getDependencySelector() {
@@ -112,10 +112,10 @@ public class SessionBuilderSupplier {
         return new ChainedDependencyGraphTransformer(
                 new ConflictResolver(
                         new ConfigurableVersionSelector(),
-                        new ManagedScopeSelector(this.getScopeManager()),
+                        new ManagedScopeSelector(getScopeManager()),
                         new SimpleOptionalitySelector(),
-                        new ManagedScopeDeriver(this.getScopeManager())),
-                new ManagedDependencyContextRefiner(this.getScopeManager()));
+                        new ManagedScopeDeriver(getScopeManager())),
+                new ManagedDependencyContextRefiner(getScopeManager()));
     }
 
     protected ArtifactTypeRegistry getArtifactTypeRegistry() {


### PR DESCRIPTION
Just assume integrator (ie Maven) knows what is doing, as IF integrator wants to use ScopeManager, it needs to tie it into proper components (see suppliers). OTOH, suppliers are cleaned up and aligned.

Otherwise this is really just a nasty issue/bug on integrator side.

Fixes #1648 