### PR TITLE
Maven Resolver lockrepro

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependenciesParallel.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependenciesParallel.java
@@ -215,7 +215,7 @@ public class ResolveTransitiveDependenciesParallel {
                 DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, null);
                 List<ArtifactResult> artifactResults =
                         system.resolveDependencies(session, dependencyRequest).getArtifactResults();
-                int resolved = 9;
+                int resolved = 0;
                 int fails = 0;
                 for (ArtifactResult artifactResult : artifactResults) {
                     if (artifactResult.isResolved()) {


### PR DESCRIPTION
Reproducer for Resolver 2.x. Does not run as part of test/build, is meant to be ad-hoc be run from IDE.

