### PR TITLE
[MNG-7559] Fix version comparison with case insensitive lexical order

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
@@ -176,26 +176,33 @@ final class GenericVersion implements Version {
 
     static final class Tokenizer {
 
-        private static final Integer QUALIFIER_ALPHA = -5;
+        private static final Integer QUALIFIER_ALPHA = -7;
 
-        private static final Integer QUALIFIER_BETA = -4;
+        private static final Integer QUALIFIER_BETA = -6;
 
-        private static final Integer QUALIFIER_MILESTONE = -3;
+        private static final Integer QUALIFIER_MILESTONE = -5;
 
         private static final Map<String, Integer> QUALIFIERS;
 
         static {
             QUALIFIERS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            // PRE RELEASE
             QUALIFIERS.put("alpha", QUALIFIER_ALPHA);
             QUALIFIERS.put("beta", QUALIFIER_BETA);
             QUALIFIERS.put("milestone", QUALIFIER_MILESTONE);
-            QUALIFIERS.put("cr", -2);
-            QUALIFIERS.put("rc", -2);
+            QUALIFIERS.put("pr", -4);
+            QUALIFIERS.put("pre", -4);
+            QUALIFIERS.put("preview", -4);
+            QUALIFIERS.put("rc", -3);
+            QUALIFIERS.put("cr", -3);
+            QUALIFIERS.put("dev", -2);
             QUALIFIERS.put("snapshot", -1);
-            QUALIFIERS.put("ga", 0);
-            QUALIFIERS.put("final", 0);
-            QUALIFIERS.put("release", 0);
+            // RELEASE
             QUALIFIERS.put("", 0);
+            QUALIFIERS.put("final", 0);
+            QUALIFIERS.put("ga", 0);
+            QUALIFIERS.put("release", 0);
+            // POST RELEASE
             QUALIFIERS.put("sp", 1);
         }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersionScheme.java
@@ -36,8 +36,9 @@ import org.eclipse.aether.version.InvalidVersionSpecificationException;
  * <p>
  * Numeric segments are compared mathematically, alphabetic segments are compared lexicographically and
  * case-insensitively. However, the following qualifier strings are recognized and treated specially: "alpha" = "a" &lt;
- * "beta" = "b" &lt; "milestone" = "m" &lt; "cr" = "rc" &lt; "snapshot" &lt; "final" = "ga" &lt; "sp". All of those
- * well-known qualifiers are considered smaller/older than other strings. An empty segment/string is equivalent to 0.
+ * "beta" = "b" &lt; "milestone" = "m" &lt; "pr" = "pre" = "preview" &lt; "rc" = "cr" &lt; "dev" &lt; "snapshot" &lt;
+ * "final" = "ga" = "release" &lt; "sp". All of those well-known qualifiers are considered smaller/older than other
+ * strings. An empty segment/string is equivalent to 0.
  * </p>
  * <p>
  * In addition to the above mentioned qualifiers, the tokens "min" and "max" may be used as final version segment to

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/package-info.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/package-info.java
@@ -42,18 +42,20 @@
  *             <li>"alpha" (== "a" when immediately followed by number)</li>
  *             <li>"beta" (== "b" when immediately followed by number)</li>
  *             <li>"milestone" (== "m" when immediately followed by number)</li>
- *             <li>"rc" == "cr" (use of "cr" is discouraged)</li>
+ *             <li>"pr" = "pre" = "preview" (use is discouraged)</li>
+ *             <li>"rc" == "cr" (use of "cr" is discouraged, use rc instead)</li>
+ *             <li>"dev" (use is discouraged)</li>
  *             <li>"snapshot"</li>
- *             <li>"ga" == "final" == "release"</li>
- *             <li>"sp"</li>
+ *             <li>"final" == "ga" == "release" (use is discouraged, use no qualifier instead)</li>
+ *             <li>"sp" (use of "sp" is discouraged, increment patch version instead)</li>
  *         </ul>
  *     </li>
  *     <li>String segments are sorted lexicographically and case-insensitively per ROOT locale, ascending.</li>
  *     <li>There are two special segments, {@code "min"} and {@code "max"} that represent absolute minimum and absolute maximum in comparisons. They can be used only as the trailing segment.</li>
  *     <li>As last step, trailing "zero segments" are trimmed. Similarly, "zero segments" positioned before numeric and non-numeric transitions (either explicitly or implicitly delimited) are trimmed.</li>
- *     <li>When trimming, "zero segments" are qualifiers {@code "ga"}, {@code "final"}, {@code "release"} only if being last (right-most) segment, empty string and "0" always.</li>
+ *     <li>When trimming, "zero segments" are qualifiers {@code "final"}, {@code "ga"}, {@code "release"} only if being last (right-most) segment, empty string and "0" always.</li>
  *     <li>In comparison of same kind segments, the given type of segment determines comparison rules.</li>
- *     <li>In comparison of different kind of segments, following applies: {@code max > numeric > string > qualifier > min}.</li>
+ *     <li>In comparison of different kind of segments, following applies: {@code min < qualifier < string < numeric < max}.</li>
  *     <li>Any version can be considered to have an infinite number of invisible trailing "zero segments", for the purposes of comparison (in other words, "1" == "1.0.0.0.0.0.0.0.0....")</li>
  *     <li>It is common that a version identifier starts with numeric segment (consider this "best practice").</li>
  * </ul>


### PR DESCRIPTION
This PR description was edited to reflect its latest status:

Recurring issues show that Maven’s current handling of qualifiers is incomplete, impacting multiple companies and users:
* mojohaus/versions#744
* https://github.com/apache/maven/issues/8891
* https://github.com/dependabot/dependabot-core/pull/6747
* https://github.com/dependabot/dependabot-core/pull/10207

These issues need to be addressed in Maven Resolver. I am working to encourage Maven to adopt a fix through this PR.

Proposed ordering:
* alpha < beta < milestone < pr = pre = preview < rc = cr < dev < snapshot < final = ga = release < sp

I edited the documentation to discourage the use of certain qualifiers:
* The use of pr, pre, preview is discouraged
* The use of cr is discouraged (use rc instead)
* The use of dev is discouraged
* The use of final, ga, release is discouraged (use no qualifier instead)
* The use of sp is discouraged (increment patch version instead)

Optional inclusions:
* ea (early access), edr, pfd (drafts), mr

As long as discouraged qualifiers continue to be used in practice, tools will still need to support them. Once they are phased out, however, support can be safely dropped.

Another possible direction would be:
* Partial SemVer2 support, which could simplify handling of qualifiers:
  * Accept the "+" char as a separator.
  * Temporarily treat discouraged qualifiers as follows (while discouraging their use when necessary):
    * latest pre-release: dev, snapshot
    * release: final, ga, release
    * post-release: sp
  * Treat all other qualifiers as pre-release without hard-coding them, reducing the number of special cases.
  * Use aliases/mapping:
    * a to alpha
    * b to beta
    * m to milestone
    * cr to rc
    * "final", "ga", "release" to ""
* Maven could force the build to fail if any module uses discouraged qualifiers.
* Maven Central could begin rejecting new artifacts using discouraged qualifiers.

Thanks for your input.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure please ask on the developers list.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
