### PR TITLE
Better control of plexus-utils

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/pom.xml
@@ -44,12 +44,12 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>4.0.3</version>
+        <version>${plexusUtils4Version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>4.1.1</version>
+        <version>${plexusXml4Version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -37,6 +37,17 @@
     ]]></bnd.instructions.additions>
   </properties>
 
+  <dependencyManagement>
+    <!-- we need to keep these aligned with Maven3; override mgmt from top level POM -->
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>${plexusUtils3Version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/maven-resolver-supplier-mvn4/pom.xml
+++ b/maven-resolver-supplier-mvn4/pom.xml
@@ -44,12 +44,12 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>4.0.2</version>
+        <version>${plexusUtils4Version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>4.1.1</version>
+        <version>${plexusXml4Version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/maven-resolver-tools/pom.xml
+++ b/maven-resolver-tools/pom.xml
@@ -130,6 +130,11 @@
       <version>${roasterVersion}</version>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtils4Version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <version>9.9.1</version>
@@ -138,10 +143,6 @@
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity-engine-core</artifactId>
       <version>2.4.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
       <groupId>info.picocli</groupId>

--- a/maven-resolver-tools/src/main/java/org/eclipse/aether/tools/CollectConfiguration.java
+++ b/maven-resolver-tools/src/main/java/org/eclipse/aether/tools/CollectConfiguration.java
@@ -109,9 +109,7 @@ public class CollectConfiguration implements Callable<Integer> {
                     stream.map(Path::toAbsolutePath)
                             .filter(p -> p.getFileName().toString().endsWith(".class"))
                             .filter(p -> p.toString().contains("/target/classes/"))
-                            .forEach(p -> {
-                                processMavenClass(p, discoveredKeys);
-                            });
+                            .forEach(p -> processMavenClass(p, discoveredKeys));
                 } else if (mode == Mode.resolver) {
                     System.out.println("Processing Resolver sources from " + rootDirectory);
                     stream.map(Path::toAbsolutePath)

--- a/maven-resolver-transport-wagon/pom.xml
+++ b/maven-resolver-transport-wagon/pom.xml
@@ -68,6 +68,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
+      <version>${plexusUtils3Version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
     <!-- used by supplier and demo only -->
     <maven3Version>3.9.14</maven3Version>
     <maven4Version>4.0.0-rc-5</maven4Version>
+    <plexusUtils3Version>3.6.1</plexusUtils3Version>
+    <plexusUtils4Version>4.0.3</plexusUtils4Version>
+    <plexusXml4Version>4.1.1</plexusXml4Version>
     <minimalMavenBuildVersion>[3.8.8,)</minimalMavenBuildVersion>
     <!-- MRESOLVER-422: keep this in sync with Javadoc plugin configuration (but cannot directly, as this below is range) -->
     <minimalJavaBuildVersion>[21,)</minimalJavaBuildVersion>
@@ -239,13 +242,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>5.23.0</version>
-      </dependency>
-
-      <!-- we need override plexus-util/xml versions from parent -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.6.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Resolver DOES NOT USE IT (well, only Wagon), still, it is constantly around as `mvn3/4` transitive dependency. We still need to manage it properly, given it comes from parent as well.
