### PR TITLE
Remove unnecessary repository preparation in metadata resolution for prefixes

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -387,10 +387,6 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         MetadataResolver mr = metadataResolver.get();
         RemoteRepositoryManager rm = remoteRepositoryManager.get();
         if (mr != null && rm != null) {
-            // create "prepared" (auth, proxy and mirror equipped repo)
-            RemoteRepository prepared = rm.aggregateRepositories(
-                            session, Collections.emptyList(), Collections.singletonList(remoteRepository), true)
-                    .get(0);
             // retrieve prefix as metadata from repository
             MetadataResult result = mr.resolveMetadata(
                             new DefaultRepositorySystemSession(session)
@@ -398,7 +394,7 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
                                     .setConfigProperty(CONFIG_PROP_SKIPPED, Boolean.TRUE.toString()),
                             Collections.singleton(new MetadataRequest(
                                             new DefaultMetadata(PREFIX_FILE_TYPE, Metadata.Nature.RELEASE_OR_SNAPSHOT))
-                                    .setRepository(prepared)
+                                    .setRepository(remoteRepository)
                                     .setDeleteLocalCopyIfMissing(true)
                                     .setFavorLocalRepository(true)))
                     .get(0);


### PR DESCRIPTION

Repository should be already configured, it is too late to change configuration. The same configuration should be used for standard operation and resolving metadata.

Example: plugins can provide unconfigured repo,
when we have configuration for mirror in settings - mirror will be used only for metadata.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
