### PR TITLE
Advised and Enforced Management

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
@@ -19,7 +19,7 @@
 package org.eclipse.aether.collection;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.eclipse.aether.graph.Exclusion;
@@ -43,15 +43,15 @@ public final class DependencyManagement {
         PROPERTIES
     }
 
-    private final Map<Subject, Object> managedValues;
-    private final Map<Subject, Boolean> managedEnforced;
+    private final EnumMap<Subject, Object> managedValues;
+    private final EnumMap<Subject, Boolean> managedEnforced;
 
     /**
      * Creates an empty management update.
      */
     public DependencyManagement() {
-        this.managedValues = new HashMap<>();
-        this.managedEnforced = new HashMap<>();
+        this.managedValues = new EnumMap<>(Subject.class);
+        this.managedEnforced = new EnumMap<>(Subject.class);
     }
 
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.collection;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.aether.graph.Exclusion;
@@ -29,22 +30,46 @@ import org.eclipse.aether.graph.Exclusion;
  * @see DependencyManager#manageDependency(org.eclipse.aether.graph.Dependency)
  */
 public final class DependencyManagement {
+    /**
+     * Enumeration of manageable attributes, attributes that can be subjected to dependency management.
+     *
+     * @since 2.0.17
+     */
+    public enum Subject {
+        VERSION,
+        SCOPE,
+        OPTIONAL,
+        EXCLUSIONS,
+        PROPERTIES
+    }
 
-    private String version;
-
-    private String scope;
-
-    private Boolean optional;
-
-    private Collection<Exclusion> exclusions;
-
-    private Map<String, String> properties;
+    private final Map<Subject, Object> managedValues;
+    private final Map<Subject, Boolean> managedEnforced;
 
     /**
      * Creates an empty management update.
      */
     public DependencyManagement() {
-        // enables default constructor
+        this.managedValues = new HashMap<>();
+        this.managedEnforced = new HashMap<>();
+    }
+
+    /**
+     * Returns {@code true} if passed in subject is managed.
+     *
+     * @since 2.0.17
+     */
+    public boolean isManagedSubject(Subject subject) {
+        return managedValues.containsKey(subject);
+    }
+
+    /**
+     * Returns {@code true} if passed in subject is managed and is enforced.
+     *
+     * @since 2.0.17
+     */
+    public boolean isManagedSubjectEnforced(Subject subject) {
+        return isManagedSubject(subject) && managedEnforced.getOrDefault(subject, false);
     }
 
     /**
@@ -54,7 +79,7 @@ public final class DependencyManagement {
      *         remain unchanged.
      */
     public String getVersion() {
-        return version;
+        return (String) managedValues.get(Subject.VERSION);
     }
 
     /**
@@ -62,9 +87,29 @@ public final class DependencyManagement {
      *
      * @param version The new version, may be {@code null} if the version is not managed.
      * @return This management update for chaining, never {@code null}.
+     * @deprecated Use {@link #setVersion(String, boolean)} instead.
      */
+    @Deprecated
     public DependencyManagement setVersion(String version) {
-        this.version = version;
+        return setVersion(version, true);
+    }
+
+    /**
+     * Sets the new version to apply to the dependency.
+     *
+     * @param version The new version, may be {@code null} if the version is not managed.
+     * @param enforced The enforcement of new value.
+     * @return This management update for chaining, never {@code null}.
+     * @since 2.0.17
+     */
+    public DependencyManagement setVersion(String version, boolean enforced) {
+        if (version == null) {
+            this.managedValues.remove(Subject.VERSION);
+            this.managedEnforced.remove(Subject.VERSION);
+        } else {
+            this.managedValues.put(Subject.VERSION, version);
+            this.managedEnforced.put(Subject.VERSION, enforced);
+        }
         return this;
     }
 
@@ -75,7 +120,7 @@ public final class DependencyManagement {
      *         unchanged.
      */
     public String getScope() {
-        return scope;
+        return (String) managedValues.get(Subject.SCOPE);
     }
 
     /**
@@ -83,9 +128,29 @@ public final class DependencyManagement {
      *
      * @param scope The new scope, may be {@code null} if the scope is not managed.
      * @return This management update for chaining, never {@code null}.
+     * @deprecated Use {@link #setScope(String, boolean)} instead.
      */
+    @Deprecated
     public DependencyManagement setScope(String scope) {
-        this.scope = scope;
+        return setScope(scope, true);
+    }
+
+    /**
+     * Sets the new scope to apply to the dependency.
+     *
+     * @param scope The new scope, may be {@code null} if the scope is not managed.
+     * @param enforced The enforcement of new value.
+     * @return This management update for chaining, never {@code null}.
+     * @since 2.0.17
+     */
+    public DependencyManagement setScope(String scope, boolean enforced) {
+        if (scope == null) {
+            this.managedValues.remove(Subject.SCOPE);
+            this.managedEnforced.remove(Subject.SCOPE);
+        } else {
+            this.managedValues.put(Subject.SCOPE, scope);
+            this.managedEnforced.put(Subject.SCOPE, enforced);
+        }
         return this;
     }
 
@@ -96,7 +161,7 @@ public final class DependencyManagement {
      *         dependency should remain unchanged.
      */
     public Boolean getOptional() {
-        return optional;
+        return (Boolean) managedValues.get(Subject.OPTIONAL);
     }
 
     /**
@@ -104,9 +169,29 @@ public final class DependencyManagement {
      *
      * @param optional The optional flag, may be {@code null} if the flag is not managed.
      * @return This management update for chaining, never {@code null}.
+     * @deprecated Use {@link #setOptional(Boolean, boolean)} instead.
      */
+    @Deprecated
     public DependencyManagement setOptional(Boolean optional) {
-        this.optional = optional;
+        return setOptional(optional, true);
+    }
+
+    /**
+     * Sets the new optional flag to apply to the dependency.
+     *
+     * @param optional The optional flag, may be {@code null} if the flag is not managed.
+     * @param enforced The enforcement of new value.
+     * @return This management update for chaining, never {@code null}.
+     * @since 2.0.17
+     */
+    public DependencyManagement setOptional(Boolean optional, boolean enforced) {
+        if (optional == null) {
+            this.managedValues.remove(Subject.OPTIONAL);
+            this.managedEnforced.remove(Subject.OPTIONAL);
+        } else {
+            this.managedValues.put(Subject.OPTIONAL, optional);
+            this.managedEnforced.put(Subject.OPTIONAL, enforced);
+        }
         return this;
     }
 
@@ -118,8 +203,9 @@ public final class DependencyManagement {
      * @return The new exclusions or {@code null} if the exclusions are not managed and the existing dependency
      *         exclusions should remain unchanged.
      */
+    @SuppressWarnings("unchecked")
     public Collection<Exclusion> getExclusions() {
-        return exclusions;
+        return (Collection<Exclusion>) managedValues.get(Subject.EXCLUSIONS);
     }
 
     /**
@@ -129,9 +215,31 @@ public final class DependencyManagement {
      *
      * @param exclusions The new exclusions, may be {@code null} if the exclusions are not managed.
      * @return This management update for chaining, never {@code null}.
+     * @deprecated Use {@link #setExclusions(Collection, boolean)} instead.
      */
+    @Deprecated
     public DependencyManagement setExclusions(Collection<Exclusion> exclusions) {
-        this.exclusions = exclusions;
+        return setExclusions(exclusions, true);
+    }
+
+    /**
+     * Sets the new exclusions to apply to the dependency. Note that this collection denotes the complete set of
+     * exclusions for the dependency, i.e. the dependency manager controls whether any existing exclusions get merged
+     * with information from dependency management or overridden by it.
+     *
+     * @param exclusions The new exclusions, may be {@code null} if the exclusions are not managed.
+     * @param enforced The enforcement of new value.
+     * @return This management update for chaining, never {@code null}.
+     * @since 2.0.17
+     */
+    public DependencyManagement setExclusions(Collection<Exclusion> exclusions, boolean enforced) {
+        if (exclusions == null) {
+            this.managedValues.remove(Subject.EXCLUSIONS);
+            this.managedEnforced.remove(Subject.EXCLUSIONS);
+        } else {
+            this.managedValues.put(Subject.EXCLUSIONS, exclusions);
+            this.managedEnforced.put(Subject.EXCLUSIONS, enforced);
+        }
         return this;
     }
 
@@ -143,8 +251,9 @@ public final class DependencyManagement {
      * @return The new artifact properties or {@code null} if the properties are not managed and the existing properties
      *         should remain unchanged.
      */
+    @SuppressWarnings("unchecked")
     public Map<String, String> getProperties() {
-        return properties;
+        return (Map<String, String>) managedValues.get(Subject.PROPERTIES);
     }
 
     /**
@@ -154,9 +263,31 @@ public final class DependencyManagement {
      *
      * @param properties The new artifact properties, may be {@code null} if the properties are not managed.
      * @return This management update for chaining, never {@code null}.
+     * @deprecated Use {@link #setProperties(Map, boolean)} instead.
      */
+    @Deprecated
     public DependencyManagement setProperties(Map<String, String> properties) {
-        this.properties = properties;
+        return setProperties(properties, true);
+    }
+
+    /**
+     * Sets the new properties to apply to the dependency. Note that this map denotes the complete set of properties,
+     * i.e. the dependency manager controls whether any existing properties get merged with the information from
+     * dependency management or overridden by it.
+     *
+     * @param properties The new artifact properties, may be {@code null} if the properties are not managed.
+     * @param enforced The enforcement of new value.
+     * @return This management update for chaining, never {@code null}.
+     * @since 2.0.17
+     */
+    public DependencyManagement setProperties(Map<String, String> properties, boolean enforced) {
+        if (properties == null) {
+            this.managedValues.remove(Subject.PROPERTIES);
+            this.managedEnforced.remove(Subject.PROPERTIES);
+        } else {
+            this.managedValues.put(Subject.PROPERTIES, properties);
+            this.managedEnforced.put(Subject.PROPERTIES, enforced);
+        }
         return this;
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyManagement.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.collection;
 
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.eclipse.aether.graph.Exclusion;
@@ -33,7 +34,7 @@ public final class DependencyManagement {
     /**
      * Enumeration of manageable attributes, attributes that can be subjected to dependency management.
      *
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public enum Subject {
         VERSION,
@@ -44,20 +45,20 @@ public final class DependencyManagement {
     }
 
     private final EnumMap<Subject, Object> managedValues;
-    private final EnumMap<Subject, Boolean> managedEnforced;
+    private final EnumSet<Subject> managedEnforced;
 
     /**
      * Creates an empty management update.
      */
     public DependencyManagement() {
         this.managedValues = new EnumMap<>(Subject.class);
-        this.managedEnforced = new EnumMap<>(Subject.class);
+        this.managedEnforced = EnumSet.noneOf(Subject.class);
     }
 
     /**
      * Returns {@code true} if passed in subject is managed.
      *
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public boolean isManagedSubject(Subject subject) {
         return managedValues.containsKey(subject);
@@ -66,10 +67,10 @@ public final class DependencyManagement {
     /**
      * Returns {@code true} if passed in subject is managed and is enforced.
      *
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public boolean isManagedSubjectEnforced(Subject subject) {
-        return isManagedSubject(subject) && managedEnforced.getOrDefault(subject, false);
+        return isManagedSubject(subject) && managedEnforced.contains(subject);
     }
 
     /**
@@ -100,17 +101,10 @@ public final class DependencyManagement {
      * @param version The new version, may be {@code null} if the version is not managed.
      * @param enforced The enforcement of new value.
      * @return This management update for chaining, never {@code null}.
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public DependencyManagement setVersion(String version, boolean enforced) {
-        if (version == null) {
-            this.managedValues.remove(Subject.VERSION);
-            this.managedEnforced.remove(Subject.VERSION);
-        } else {
-            this.managedValues.put(Subject.VERSION, version);
-            this.managedEnforced.put(Subject.VERSION, enforced);
-        }
-        return this;
+        return set(Subject.VERSION, version, enforced);
     }
 
     /**
@@ -141,17 +135,10 @@ public final class DependencyManagement {
      * @param scope The new scope, may be {@code null} if the scope is not managed.
      * @param enforced The enforcement of new value.
      * @return This management update for chaining, never {@code null}.
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public DependencyManagement setScope(String scope, boolean enforced) {
-        if (scope == null) {
-            this.managedValues.remove(Subject.SCOPE);
-            this.managedEnforced.remove(Subject.SCOPE);
-        } else {
-            this.managedValues.put(Subject.SCOPE, scope);
-            this.managedEnforced.put(Subject.SCOPE, enforced);
-        }
-        return this;
+        return set(Subject.SCOPE, scope, enforced);
     }
 
     /**
@@ -182,17 +169,10 @@ public final class DependencyManagement {
      * @param optional The optional flag, may be {@code null} if the flag is not managed.
      * @param enforced The enforcement of new value.
      * @return This management update for chaining, never {@code null}.
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public DependencyManagement setOptional(Boolean optional, boolean enforced) {
-        if (optional == null) {
-            this.managedValues.remove(Subject.OPTIONAL);
-            this.managedEnforced.remove(Subject.OPTIONAL);
-        } else {
-            this.managedValues.put(Subject.OPTIONAL, optional);
-            this.managedEnforced.put(Subject.OPTIONAL, enforced);
-        }
-        return this;
+        return set(Subject.OPTIONAL, optional, enforced);
     }
 
     /**
@@ -230,17 +210,10 @@ public final class DependencyManagement {
      * @param exclusions The new exclusions, may be {@code null} if the exclusions are not managed.
      * @param enforced The enforcement of new value.
      * @return This management update for chaining, never {@code null}.
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public DependencyManagement setExclusions(Collection<Exclusion> exclusions, boolean enforced) {
-        if (exclusions == null) {
-            this.managedValues.remove(Subject.EXCLUSIONS);
-            this.managedEnforced.remove(Subject.EXCLUSIONS);
-        } else {
-            this.managedValues.put(Subject.EXCLUSIONS, exclusions);
-            this.managedEnforced.put(Subject.EXCLUSIONS, enforced);
-        }
-        return this;
+        return set(Subject.EXCLUSIONS, exclusions, enforced);
     }
 
     /**
@@ -278,15 +251,26 @@ public final class DependencyManagement {
      * @param properties The new artifact properties, may be {@code null} if the properties are not managed.
      * @param enforced The enforcement of new value.
      * @return This management update for chaining, never {@code null}.
-     * @since 2.0.17
+     * @since 2.0.19
      */
     public DependencyManagement setProperties(Map<String, String> properties, boolean enforced) {
-        if (properties == null) {
-            this.managedValues.remove(Subject.PROPERTIES);
-            this.managedEnforced.remove(Subject.PROPERTIES);
+        return set(Subject.PROPERTIES, properties, enforced);
+    }
+
+    /**
+     * Generic but private setter that applies common logic.
+     */
+    private DependencyManagement set(Subject subject, Object value, boolean enforced) {
+        if (value == null) {
+            this.managedValues.remove(subject);
+            this.managedEnforced.remove(subject);
         } else {
-            this.managedValues.put(Subject.PROPERTIES, properties);
-            this.managedEnforced.put(Subject.PROPERTIES, enforced);
+            this.managedValues.put(subject, value);
+            if (enforced) {
+                this.managedEnforced.add(subject);
+            } else {
+                this.managedEnforced.remove(subject);
+            }
         }
         return this;
     }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.graph;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,8 @@ import static java.util.Objects.requireNonNull;
  * A node within a dependency graph.
  */
 public final class DefaultDependencyNode implements DependencyNode {
+    private final Map<DependencyManagement.Subject, Boolean> emptyManagedSubjects =
+            Collections.unmodifiableMap(new EnumMap<>(DependencyManagement.Subject.class));
 
     private List<DependencyNode> children;
 
@@ -52,7 +55,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     private Version version;
 
-    private Map<DependencyManagement.Subject, Boolean> managedSubjects = Collections.emptyMap();
+    private Map<DependencyManagement.Subject, Boolean> managedSubjects = emptyManagedSubjects;
 
     private List<RemoteRepository> repositories;
 
@@ -106,7 +109,8 @@ public final class DefaultDependencyNode implements DependencyNode {
         setAliases(node.getAliases());
         setRequestContext(node.getRequestContext());
 
-        HashMap<DependencyManagement.Subject, Boolean> managedSubjects = new HashMap<>();
+        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects =
+                new EnumMap<>(DependencyManagement.Subject.class);
         for (DependencyManagement.Subject subject : DependencyManagement.Subject.values()) {
             if (node.isManagedSubject(subject)) {
                 managedSubjects.put(subject, node.isManagedSubjectEnforced(subject));
@@ -262,12 +266,28 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     @Deprecated
     public void setManagedBits(int managedBits) {
-        throw new IllegalArgumentException("bits are not supported");
+        EnumMap<DependencyManagement.Subject, Boolean> subjects = new EnumMap<>(DependencyManagement.Subject.class);
+        if ((managedBits & DependencyNode.MANAGED_VERSION) != 0) {
+            subjects.put(DependencyManagement.Subject.VERSION, true);
+        }
+        if ((managedBits & DependencyNode.MANAGED_SCOPE) != 0) {
+            subjects.put(DependencyManagement.Subject.SCOPE, true);
+        }
+        if ((managedBits & DependencyNode.MANAGED_OPTIONAL) != 0) {
+            subjects.put(DependencyManagement.Subject.OPTIONAL, true);
+        }
+        if ((managedBits & DependencyNode.MANAGED_PROPERTIES) != 0) {
+            subjects.put(DependencyManagement.Subject.PROPERTIES, true);
+        }
+        if ((managedBits & DependencyNode.MANAGED_EXCLUSIONS) != 0) {
+            subjects.put(DependencyManagement.Subject.EXCLUSIONS, true);
+        }
+        setManagedSubjects(subjects.isEmpty() ? null : subjects);
     }
 
     public void setManagedSubjects(Map<DependencyManagement.Subject, Boolean> managedSubjects) {
-        if (managedSubjects == null) {
-            this.managedSubjects = Collections.emptyMap();
+        if (managedSubjects == null || managedSubjects.isEmpty()) {
+            this.managedSubjects = emptyManagedSubjects;
         } else {
             this.managedSubjects = managedSubjects;
         }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -300,7 +300,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     @Override
     public boolean isManagedSubjectEnforced(DependencyManagement.Subject subject) {
-        return managedSubjects.getOrDefault(subject, false);
+        return isManagedSubject(subject) && managedSubjects.getOrDefault(subject, false);
     }
 
     @Override

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -38,9 +38,6 @@ import static java.util.Objects.requireNonNull;
  * A node within a dependency graph.
  */
 public final class DefaultDependencyNode implements DependencyNode {
-    private final Map<DependencyManagement.Subject, Boolean> emptyManagedSubjects =
-            Collections.unmodifiableMap(new EnumMap<>(DependencyManagement.Subject.class));
-
     private List<DependencyNode> children;
 
     private Dependency dependency;
@@ -55,7 +52,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     private Version version;
 
-    private Map<DependencyManagement.Subject, Boolean> managedSubjects = emptyManagedSubjects;
+    private Map<DependencyManagement.Subject, Boolean> managedSubjects;
 
     private List<RemoteRepository> repositories;
 
@@ -70,13 +67,14 @@ public final class DefaultDependencyNode implements DependencyNode {
      */
     public DefaultDependencyNode(Dependency dependency) {
         this.dependency = dependency;
-        artifact = (dependency != null) ? dependency.getArtifact() : null;
-        children = new ArrayList<>(0);
-        aliases = Collections.emptyList();
-        relocations = Collections.emptyList();
-        repositories = Collections.emptyList();
-        context = "";
-        data = Collections.emptyMap();
+        this.artifact = (dependency != null) ? dependency.getArtifact() : null;
+        this.children = new ArrayList<>(0);
+        this.aliases = Collections.emptyList();
+        this.relocations = Collections.emptyList();
+        this.managedSubjects = null;
+        this.repositories = Collections.emptyList();
+        this.context = "";
+        this.data = Collections.emptyMap();
     }
 
     /**
@@ -88,12 +86,13 @@ public final class DefaultDependencyNode implements DependencyNode {
      */
     public DefaultDependencyNode(Artifact artifact) {
         this.artifact = artifact;
-        children = new ArrayList<>(0);
-        aliases = Collections.emptyList();
-        relocations = Collections.emptyList();
-        repositories = Collections.emptyList();
-        context = "";
-        data = Collections.emptyMap();
+        this.children = new ArrayList<>(0);
+        this.aliases = Collections.emptyList();
+        this.relocations = Collections.emptyList();
+        this.managedSubjects = null;
+        this.repositories = Collections.emptyList();
+        this.context = "";
+        this.data = Collections.emptyMap();
     }
 
     /**
@@ -103,9 +102,9 @@ public final class DefaultDependencyNode implements DependencyNode {
      * @param node The node to copy, must not be {@code null}.
      */
     public DefaultDependencyNode(DependencyNode node) {
-        dependency = node.getDependency();
-        artifact = node.getArtifact();
-        children = new ArrayList<>(0);
+        this.dependency = node.getDependency();
+        this.artifact = node.getArtifact();
+        this.children = new ArrayList<>(0);
         setAliases(node.getAliases());
         setRequestContext(node.getRequestContext());
 
@@ -287,7 +286,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     public void setManagedSubjects(Map<DependencyManagement.Subject, Boolean> managedSubjects) {
         if (managedSubjects == null || managedSubjects.isEmpty()) {
-            this.managedSubjects = emptyManagedSubjects;
+            this.managedSubjects = null;
         } else {
             this.managedSubjects = managedSubjects;
         }
@@ -295,7 +294,7 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     @Override
     public boolean isManagedSubject(DependencyManagement.Subject subject) {
-        return managedSubjects.containsKey(subject);
+        return managedSubjects != null && managedSubjects.containsKey(subject);
     }
 
     @Override

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DefaultDependencyNode.java
@@ -38,6 +38,8 @@ import static java.util.Objects.requireNonNull;
  * A node within a dependency graph.
  */
 public final class DefaultDependencyNode implements DependencyNode {
+    private static final DependencyManagement.Subject[] SUBJECTS = DependencyManagement.Subject.values();
+
     private List<DependencyNode> children;
 
     private Dependency dependency;
@@ -108,18 +110,16 @@ public final class DefaultDependencyNode implements DependencyNode {
         setAliases(node.getAliases());
         setRequestContext(node.getRequestContext());
 
-        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects =
-                new EnumMap<>(DependencyManagement.Subject.class);
-        for (DependencyManagement.Subject subject : DependencyManagement.Subject.values()) {
+        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects = null;
+        for (DependencyManagement.Subject subject : SUBJECTS) {
             if (node.isManagedSubject(subject)) {
+                if (managedSubjects == null) {
+                    managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
+                }
                 managedSubjects.put(subject, node.isManagedSubjectEnforced(subject));
             }
         }
-        if (managedSubjects.isEmpty()) {
-            setManagedSubjects(null);
-        } else {
-            setManagedSubjects(managedSubjects);
-        }
+        setManagedSubjects(managedSubjects);
 
         setRelocations(node.getRelocations());
         setRepositories(node.getRepositories());
@@ -265,6 +265,10 @@ public final class DefaultDependencyNode implements DependencyNode {
 
     @Deprecated
     public void setManagedBits(int managedBits) {
+        if (managedBits == 0) {
+            setManagedSubjects(null);
+            return;
+        }
         EnumMap<DependencyManagement.Subject, Boolean> subjects = new EnumMap<>(DependencyManagement.Subject.class);
         if ((managedBits & DependencyNode.MANAGED_VERSION) != 0) {
             subjects.put(DependencyManagement.Subject.VERSION, true);

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
@@ -188,6 +188,7 @@ public interface DependencyNode {
     /**
      * Returns {@code true} if given subject is managed.
      *
+     * @param subject the {@link org.eclipse.aether.collection.DependencyManagement.Subject}, must not be {@code null}.
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
      * @since 2.0.17
      */
@@ -211,6 +212,7 @@ public interface DependencyNode {
     /**
      * Returns {@code true} if given subject is managed with enforcing modality on this node.
      *
+     * @param subject the {@link org.eclipse.aether.collection.DependencyManagement.Subject}, must not be {@code null}.
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
      * @since 2.0.17
      */

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
@@ -191,7 +191,22 @@ public interface DependencyNode {
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
      * @since 2.0.17
      */
-    boolean isManagedSubject(DependencyManagement.Subject subject);
+    default boolean isManagedSubject(DependencyManagement.Subject subject) {
+        switch (subject) {
+            case VERSION:
+                return (getManagedBits() & MANAGED_VERSION) != 0;
+            case SCOPE:
+                return (getManagedBits() & MANAGED_SCOPE) != 0;
+            case OPTIONAL:
+                return (getManagedBits() & MANAGED_OPTIONAL) != 0;
+            case PROPERTIES:
+                return (getManagedBits() & MANAGED_PROPERTIES) != 0;
+            case EXCLUSIONS:
+                return (getManagedBits() & MANAGED_EXCLUSIONS) != 0;
+            default:
+                throw new IllegalArgumentException("Unknown subject: " + subject.name());
+        }
+    }
 
     /**
      * Returns {@code true} if given subject is managed with enforcing modality on this node.
@@ -199,7 +214,9 @@ public interface DependencyNode {
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
      * @since 2.0.17
      */
-    boolean isManagedSubjectEnforced(DependencyManagement.Subject subject);
+    default boolean isManagedSubjectEnforced(DependencyManagement.Subject subject) {
+        return isManagedSubject(subject);
+    }
 
     /**
      * Gets the remote repositories from which this node's artifact shall be resolved.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionConstraint;
@@ -38,40 +39,49 @@ import org.eclipse.aether.version.VersionConstraint;
  * @noextend This interface is not intended to be extended by clients.
  */
 public interface DependencyNode {
-
     /**
      * A bit flag indicating the dependency version was subject to dependency management
      *
      * @see #getManagedBits()
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int MANAGED_VERSION = 0x01;
 
     /**
      * A bit flag indicating the dependency scope was subject to dependency management
      *
      * @see #getManagedBits()
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int MANAGED_SCOPE = 0x02;
 
     /**
      * A bit flag indicating the optional flag was subject to dependency management
      *
      * @see #getManagedBits()
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int MANAGED_OPTIONAL = 0x04;
 
     /**
      * A bit flag indicating the artifact properties were subject to dependency management
      *
      * @see #getManagedBits()
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int MANAGED_PROPERTIES = 0x08;
 
     /**
      * A bit flag indicating the exclusions were subject to dependency management
      *
      * @see #getManagedBits()
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int MANAGED_EXCLUSIONS = 0x10;
 
     /**
@@ -170,8 +180,26 @@ public interface DependencyNode {
      * @return A bit field containing any of the bits {@link #MANAGED_VERSION}, {@link #MANAGED_SCOPE},
      *         {@link #MANAGED_OPTIONAL}, {@link #MANAGED_PROPERTIES} and {@link #MANAGED_EXCLUSIONS} if the
      *         corresponding attribute was set via dependency management.
+     * @deprecated Use {@link #isManagedSubject(DependencyManagement.Subject)} and {@link #isManagedSubjectEnforced(DependencyManagement.Subject)} instead.
      */
+    @Deprecated
     int getManagedBits();
+
+    /**
+     * Returns {@code true} if given subject is managed.
+     *
+     * @see org.eclipse.aether.collection.DependencyManagement.Subject
+     * @since 2.0.17
+     */
+    boolean isManagedSubject(DependencyManagement.Subject subject);
+
+    /**
+     * Returns {@code true} if given subject is managed with enforcing modality on this node.
+     *
+     * @see org.eclipse.aether.collection.DependencyManagement.Subject
+     * @since 2.0.17
+     */
+    boolean isManagedSubjectEnforced(DependencyManagement.Subject subject);
 
     /**
      * Gets the remote repositories from which this node's artifact shall be resolved.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/graph/DependencyNode.java
@@ -190,7 +190,7 @@ public interface DependencyNode {
      *
      * @param subject the {@link org.eclipse.aether.collection.DependencyManagement.Subject}, must not be {@code null}.
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
-     * @since 2.0.17
+     * @since 2.0.19
      */
     default boolean isManagedSubject(DependencyManagement.Subject subject) {
         switch (subject) {
@@ -214,7 +214,7 @@ public interface DependencyNode {
      *
      * @param subject the {@link org.eclipse.aether.collection.DependencyManagement.Subject}, must not be {@code null}.
      * @see org.eclipse.aether.collection.DependencyManagement.Subject
-     * @since 2.0.17
+     * @since 2.0.19
      */
     default boolean isManagedSubjectEnforced(DependencyManagement.Subject subject) {
         return isManagedSubject(subject);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -35,6 +35,7 @@ import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
+import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencyTraverser;
 import org.eclipse.aether.collection.VersionFilter;
 import org.eclipse.aether.graph.DefaultDependencyNode;
@@ -344,8 +345,16 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         return a.getGroupId() + ':' + a.getArtifactId() + ':' + a.getClassifier() + ':' + a.getExtension();
     }
 
+    protected PremanagedDependency createPremanagedDependency(
+            DependencyManager depManager,
+            Dependency dependency,
+            boolean disableVersionManagement,
+            boolean premanagedState) {
+        return PremanagedDependency.create(depManager, dependency, disableVersionManagement, premanagedState);
+    }
+
     @SuppressWarnings("checkstyle:parameternumber")
-    protected static DefaultDependencyNode createDependencyNode(
+    protected DefaultDependencyNode createDependencyNode(
             List<Artifact> relocations,
             PremanagedDependency preManaged,
             VersionRangeResult rangeResult,
@@ -365,7 +374,7 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         return child;
     }
 
-    protected static DefaultDependencyNode createDependencyNode(
+    protected DefaultDependencyNode createDependencyNodeCycle(
             List<Artifact> relocations,
             PremanagedDependency preManaged,
             VersionRangeResult rangeResult,

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
@@ -29,7 +29,6 @@ import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
 
@@ -38,27 +37,30 @@ import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
  */
 public class PremanagedDependency {
 
-    final String premanagedVersion;
+    private final String premanagedVersion;
 
-    final String premanagedScope;
+    private final String premanagedScope;
 
-    final Boolean premanagedOptional;
-
-    /**
-     * @since 1.1.0
-     */
-    final Collection<Exclusion> premanagedExclusions;
+    private final Boolean premanagedOptional;
 
     /**
      * @since 1.1.0
      */
-    final Map<String, String> premanagedProperties;
+    private final Collection<Exclusion> premanagedExclusions;
 
-    final int managedBits;
+    /**
+     * @since 1.1.0
+     */
+    private final Map<String, String> premanagedProperties;
 
-    final Dependency managedDependency;
+    /**
+     * @since 2.0.17
+     */
+    private final Map<DependencyManagement.Subject, Boolean> managedSubjects;
 
-    final boolean premanagedState;
+    private final Dependency managedDependency;
+
+    private final boolean premanagedState;
 
     @SuppressWarnings("checkstyle:parameternumber")
     PremanagedDependency(
@@ -67,7 +69,7 @@ public class PremanagedDependency {
             Boolean premanagedOptional,
             Collection<Exclusion> premanagedExclusions,
             Map<String, String> premanagedProperties,
-            int managedBits,
+            Map<DependencyManagement.Subject, Boolean> managedSubjects,
             Dependency managedDependency,
             boolean premanagedState) {
         this.premanagedVersion = premanagedVersion;
@@ -80,7 +82,7 @@ public class PremanagedDependency {
         this.premanagedProperties =
                 premanagedProperties != null ? Collections.unmodifiableMap(new HashMap<>(premanagedProperties)) : null;
 
-        this.managedBits = managedBits;
+        this.managedSubjects = managedSubjects;
         this.managedDependency = managedDependency;
         this.premanagedState = premanagedState;
     }
@@ -92,7 +94,7 @@ public class PremanagedDependency {
             boolean premanagedState) {
         DependencyManagement depMngt = depManager != null ? depManager.manageDependency(dependency) : null;
 
-        int managedBits = 0;
+        Map<DependencyManagement.Subject, Boolean> managedSubjects = new HashMap<>();
         String premanagedVersion = null;
         String premanagedScope = null;
         Boolean premanagedOptional = null;
@@ -104,37 +106,48 @@ public class PremanagedDependency {
                 Artifact artifact = dependency.getArtifact();
                 premanagedVersion = artifact.getVersion();
                 dependency = dependency.setArtifact(artifact.setVersion(depMngt.getVersion()));
-                managedBits |= DependencyNode.MANAGED_VERSION;
+                managedSubjects.put(
+                        DependencyManagement.Subject.VERSION,
+                        depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.VERSION));
             }
             if (depMngt.getProperties() != null) {
                 Artifact artifact = dependency.getArtifact();
                 premanagedProperties = artifact.getProperties();
                 dependency = dependency.setArtifact(artifact.setProperties(depMngt.getProperties()));
-                managedBits |= DependencyNode.MANAGED_PROPERTIES;
+                managedSubjects.put(
+                        DependencyManagement.Subject.PROPERTIES,
+                        depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.PROPERTIES));
             }
             if (depMngt.getScope() != null) {
                 premanagedScope = dependency.getScope();
                 dependency = dependency.setScope(depMngt.getScope());
-                managedBits |= DependencyNode.MANAGED_SCOPE;
+                managedSubjects.put(
+                        DependencyManagement.Subject.SCOPE,
+                        depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.SCOPE));
             }
             if (depMngt.getOptional() != null) {
                 premanagedOptional = dependency.isOptional();
                 dependency = dependency.setOptional(depMngt.getOptional());
-                managedBits |= DependencyNode.MANAGED_OPTIONAL;
+                managedSubjects.put(
+                        DependencyManagement.Subject.OPTIONAL,
+                        depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.OPTIONAL));
             }
             if (depMngt.getExclusions() != null) {
                 premanagedExclusions = dependency.getExclusions();
                 dependency = dependency.setExclusions(depMngt.getExclusions());
-                managedBits |= DependencyNode.MANAGED_EXCLUSIONS;
+                managedSubjects.put(
+                        DependencyManagement.Subject.EXCLUSIONS,
+                        depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.EXCLUSIONS));
             }
         }
+
         return new PremanagedDependency(
                 premanagedVersion,
                 premanagedScope,
                 premanagedOptional,
                 premanagedExclusions,
                 premanagedProperties,
-                managedBits,
+                managedSubjects,
                 dependency,
                 premanagedState);
     }
@@ -144,7 +157,7 @@ public class PremanagedDependency {
     }
 
     public void applyTo(DefaultDependencyNode child) {
-        child.setManagedBits(managedBits);
+        child.setManagedSubjects(managedSubjects);
         if (premanagedState) {
             child.setData(DependencyManagerUtils.NODE_DATA_PREMANAGED_VERSION, premanagedVersion);
             child.setData(DependencyManagerUtils.NODE_DATA_PREMANAGED_SCOPE, premanagedScope);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl.collect;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,7 +57,7 @@ public class PremanagedDependency {
     /**
      * @since 2.0.17
      */
-    private final Map<DependencyManagement.Subject, Boolean> managedSubjects;
+    private final EnumMap<DependencyManagement.Subject, Boolean> managedSubjects;
 
     private final Dependency managedDependency;
 
@@ -69,7 +70,7 @@ public class PremanagedDependency {
             Boolean premanagedOptional,
             Collection<Exclusion> premanagedExclusions,
             Map<String, String> premanagedProperties,
-            Map<DependencyManagement.Subject, Boolean> managedSubjects,
+            EnumMap<DependencyManagement.Subject, Boolean> managedSubjects,
             Dependency managedDependency,
             boolean premanagedState) {
         this.premanagedVersion = premanagedVersion;
@@ -94,7 +95,8 @@ public class PremanagedDependency {
             boolean premanagedState) {
         DependencyManagement depMngt = depManager != null ? depManager.manageDependency(dependency) : null;
 
-        Map<DependencyManagement.Subject, Boolean> managedSubjects = new HashMap<>();
+        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects =
+                new EnumMap<>(DependencyManagement.Subject.class);
         String premanagedVersion = null;
         String premanagedScope = null;
         Boolean premanagedOptional = null;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/PremanagedDependency.java
@@ -55,7 +55,7 @@ public class PremanagedDependency {
     private final Map<String, String> premanagedProperties;
 
     /**
-     * @since 2.0.17
+     * @since 2.0.19
      */
     private final EnumMap<DependencyManagement.Subject, Boolean> managedSubjects;
 
@@ -95,8 +95,7 @@ public class PremanagedDependency {
             boolean premanagedState) {
         DependencyManagement depMngt = depManager != null ? depManager.manageDependency(dependency) : null;
 
-        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects =
-                new EnumMap<>(DependencyManagement.Subject.class);
+        EnumMap<DependencyManagement.Subject, Boolean> managedSubjects = null;
         String premanagedVersion = null;
         String premanagedScope = null;
         Boolean premanagedOptional = null;
@@ -105,6 +104,7 @@ public class PremanagedDependency {
 
         if (depMngt != null) {
             if (depMngt.getVersion() != null && !disableVersionManagement) {
+                managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
                 Artifact artifact = dependency.getArtifact();
                 premanagedVersion = artifact.getVersion();
                 dependency = dependency.setArtifact(artifact.setVersion(depMngt.getVersion()));
@@ -113,6 +113,9 @@ public class PremanagedDependency {
                         depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.VERSION));
             }
             if (depMngt.getProperties() != null) {
+                if (managedSubjects == null) {
+                    managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
+                }
                 Artifact artifact = dependency.getArtifact();
                 premanagedProperties = artifact.getProperties();
                 dependency = dependency.setArtifact(artifact.setProperties(depMngt.getProperties()));
@@ -121,6 +124,9 @@ public class PremanagedDependency {
                         depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.PROPERTIES));
             }
             if (depMngt.getScope() != null) {
+                if (managedSubjects == null) {
+                    managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
+                }
                 premanagedScope = dependency.getScope();
                 dependency = dependency.setScope(depMngt.getScope());
                 managedSubjects.put(
@@ -128,6 +134,9 @@ public class PremanagedDependency {
                         depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.SCOPE));
             }
             if (depMngt.getOptional() != null) {
+                if (managedSubjects == null) {
+                    managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
+                }
                 premanagedOptional = dependency.isOptional();
                 dependency = dependency.setOptional(depMngt.getOptional());
                 managedSubjects.put(
@@ -135,6 +144,9 @@ public class PremanagedDependency {
                         depMngt.isManagedSubjectEnforced(DependencyManagement.Subject.OPTIONAL));
             }
             if (depMngt.getExclusions() != null) {
+                if (managedSubjects == null) {
+                    managedSubjects = new EnumMap<>(DependencyManagement.Subject.class);
+                }
                 premanagedExclusions = dependency.getExclusions();
                 dependency = dependency.setExclusions(depMngt.getExclusions());
                 managedSubjects.put(

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -209,7 +209,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
                         managedDependencies,
                         parents,
                         dependency,
-                        PremanagedDependency.create(rootDepManager, dependency, false, args.premanagedState));
+                        createPremanagedDependency(rootDepManager, dependency, false, args.premanagedState));
                 if (!filter(processingContext)) {
                     processingContext.withDependency(processingContext.premanagedDependency.getManagedDependency());
                     resolveArtifactDescriptorAsync(args, processingContext, results);
@@ -274,7 +274,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
                     results.addCycle(context.parents, cycleEntry, d);
                     DependencyNode cycleNode = context.parents.get(cycleEntry);
                     if (cycleNode.getDependency() != null) {
-                        DefaultDependencyNode child = createDependencyNode(
+                        DefaultDependencyNode child = createDependencyNodeCycle(
                                 relocations, preManaged, rangeResult, version, d, descriptorResult, cycleNode);
                         context.getParent().getChildren().add(child);
                         continue;
@@ -288,7 +288,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
                                             .getArtifactId()
                                             .equals(d.getArtifact().getArtifactId());
 
-                    PremanagedDependency premanagedDependency = PremanagedDependency.create(
+                    PremanagedDependency premanagedDependency = createPremanagedDependency(
                             context.depManager, d, disableVersionManagementSubsequently, args.premanagedState);
                     DependencyProcessingContext relocatedContext = new DependencyProcessingContext(
                             context.depSelector,
@@ -406,7 +406,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
                 for (Dependency dependency : descriptorResult.getDependencies()) {
                     RequestTrace childTrace = collectStepTrace(
                             parentContext.trace, args.request.getRequestContext(), parents, dependency);
-                    PremanagedDependency premanagedDependency = PremanagedDependency.create(
+                    PremanagedDependency premanagedDependency = createPremanagedDependency(
                             childManager, dependency, disableVersionManagement, args.premanagedState);
                     DependencyProcessingContext processingContext = new DependencyProcessingContext(
                             childSelector,

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
@@ -191,7 +191,7 @@ public class DfDependencyCollector extends DependencyCollectorDelegate {
 
         RequestTrace trace = collectStepTrace(parent, args.request.getRequestContext(), args.nodes.nodes, dependency);
         PremanagedDependency preManaged =
-                PremanagedDependency.create(depManager, dependency, disableVersionManagement, args.premanagedState);
+                createPremanagedDependency(depManager, dependency, disableVersionManagement, args.premanagedState);
         dependency = preManaged.getManagedDependency();
 
         boolean noDescriptor = isLackingDescriptor(args.session, dependency.getArtifact());
@@ -231,7 +231,7 @@ public class DfDependencyCollector extends DependencyCollectorDelegate {
                     results.addCycle(args.nodes.nodes, cycleEntry, d);
                     DependencyNode cycleNode = args.nodes.get(cycleEntry);
                     if (cycleNode.getDependency() != null) {
-                        DefaultDependencyNode child = createDependencyNode(
+                        DefaultDependencyNode child = createDependencyNodeCycle(
                                 relocations, preManaged, rangeResult, version, d, descriptorResult, cycleNode);
                         node.getChildren().add(child);
                         continue;

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -291,16 +292,16 @@ public class DependencyGraphParser {
             DefaultArtifact artifact = new DefaultArtifact(def.coords, def.properties);
             Dependency dependency = new Dependency(artifact, def.scope, def.optional);
             node = new DefaultDependencyNode(dependency);
-            int managedBits = 0;
+            Map<DependencyManagement.Subject, Boolean> managedSubjects = new HashMap<>();
             if (def.premanagedScope != null) {
-                managedBits |= DependencyNode.MANAGED_SCOPE;
+                managedSubjects.put(DependencyManagement.Subject.SCOPE, true);
                 node.setData("premanaged.scope", def.premanagedScope);
             }
             if (def.premanagedVersion != null) {
-                managedBits |= DependencyNode.MANAGED_VERSION;
+                managedSubjects.put(DependencyManagement.Subject.VERSION, true);
                 node.setData("premanaged.version", def.premanagedVersion);
             }
-            node.setManagedBits(managedBits);
+            node.setManagedSubjects(managedSubjects);
             if (def.relocations != null) {
                 List<Artifact> relocations = new ArrayList<>();
                 for (String relocation : def.relocations) {

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -292,7 +293,8 @@ public class DependencyGraphParser {
             DefaultArtifact artifact = new DefaultArtifact(def.coords, def.properties);
             Dependency dependency = new Dependency(artifact, def.scope, def.optional);
             node = new DefaultDependencyNode(dependency);
-            Map<DependencyManagement.Subject, Boolean> managedSubjects = new HashMap<>();
+            EnumMap<DependencyManagement.Subject, Boolean> managedSubjects =
+                    new EnumMap<>(DependencyManagement.Subject.class);
             if (def.premanagedScope != null) {
                 managedSubjects.put(DependencyManagement.Subject.SCOPE, true);
                 node.setData("premanaged.scope", def.premanagedScope);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -208,10 +208,12 @@ public abstract class AbstractDependencyManager implements DependencyManager {
     }
 
     /**
-     * Root manager is the one not being derived with {@link #deriveChildManager(DependencyCollectionContext)}.
+     * Returns {@code true} if this manager represents the root level (factory or root POM level).
+     * Per the depth model: 0 = factory (seed), 1 = root (project POM), 2+ = descendants.
+     * Management entries from root level should be enforced, while those from descendants are advised.
      */
     private boolean isRootManager() {
-        return path.isEmpty();
+        return depth <= 1;
     }
 
     private AbstractDependencyManager getManagedVersion(Key key) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -461,7 +461,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             }
             Collection<Exclusion> result = new LinkedHashSet<>(dependency.getExclusions());
             result.addAll(exclusions);
-            management.setExclusions(result, false);
+            management.setExclusions(result, true);
         }
 
         return management;

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/AbstractDependencyManager.java
@@ -207,6 +207,13 @@ public abstract class AbstractDependencyManager implements DependencyManager {
         return managedVersions != null && managedVersions.containsKey(key);
     }
 
+    /**
+     * Root manager is the one not being derived with {@link #deriveChildManager(DependencyCollectionContext)}.
+     */
+    private boolean isRootManager() {
+        return path.isEmpty();
+    }
+
     private AbstractDependencyManager getManagedVersion(Key key) {
         for (AbstractDependencyManager ancestor : path) {
             if (ancestor.managedVersions != null && ancestor.managedVersions.containsKey(key)) {
@@ -398,7 +405,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
             // apply only rules coming from "higher" levels
             if (versionOwner != null) {
                 management = new DependencyManagement();
-                management.setVersion(versionOwner.managedVersions.get(key), versionOwner.path.isEmpty());
+                management.setVersion(versionOwner.managedVersions.get(key), versionOwner.isRootManager());
             }
 
             AbstractDependencyManager scopeOwner = getManagedScope(key);
@@ -409,7 +416,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                     management = new DependencyManagement();
                 }
                 String managedScope = scopeOwner.managedScopes.get(key);
-                management.setScope(managedScope, scopeOwner.path.isEmpty());
+                management.setScope(managedScope, scopeOwner.isRootManager());
 
                 if (systemDependencyScope != null
                         && !systemDependencyScope.is(managedScope)
@@ -445,7 +452,7 @@ public abstract class AbstractDependencyManager implements DependencyManager {
                 if (management == null) {
                     management = new DependencyManagement();
                 }
-                management.setOptional(optionalOwner.managedOptionals.get(key), optionalOwner.path.isEmpty());
+                management.setOptional(optionalOwner.managedOptionals.get(key), optionalOwner.isRootManager());
             }
         }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DependencyManagerUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/DependencyManagerUtils.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.Exclusion;
 
@@ -87,7 +88,7 @@ public final class DependencyManagerUtils {
      *         or if {@link #CONFIG_PROP_VERBOSE} was not enabled
      */
     public static String getPremanagedVersion(DependencyNode node) {
-        if ((node.getManagedBits() & DependencyNode.MANAGED_VERSION) == 0) {
+        if (!node.isManagedSubject(DependencyManagement.Subject.VERSION)) {
             return null;
         }
         return cast(node.getData().get(NODE_DATA_PREMANAGED_VERSION), String.class);
@@ -101,7 +102,7 @@ public final class DependencyManagerUtils {
      *         if {@link #CONFIG_PROP_VERBOSE} was not enabled
      */
     public static String getPremanagedScope(DependencyNode node) {
-        if ((node.getManagedBits() & DependencyNode.MANAGED_SCOPE) == 0) {
+        if (!node.isManagedSubject(DependencyManagement.Subject.SCOPE)) {
             return null;
         }
         return cast(node.getData().get(NODE_DATA_PREMANAGED_SCOPE), String.class);
@@ -115,7 +116,7 @@ public final class DependencyManagerUtils {
      *         {@link #CONFIG_PROP_VERBOSE} was not enabled
      */
     public static Boolean getPremanagedOptional(DependencyNode node) {
-        if ((node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL) == 0) {
+        if (!node.isManagedSubject(DependencyManagement.Subject.OPTIONAL)) {
             return null;
         }
         return cast(node.getData().get(NODE_DATA_PREMANAGED_OPTIONAL), Boolean.class);
@@ -131,7 +132,7 @@ public final class DependencyManagerUtils {
      */
     @SuppressWarnings("unchecked")
     public static Collection<Exclusion> getPremanagedExclusions(DependencyNode node) {
-        if ((node.getManagedBits() & DependencyNode.MANAGED_EXCLUSIONS) == 0) {
+        if (!node.isManagedSubject(DependencyManagement.Subject.EXCLUSIONS)) {
             return null;
         }
         return cast(node.getData().get(NODE_DATA_PREMANAGED_EXCLUSIONS), Collection.class);
@@ -147,7 +148,7 @@ public final class DependencyManagerUtils {
      */
     @SuppressWarnings("unchecked")
     public static Map<String, String> getPremanagedProperties(DependencyNode node) {
-        if ((node.getManagedBits() & DependencyNode.MANAGED_PROPERTIES) == 0) {
+        if (!node.isManagedSubject(DependencyManagement.Subject.PROPERTIES)) {
             return null;
         }
         return cast(node.getData().get(NODE_DATA_PREMANAGED_PROPERTIES), Map.class);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/manager/TransitiveDependencyManager.java
@@ -145,30 +145,4 @@ public final class TransitiveDependencyManager extends AbstractDependencyManager
                 managedExclusions,
                 systemDependencyScope);
     }
-
-    /**
-     * Controls inheritance-based property derivation for scope and optional properties.
-     * <p>
-     * <strong>Why scope and optional are special:</strong> In dependency graphs, these two properties
-     * are subject to inheritance during graph transformation (which is outside ModelBuilder's scope).
-     * Therefore, scope and optional are derived only from the root to prevent interference with
-     * inheritance logic.
-     * </p>
-     * <p>
-     * <strong>The inheritance problem:</strong> If we managed scope/optional from sources below the root,
-     * we would mark nodes as "managed" in the dependency graph. The "managed" flag means "do not touch it,
-     * it is as it should be", which would prevent proper inheritance application during later graph
-     * transformation, causing nodes to end up with incorrect scope or optional states.
-     * </p>
-     * <p>
-     * <strong>Special case:</strong> The "system" scope has special handling due to its unique path requirements.
-     * </p>
-     *
-     * @return true only at depth 0 (root level) to ensure inheritance-based properties are only
-     *         derived from the root, false otherwise
-     */
-    @Override
-    protected boolean isInheritedDerived() {
-        return depth == 0;
-    }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ClassicConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/ClassicConflictResolver.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.DependencyGraphTransformationContext;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -675,7 +676,7 @@ public final class ClassicConflictResolver extends ConflictResolver {
         }
 
         private String deriveScope(DependencyNode node, String conflictId) throws RepositoryException {
-            if ((node.getManagedBits() & DependencyNode.MANAGED_SCOPE) != 0
+            if (node.isManagedSubjectEnforced(DependencyManagement.Subject.SCOPE)
                     || (conflictId != null && resolvedIds.containsKey(conflictId))) {
                 return scope(node.getDependency());
             }
@@ -702,7 +703,7 @@ public final class ClassicConflictResolver extends ConflictResolver {
             Dependency dep = node.getDependency();
             boolean optional = (dep != null) && dep.isOptional();
             if (optional
-                    || (node.getManagedBits() & DependencyNode.MANAGED_OPTIONAL) != 0
+                    || node.isManagedSubjectEnforced(DependencyManagement.Subject.OPTIONAL)
                     || (conflictId != null && resolvedIds.containsKey(conflictId))) {
                 return optional;
             }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
@@ -32,6 +32,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.DependencyGraphTransformationContext;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -423,12 +424,12 @@ public final class PathConflictResolver extends ConflictResolver {
         private void derive(int levels, boolean winner) throws RepositoryException {
             if (!winner) {
                 if (this.parent != null) {
-                    if ((dn.getManagedBits() & DependencyNode.MANAGED_SCOPE) == 0) {
+                    if (!dn.isManagedSubjectEnforced(DependencyManagement.Subject.SCOPE)) {
                         ScopeContext context = new ScopeContext(this.parent.scope, this.scope);
                         state.scopeDeriver.deriveScope(context);
                         this.scope = context.derivedScope;
                     }
-                    if ((dn.getManagedBits() & DependencyNode.MANAGED_OPTIONAL) == 0) {
+                    if (!dn.isManagedSubjectEnforced(DependencyManagement.Subject.OPTIONAL)) {
                         if (!this.optional && this.parent.optional) {
                             this.optional = true;
                         }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/manager/DependencyManagerTest.java
@@ -20,14 +20,18 @@ package org.eclipse.aether.util.graph.manager;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencyManagement;
+import org.eclipse.aether.collection.DependencyManagement.Subject;
 import org.eclipse.aether.collection.DependencyManager;
+import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -267,5 +271,176 @@ public class DependencyManagerTest {
         mngt = manager.manageDependency(new Dependency(E1, null));
         // DO NOT APPLY ONTO ITSELF
         assertNull(mngt);
+    }
+
+    /**
+     * Tests that root-level management produces enforced results for version, scope, and optional.
+     */
+    @Test
+    void testTransitiveEnforcementFromRoot() {
+        DependencyManager manager = new TransitiveDependencyManager(null);
+
+        // depth=1: derive from root with managed dependencies
+        manager = manager.deriveChildManager(newContext(
+                new Dependency(A2, null, null), new Dependency(B, null, true), new Dependency(C1, "newscope", null)));
+
+        // depth=2: management is applied — check enforcement flags
+        manager = manager.deriveChildManager(newContext());
+        DependencyManagement mngt = manager.manageDependency(new Dependency(A1, null));
+        assertNotNull(mngt);
+        assertEquals(A2.getVersion(), mngt.getVersion());
+        // version management from root should be enforced
+        assertTrue(mngt.isManagedSubject(Subject.VERSION));
+        assertTrue(mngt.isManagedSubjectEnforced(Subject.VERSION));
+
+        mngt = manager.manageDependency(new Dependency(C1, null));
+        assertNotNull(mngt);
+        assertEquals("newscope", mngt.getScope());
+        // scope management from root should be enforced
+        assertTrue(mngt.isManagedSubject(Subject.SCOPE));
+        assertTrue(mngt.isManagedSubjectEnforced(Subject.SCOPE));
+
+        mngt = manager.manageDependency(new Dependency(B1, null));
+        assertNotNull(mngt);
+        assertEquals(Boolean.TRUE, mngt.getOptional());
+        // optional management from root should be enforced
+        assertTrue(mngt.isManagedSubject(Subject.OPTIONAL));
+        assertTrue(mngt.isManagedSubjectEnforced(Subject.OPTIONAL));
+    }
+
+    /**
+     * Tests that transitive (non-root) management produces advised (not enforced) results
+     * for scope and optional.
+     */
+    @Test
+    void testTransitiveEnforcementFromNonRoot() {
+        DependencyManager manager = new TransitiveDependencyManager(null);
+
+        // depth=1: no managed dependencies at root level
+        manager = manager.deriveChildManager(newContext());
+
+        // depth=2: managed dependencies introduced at transitive level
+        manager = manager.deriveChildManager(newContext(
+                new Dependency(A2, null, null), new Dependency(B, null, true), new Dependency(C1, "newscope", null)));
+
+        // depth=3: management is applied — check enforcement flags
+        manager = manager.deriveChildManager(newContext());
+        DependencyManagement mngt = manager.manageDependency(new Dependency(A1, null));
+        assertNotNull(mngt);
+        assertEquals(A2.getVersion(), mngt.getVersion());
+        // version management from non-root should NOT be enforced (advised)
+        assertTrue(mngt.isManagedSubject(Subject.VERSION));
+        assertFalse(mngt.isManagedSubjectEnforced(Subject.VERSION));
+
+        mngt = manager.manageDependency(new Dependency(C1, null));
+        assertNotNull(mngt);
+        assertEquals("newscope", mngt.getScope());
+        // scope management from non-root should NOT be enforced (advised)
+        assertTrue(mngt.isManagedSubject(Subject.SCOPE));
+        assertFalse(mngt.isManagedSubjectEnforced(Subject.SCOPE));
+
+        mngt = manager.manageDependency(new Dependency(B1, null));
+        assertNotNull(mngt);
+        assertEquals(Boolean.TRUE, mngt.getOptional());
+        // optional management from non-root should NOT be enforced (advised)
+        assertTrue(mngt.isManagedSubject(Subject.OPTIONAL));
+        assertFalse(mngt.isManagedSubjectEnforced(Subject.OPTIONAL));
+    }
+
+    /**
+     * Tests that classic dependency manager also produces enforced results from root.
+     */
+    @Test
+    void testClassicEnforcementFromRoot() {
+        DependencyManager manager = new ClassicDependencyManager(null);
+
+        // depth=1: derive from root
+        manager = manager.deriveChildManager(
+                newContext(new Dependency(A2, null, null), new Dependency(C1, "newscope", null)));
+
+        // depth=2: management is applied
+        manager = manager.deriveChildManager(newContext());
+        DependencyManagement mngt = manager.manageDependency(new Dependency(A1, null));
+        assertNotNull(mngt);
+        assertTrue(mngt.isManagedSubjectEnforced(Subject.VERSION));
+
+        mngt = manager.manageDependency(new Dependency(C1, null));
+        assertNotNull(mngt);
+        assertTrue(mngt.isManagedSubjectEnforced(Subject.SCOPE));
+    }
+
+    /**
+     * Tests backwards compatibility: setManagedBits maps to isManagedSubject/isManagedSubjectEnforced.
+     */
+    @Test
+    void testSetManagedBitsBackwardsCompat() {
+        DefaultDependencyNode node = new DefaultDependencyNode(new Dependency(A1, "compile"));
+
+        // Set via deprecated API
+        node.setManagedBits(DependencyNode.MANAGED_VERSION | DependencyNode.MANAGED_SCOPE);
+
+        // Check via new API — all mapped as enforced
+        assertTrue(node.isManagedSubject(Subject.VERSION));
+        assertTrue(node.isManagedSubjectEnforced(Subject.VERSION));
+        assertTrue(node.isManagedSubject(Subject.SCOPE));
+        assertTrue(node.isManagedSubjectEnforced(Subject.SCOPE));
+
+        // Unset subjects
+        assertFalse(node.isManagedSubject(Subject.OPTIONAL));
+        assertFalse(node.isManagedSubjectEnforced(Subject.OPTIONAL));
+        assertFalse(node.isManagedSubject(Subject.PROPERTIES));
+        assertFalse(node.isManagedSubject(Subject.EXCLUSIONS));
+
+        // Round-trip: getManagedBits still works
+        assertEquals(DependencyNode.MANAGED_VERSION | DependencyNode.MANAGED_SCOPE, node.getManagedBits());
+    }
+
+    /**
+     * Tests that setManagedSubjects with explicit enforcement flags works correctly.
+     */
+    @Test
+    void testSetManagedSubjectsWithEnforcement() {
+        DefaultDependencyNode node = new DefaultDependencyNode(new Dependency(A1, "compile"));
+
+        EnumMap<Subject, Boolean> subjects = new EnumMap<>(Subject.class);
+        subjects.put(Subject.VERSION, true); // enforced
+        subjects.put(Subject.SCOPE, false); // advised
+        subjects.put(Subject.OPTIONAL, false); // advised
+        node.setManagedSubjects(subjects);
+
+        // All are managed
+        assertTrue(node.isManagedSubject(Subject.VERSION));
+        assertTrue(node.isManagedSubject(Subject.SCOPE));
+        assertTrue(node.isManagedSubject(Subject.OPTIONAL));
+        assertFalse(node.isManagedSubject(Subject.PROPERTIES));
+
+        // Only version is enforced
+        assertTrue(node.isManagedSubjectEnforced(Subject.VERSION));
+        assertFalse(node.isManagedSubjectEnforced(Subject.SCOPE));
+        assertFalse(node.isManagedSubjectEnforced(Subject.OPTIONAL));
+        assertFalse(node.isManagedSubjectEnforced(Subject.PROPERTIES));
+
+        // getManagedBits still reports all managed subjects (regardless of enforcement)
+        assertEquals(
+                DependencyNode.MANAGED_VERSION | DependencyNode.MANAGED_SCOPE | DependencyNode.MANAGED_OPTIONAL,
+                node.getManagedBits());
+    }
+
+    /**
+     * Tests that setManagedSubjects with null clears all managed subjects.
+     */
+    @Test
+    void testSetManagedSubjectsNull() {
+        DefaultDependencyNode node = new DefaultDependencyNode(new Dependency(A1, "compile"));
+
+        EnumMap<Subject, Boolean> subjects = new EnumMap<>(Subject.class);
+        subjects.put(Subject.VERSION, true);
+        node.setManagedSubjects(subjects);
+        assertTrue(node.isManagedSubject(Subject.VERSION));
+
+        // Clear
+        node.setManagedSubjects(null);
+        assertFalse(node.isManagedSubject(Subject.VERSION));
+        assertEquals(0, node.getManagedBits());
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
@@ -20,11 +20,13 @@ package org.eclipse.aether.util.graph.transformer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.DependencyManagement;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -520,6 +522,84 @@ public final class ConflictResolverTest extends AbstractConflictResolverTest {
                 fail("Unknown conflict resolver");
             }
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("conflictResolverSource")
+    void enforcedScopeNotDerived(ConflictResolver conflictResolver) throws RepositoryException {
+        // Root -> Parent (test) -> Child (compile, scope enforced)
+        // Scope derivation would normally narrow Child's scope to "test" (from parent),
+        // but enforced scope should prevent that.
+        DependencyNode root = makeDependencyNode("some-group", "root", "1.0");
+        DependencyNode parent = makeDependencyNode("some-group", "parent", "1.0", "test");
+        DefaultDependencyNode child =
+                (DefaultDependencyNode) makeDependencyNode("some-group", "child", "1.0", "compile");
+        EnumMap<DependencyManagement.Subject, Boolean> enforcedScope =
+                new EnumMap<>(DependencyManagement.Subject.class);
+        enforcedScope.put(DependencyManagement.Subject.SCOPE, true);
+        child.setManagedSubjects(enforcedScope);
+        root.setChildren(mutableList(parent));
+        parent.setChildren(mutableList(child));
+
+        transform(conflictResolver, root);
+        assertEquals("compile", child.getDependency().getScope(), "Enforced scope should not be derived from parent");
+    }
+
+    @ParameterizedTest
+    @MethodSource("conflictResolverSource")
+    void advisedScopeIsDerived(ConflictResolver conflictResolver) throws RepositoryException {
+        // Root -> Parent (test) -> Child (compile, scope advised)
+        // Scope derivation should narrow Child's scope to "test" because it's only advised.
+        DependencyNode root = makeDependencyNode("some-group", "root", "1.0");
+        DependencyNode parent = makeDependencyNode("some-group", "parent", "1.0", "test");
+        DefaultDependencyNode child =
+                (DefaultDependencyNode) makeDependencyNode("some-group", "child", "1.0", "compile");
+        EnumMap<DependencyManagement.Subject, Boolean> advisedScope = new EnumMap<>(DependencyManagement.Subject.class);
+        advisedScope.put(DependencyManagement.Subject.SCOPE, false);
+        child.setManagedSubjects(advisedScope);
+        root.setChildren(mutableList(parent));
+        parent.setChildren(mutableList(child));
+
+        transform(conflictResolver, root);
+        assertEquals("test", child.getDependency().getScope(), "Advised scope should be derived from parent");
+    }
+
+    @ParameterizedTest
+    @MethodSource("conflictResolverSource")
+    void enforcedOptionalNotDerived(ConflictResolver conflictResolver) throws RepositoryException {
+        // Root -> Parent (optional=true) -> Child (optional=false, optional enforced)
+        // Optional derivation would normally set Child to optional (from parent),
+        // but enforced optional should prevent that.
+        DependencyNode root = makeDependencyNode("some-group", "root", "1.0");
+        DependencyNode parent = makeDependencyNode("some-group", "parent", "1.0");
+        parent.setOptional(true);
+        DefaultDependencyNode child = (DefaultDependencyNode) makeDependencyNode("some-group", "child", "1.0");
+        child.setOptional(false);
+        EnumMap<DependencyManagement.Subject, Boolean> enforcedOptional =
+                new EnumMap<>(DependencyManagement.Subject.class);
+        enforcedOptional.put(DependencyManagement.Subject.OPTIONAL, true);
+        child.setManagedSubjects(enforcedOptional);
+        root.setChildren(mutableList(parent));
+        parent.setChildren(mutableList(child));
+
+        transform(conflictResolver, root);
+        assertFalse(child.getDependency().isOptional(), "Enforced optional should not be derived from parent");
+    }
+
+    @ParameterizedTest
+    @MethodSource("conflictResolverSource")
+    void unmanagedScopeIsDerivedAsUsual(ConflictResolver conflictResolver) throws RepositoryException {
+        // Root -> Parent (test) -> Child (compile, no management)
+        // Scope derivation should narrow Child's scope to "test" as usual (backwards compat).
+        DependencyNode root = makeDependencyNode("some-group", "root", "1.0");
+        DependencyNode parent = makeDependencyNode("some-group", "parent", "1.0", "test");
+        DependencyNode child = makeDependencyNode("some-group", "child", "1.0", "compile");
+        root.setChildren(mutableList(parent));
+        parent.setChildren(mutableList(child));
+
+        transform(conflictResolver, root);
+        assertEquals(
+                "test", child.getDependency().getScope(), "Unmanaged scope should be derived from parent as usual");
     }
 
     private static DependencyNode makeDependencyNode(String groupId, String artifactId, String version) {


### PR DESCRIPTION
Originally, dependency management marked a "subject" as "managed", it was 0/1 true/false only. This PR now adds ability to mark management as "advised" (may be subjected to further management) or "enforced" (equivalent of previously "managed").

Changes:
* `DependencyManager` applies management as "enforced", if they come from root (ie. project POM), otherwise as "advice" (this latter applies to transitive managers only, as for example classic manager have no data from "deeper levels").
* `ConflictManager` backs out for _enforced_ scope/optionality.
* This makes the "isInheritedDerived" hack in dependency manager not needed, as now management rule tells the modality of it (is enforced or just advised)
