### PR TITLE
Bug: depMgt in manager was "last wins" instead of "first wins"

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -197,7 +197,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             MMap<Key, String> managedLocalPaths,
             MMap<Key, Holder<Collection<Exclusion>>> managedExclusions);
 
-    private boolean containsManagedVersion(Key key) {
+    private boolean containsManagedVersion(Key key, MMap<Key, String> managedVersions) {
         for (AbstractDependencyManager ancestor : path) {
             if (ancestor.managedVersions != null && ancestor.managedVersions.containsKey(key)) {
                 return true;
@@ -218,7 +218,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
         return null;
     }
 
-    private boolean containsManagedScope(Key key) {
+    private boolean containsManagedScope(Key key, MMap<Key, String> managedScopes) {
         for (AbstractDependencyManager ancestor : path) {
             if (ancestor.managedScopes != null && ancestor.managedScopes.containsKey(key)) {
                 return true;
@@ -239,7 +239,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
         return null;
     }
 
-    private boolean containsManagedOptional(Key key) {
+    private boolean containsManagedOptional(Key key, MMap<Key, Boolean> managedOptionals) {
         for (AbstractDependencyManager ancestor : path) {
             if (ancestor.managedOptionals != null && ancestor.managedOptionals.containsKey(key)) {
                 return true;
@@ -260,7 +260,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
         return null;
     }
 
-    private boolean containsManagedLocalPath(Key key) {
+    private boolean containsManagedLocalPath(Key key, MMap<Key, String> managedLocalPaths) {
         for (AbstractDependencyManager ancestor : path) {
             if (ancestor.managedLocalPaths != null && ancestor.managedLocalPaths.containsKey(key)) {
                 return true;
@@ -327,7 +327,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             Key key = new Key(artifact);
 
             String version = artifact.getVersion();
-            if (!version.isEmpty() && !containsManagedVersion(key)) {
+            if (!version.isEmpty() && !containsManagedVersion(key, managedVersions)) {
                 if (managedVersions == null) {
                     managedVersions = MMap.emptyNotDone();
                 }
@@ -336,7 +336,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
 
             if (isInheritedDerived()) {
                 String scope = managedDependency.getScope();
-                if (!scope.isEmpty() && !containsManagedScope(key)) {
+                if (!scope.isEmpty() && !containsManagedScope(key, managedScopes)) {
                     if (managedScopes == null) {
                         managedScopes = MMap.emptyNotDone();
                     }
@@ -344,7 +344,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 }
 
                 Boolean optional = managedDependency.getOptional();
-                if (optional != null && !containsManagedOptional(key)) {
+                if (optional != null && !containsManagedOptional(key, managedOptionals)) {
                     if (managedOptionals == null) {
                         managedOptionals = MMap.emptyNotDone();
                     }
@@ -355,7 +355,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             String localPath = systemDependencyScope == null
                     ? null
                     : systemDependencyScope.getSystemPath(managedDependency.getArtifact());
-            if (localPath != null && !containsManagedLocalPath(key)) {
+            if (localPath != null && !containsManagedLocalPath(key, managedLocalPaths)) {
                 if (managedLocalPaths == null) {
                     managedLocalPaths = MMap.emptyNotDone();
                 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -72,6 +72,19 @@ public class DependencyManagerTest {
     }
 
     @Test
+    void duplicateDepMgt() {
+        DependencyManager manager = new TransitiveDependencyManager(null);
+        DependencyManager derived = manager.deriveChildManager(newContext(
+                        new Dependency(new DefaultArtifact("dupe:dupe:1.0"), ""),
+                        new Dependency(new DefaultArtifact("dupe:dupe:2.0"), "")))
+                .deriveChildManager(newContext());
+        DependencyManagement management =
+                derived.manageDependency(new Dependency(new DefaultArtifact("dupe:dupe:1.1"), ""));
+        // bug: here would be 2.0
+        assertEquals("1.0", management.getVersion());
+    }
+
+    @Test
     void testClassic() {
         DependencyManager manager = new ClassicDependencyManager(null);
         DependencyManagement mngt;


### PR DESCRIPTION
The dependency manager since commit 51a3de6cd5834bbb2748111f7d767093bf99007e (2.0.11+) had a bug to detect just added entries, and it resulted in "last wins" logic.

This PR fixes the issue and adds UT ensuring "first wins".

Still, we are uncovered in tests (seems we are biased), as we have no "duplicate entries in depMgt"-like tests as all!