### PR TITLE
Prevent FileNotFoundException when reading .lastUpdated tracking files

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManager.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
@@ -60,6 +61,8 @@ public final class DefaultTrackingFileManager implements TrackingFileManager {
                     Properties props = new Properties();
                     props.load(stream);
                     return props;
+                } catch (FileNotFoundException e) {
+                    return null;
                 } catch (IOException e) {
                     LOGGER.warn("Failed to read tracking file '{}'", file, e);
                     throw new UncheckedIOException(e);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultTrackingFileManagerTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.eclipse.aether.internal.impl.fs.DefaultTrackingTestFile;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
 import org.junit.Test;
 
@@ -102,6 +104,13 @@ public class DefaultTrackingFileManagerTest {
             assertNotNull(tfm.update(propFile, updates));
             assertTrue("Leaked file: " + propFile, propFile.delete());
         }
+    }
+
+    @Test
+    public void testFileNotFoundIsIgnoredWhenReadingTrackingFile() {
+        TrackingFileManager tfm = new DefaultTrackingFileManager();
+        Properties properties = tfm.read(new DefaultTrackingTestFile("hello\u0000", Paths.get("")));
+        assertNull(properties);
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/fs/DefaultTrackingTestFile.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/fs/DefaultTrackingTestFile.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.fs;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * The DefaultTrackingTestFile class extends the File class and provides additional functionality
+ * for working with files using a safe Path object.
+ * This class ensures file operations are referenced and handled using the encapsulated Path instance.
+ */
+public class DefaultTrackingTestFile extends File {
+    private final Path safePath;
+
+    public DefaultTrackingTestFile(String pathname, Path safePath) {
+        super(pathname);
+        this.safePath = safePath;
+    }
+
+    @Override
+    public Path toPath() {
+        return safePath;
+    }
+
+    @Override
+    public String getCanonicalPath() {
+        return safePath.toString();
+    }
+}


### PR DESCRIPTION
In our CI pipelines we are encountering a substantial number of exceptions like:

```
[main] [WARNING] Failed to read tracking file '/home/builduser/.m2/repository/cached/central-proxy/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar.lastUpdated'
java.io.FileNotFoundException: /home/builduser/.m2/repository/cached/central-proxy/org/apache/maven/wagon/wagon-provider-api/1.0-alpha-6/wagon-provider-api-1.0-alpha-6.jar.lastUpdated (No such file or directory)
    at java.io.FileInputStream.open0 (Native Method)
    at java.io.FileInputStream.open (FileInputStream.java:219)
    at java.io.FileInputStream.<init> (FileInputStream.java:157)
    at org.eclipse.aether.internal.impl.DefaultTrackingFileManager.read (DefaultTrackingFileManager.java:58)
    ...
```

These errors occur when a `.lastUpdated` tracking file is missing during concurrent repository access, leading the build to fail even though the file absence is harmless.

This patch introduces a safe fallback by catching `FileNotFoundException` in `DefaultTrackingFileManager.read()`. Missing or concurrently removed tracking files are now treated as non-fatal, preventing unnecessary build failures.
