### PR TITLE
Maintenance: tidy up IPC locks, make exclusive test timeout a bit longer

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/ByteChannelWrapper.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/ByteChannelWrapper.java
@@ -29,7 +29,6 @@ import java.nio.channels.ByteChannel;
  * @since 2.0.1
  */
 public class ByteChannelWrapper implements ByteChannel {
-
     private final ByteChannel socket;
 
     public ByteChannelWrapper(ByteChannel socket) {

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -116,8 +116,8 @@ public class IpcClient {
     }
 
     SocketChannel createClient() throws IOException {
-        String familyProp = System.getProperty(IpcServer.SYSTEM_PROP_FAMILY, IpcServer.DEFAULT_FAMILY);
-        SocketFamily family = familyProp != null ? SocketFamily.valueOf(familyProp) : SocketFamily.inet;
+        SocketFamily family =
+                SocketFamily.valueOf(System.getProperty(IpcServer.SYSTEM_PROP_FAMILY, IpcServer.DEFAULT_FAMILY));
 
         Path lockPath = this.lockPath.toAbsolutePath().normalize();
         Path lockFile =
@@ -414,7 +414,7 @@ public class IpcClient {
      */
     void stopServer() {
         try {
-            List<String> response = send(Arrays.asList(REQUEST_STOP), Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            List<String> response = send(List.of(REQUEST_STOP), Long.MAX_VALUE, TimeUnit.MILLISECONDS);
             if (response.size() != 1 || !RESPONSE_STOP.equals(response.get(0))) {
                 throw new IOException("Unexpected response: " + response);
             }

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcMessages.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcMessages.java
@@ -24,7 +24,6 @@ package org.eclipse.aether.named.ipc;
  * @since 2.0.1
  */
 public class IpcMessages {
-
     public static final String REQUEST_CONTEXT = "request-context";
     public static final String REQUEST_ACQUIRE = "request-acquire";
     public static final String REQUEST_CLOSE = "request-close";

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
@@ -95,15 +95,5 @@ class IpcNamedLock extends NamedLockSupport {
         }
     }
 
-    private static final class Ctx {
-        private final boolean acted;
-        private final String contextId;
-        private final boolean shared;
-
-        private Ctx(boolean acted, String contextId, boolean shared) {
-            this.acted = acted;
-            this.contextId = contextId;
-            this.shared = shared;
-        }
-    }
+    private record Ctx(boolean acted, String contextId, boolean shared) {}
 }

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLockFactory.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLockFactory.java
@@ -56,8 +56,7 @@ public class IpcNamedLockFactory extends NamedLockFactorySupport {
         requireNonNull(ipcHome);
         Path repository = ipcHome.resolve("repository");
         Path logPath = ipcHome.resolve("log");
-        Path syncPath = null;
-        this.client = new IpcClient(repository, logPath, syncPath);
+        this.client = new IpcClient(repository, logPath, null);
     }
 
     @Override

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
@@ -271,7 +271,7 @@ public class IpcServer {
                         }
                         break;
                     case IpcMessages.REQUEST_ACQUIRE:
-                        if (request.size() < 1) {
+                        if (request.isEmpty()) {
                             throw new IOException(
                                     "Expected at least one argument for " + command + " but got " + request);
                         }
@@ -321,7 +321,7 @@ public class IpcServer {
                         }
                         break;
                     case IpcMessages.REQUEST_STOP:
-                        if (request.size() != 0) {
+                        if (!request.isEmpty()) {
                             throw new IOException("Expected zero argument for " + command + " but got " + request);
                         }
                         synchronized (output) {

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/SocketFamily.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/SocketFamily.java
@@ -38,14 +38,11 @@ public enum SocketFamily {
     unix;
 
     public ServerSocketChannel openServerSocket() throws IOException {
-        switch (this) {
-            case inet:
-                return ServerSocketChannel.open().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
-            case unix:
-                return ServerSocketChannel.open(StandardProtocolFamily.UNIX).bind(null, 0);
-            default:
-                throw new IllegalStateException();
-        }
+        return switch (this) {
+            case inet -> ServerSocketChannel.open().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            case unix -> ServerSocketChannel.open(StandardProtocolFamily.UNIX).bind(null, 0);
+            default -> throw new IllegalStateException();
+        };
     }
 
     public static SocketAddress fromString(String str) {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryAdapterTestSupport.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryAdapterTestSupport.java
@@ -114,7 +114,7 @@ public abstract class NamedLockFactoryAdapterTestSupport {
     }
 
     @Test
-    @Timeout(15)
+    @Timeout(25)
     public void exclusiveAccess() throws InterruptedException {
         CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner
         CountDownLatch losers = new CountDownLatch(1); // we expect 1 loser

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryTestSupport.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryTestSupport.java
@@ -135,7 +135,7 @@ public abstract class NamedLockFactoryTestSupport {
     }
 
     @Test
-    @Timeout(15)
+    @Timeout(25)
     public void exclusiveAccess(TestInfo testInfo) throws InterruptedException {
         final Collection<NamedLockKey> keys = Collections.singleton(NamedLockKey.of(testInfo.getDisplayName()));
         CountDownLatch winners = new CountDownLatch(1); // we expect 1 winner


### PR DESCRIPTION
Increased test timeouts from 15sec to 25sec.