### PR TITLE
Bugfix: Prioritized Components Cache change detection got removed

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -57,8 +57,8 @@ public final class PrioritizedComponents<T> {
         if (cached && session.getCache() != null) {
             String key = PrioritizedComponents.class.getName() + ".pc." + discriminator.getName()
                     + Integer.toHexString(components.hashCode());
-            return (PrioritizedComponents<C>)
-                    session.getCache().computeIfAbsent(session, key, () -> create(session, components, priorityFunction));
+            return (PrioritizedComponents<C>) session.getCache()
+                    .computeIfAbsent(session, key, () -> create(session, components, priorityFunction));
         } else {
             return create(session, components, priorityFunction);
         }


### PR DESCRIPTION
The commit c32b8c9236389ee04ab5d0aac3d206f8bb1b2f36 added discriminator ("owner class") to key, but by mistake dropped the change detection.

The original intent of that commit was to avoid hash clashes as key did not factor in owner.