### PR TITLE
Fix: Remove javax.inject dependency

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LegacyTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LegacyTrackingFileManager.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  * @since 2.0.17
  * @see NamedLocksTrackingFileManager
- * @see TrackingFileManagerProvider
+ * @see TrackingFileManagerSupplier
  */
 public final class LegacyTrackingFileManager implements TrackingFileManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(LegacyTrackingFileManager.class);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/NamedLocksTrackingFileManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/NamedLocksTrackingFileManager.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  *
  * @since 2.0.17
  * @see LegacyTrackingFileManager
- * @see TrackingFileManagerProvider
+ * @see TrackingFileManagerSupplier
  */
 public final class NamedLocksTrackingFileManager implements TrackingFileManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(NamedLocksTrackingFileManager.class);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManagerProvider.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManagerProvider.java
@@ -23,74 +23,25 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.eclipse.aether.ConfigurationProperties;
-import org.eclipse.aether.impl.NamedLockFactorySelector;
-import org.eclipse.aether.named.NamedLockFactory;
-import org.eclipse.aether.util.ConfigUtils;
+import static java.util.Objects.requireNonNull;
 
 /**
- * Provides selected instance of {@link TrackingFileManager} implementation.
+ * Bridges to {@link TrackingFileManagerSupplier} when in Guice/Sisu.
  *
  * @since 2.0.17
  */
 @Singleton
 @Named
 public class TrackingFileManagerProvider implements Provider<TrackingFileManager> {
-    public static final String CONFIG_PROPS_PREFIX = ConfigurationProperties.PREFIX_SYSTEM + "trackingFileManager.";
+    private final TrackingFileManagerSupplier delegate;
 
-    /**
-     * Name of the tracking file manager to use. Supported values are "namedLocks" and "legacy". The latter should be
-     * used if it is known, that local repository is simultaneously accessed by Maven 3.10+ and older Maven versions.
-     * This decision happens early, during boot of the system, hence system properties can be used only as configuration
-     * source.
-     *
-     * @configurationSource {@link System#getProperty(String, String)}
-     * @configurationType {@link java.lang.String}
-     * @configurationDefaultValue {@link #DEFAULT_TRACKING_FILE_MANAGER_NAME}
-     */
-    public static final String CONFIG_PROP_TRACKING_FILE_MANAGER_NAME = CONFIG_PROPS_PREFIX + "name";
-
-    public static final String DEFAULT_TRACKING_FILE_MANAGER_NAME = "legacy";
-
-    private final TrackingFileManager trackingFileManager;
-
-    /**
-     * Default constructor, to be used in tests; provides "legacy" tracking file manager only.
-     */
-    public TrackingFileManagerProvider() {
-        this.trackingFileManager = new LegacyTrackingFileManager();
-    }
-
-    /**
-     * Constructor to be used in production.
-     */
     @Inject
-    public TrackingFileManagerProvider(NamedLockFactorySelector selector) {
-        // this is early construction; no session, hence we must rely on system properties instead
-        Map<String, String> config = new HashMap<>();
-        for (String name : System.getProperties().stringPropertyNames()) {
-            config.put(name, System.getProperty(name));
-        }
-        String tfmName = ConfigUtils.getString(
-                config, DEFAULT_TRACKING_FILE_MANAGER_NAME, CONFIG_PROP_TRACKING_FILE_MANAGER_NAME);
-        if ("legacy".equals(tfmName)) {
-            this.trackingFileManager = new LegacyTrackingFileManager();
-        } else if ("namedLocks".equals(tfmName)) {
-            NamedLockFactory factory = selector.getNamedLockFactory(config);
-            long time = selector.getLockWaitTime(config);
-            TimeUnit timeUnit = selector.getLockWaitTimeUnit(config);
-            this.trackingFileManager = new NamedLocksTrackingFileManager(factory, time, timeUnit);
-        } else {
-            throw new IllegalArgumentException("Unknown tracking file manager name: " + tfmName);
-        }
+    public TrackingFileManagerProvider(TrackingFileManagerSupplier metadataResolverProvider) {
+        this.delegate = requireNonNull(metadataResolverProvider);
     }
 
     @Override
     public TrackingFileManager get() {
-        return trackingFileManager;
+        return delegate.get();
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManagerSupplier.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/TrackingFileManagerSupplier.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.impl.NamedLockFactorySelector;
+import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.util.ConfigUtils;
+
+/**
+ * Supplies selected instance of {@link TrackingFileManager} implementation.
+ *
+ * @since 2.0.18
+ */
+@Singleton
+@Named
+public class TrackingFileManagerSupplier implements Supplier<TrackingFileManager> {
+    public static final String CONFIG_PROPS_PREFIX = ConfigurationProperties.PREFIX_SYSTEM + "trackingFileManager.";
+
+    /**
+     * Name of the tracking file manager to use. Supported values are "namedLocks" and "legacy". The latter should be
+     * used if it is known, that local repository is simultaneously accessed by Maven 3.10+ and older Maven versions.
+     * This decision happens early, during boot of the system, hence system properties can be used only as configuration
+     * source.
+     *
+     * @configurationSource {@link System#getProperty(String, String)}
+     * @configurationType {@link String}
+     * @configurationDefaultValue {@link #DEFAULT_TRACKING_FILE_MANAGER_NAME}
+     */
+    public static final String CONFIG_PROP_TRACKING_FILE_MANAGER_NAME = CONFIG_PROPS_PREFIX + "name";
+
+    public static final String DEFAULT_TRACKING_FILE_MANAGER_NAME = "legacy";
+
+    private final TrackingFileManager trackingFileManager;
+
+    /**
+     * Default constructor, to be used in tests; provides "legacy" tracking file manager only.
+     */
+    public TrackingFileManagerSupplier() {
+        this.trackingFileManager = new LegacyTrackingFileManager();
+    }
+
+    /**
+     * Constructor to be used in production.
+     */
+    @Inject
+    public TrackingFileManagerSupplier(NamedLockFactorySelector selector) {
+        // this is early construction; no session, hence we must rely on system properties instead
+        Map<String, String> config = new HashMap<>();
+        for (String name : System.getProperties().stringPropertyNames()) {
+            config.put(name, System.getProperty(name));
+        }
+        String tfmName = ConfigUtils.getString(
+                config, DEFAULT_TRACKING_FILE_MANAGER_NAME, CONFIG_PROP_TRACKING_FILE_MANAGER_NAME);
+        if ("legacy".equals(tfmName)) {
+            this.trackingFileManager = new LegacyTrackingFileManager();
+        } else if ("namedLocks".equals(tfmName)) {
+            NamedLockFactory factory = selector.getNamedLockFactory(config);
+            long time = selector.getLockWaitTime(config);
+            TimeUnit timeUnit = selector.getLockWaitTimeUnit(config);
+            this.trackingFileManager = new NamedLocksTrackingFileManager(factory, time, timeUnit);
+        } else {
+            throw new IllegalArgumentException("Unknown tracking file manager name: " + tfmName);
+        }
+    }
+
+    @Override
+    public TrackingFileManager get() {
+        return trackingFileManager;
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -374,7 +374,7 @@ public class DefaultArtifactResolverTest {
         resolver = setupArtifactResolver(
                 new StubVersionResolver(),
                 new DefaultUpdateCheckManager(
-                        new TrackingFileManagerProvider().get(),
+                        new TrackingFileManagerSupplier().get(),
                         new DefaultUpdatePolicyAnalyzer(),
                         new DefaultPathProcessor()));
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
@@ -79,7 +79,7 @@ public class DefaultUpdateCheckManagerTest {
                         TestFileUtils.createTempDir().toURI().toURL().toString())
                 .build();
         manager = new DefaultUpdateCheckManager(
-                new TrackingFileManagerProvider().get(), new DefaultUpdatePolicyAnalyzer(), new DefaultPathProcessor());
+                new TrackingFileManagerSupplier().get(), new DefaultUpdatePolicyAnalyzer(), new DefaultPathProcessor());
         metadata = new DefaultMetadata(
                 "gid", "aid", "ver", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT, metadataFile);
         artifact = new DefaultArtifact("gid", "aid", "", "ext", "ver").setFile(artifactFile);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -98,7 +98,7 @@ public class EnhancedLocalRepositoryManagerTest {
                 "gid", "aid", null, "maven-metadata.xml", Nature.RELEASE, TestFileUtils.createTempFile("metadata"));
 
         session = TestUtils.newSession();
-        trackingFileManager = new TrackingFileManagerProvider().get();
+        trackingFileManager = new TrackingFileManagerSupplier().get();
         manager = getManager();
 
         artifactFile = new File(basedir, manager.getPathForLocalArtifact(artifact));

--- a/maven-resolver-supplier-mvn3/pom.xml
+++ b/maven-resolver-supplier-mvn3/pom.xml
@@ -133,13 +133,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <!-- just build time -->
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -153,4 +146,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-javax.inject</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.inject:javax.inject</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -87,7 +87,7 @@ import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
-import org.eclipse.aether.internal.impl.TrackingFileManagerProvider;
+import org.eclipse.aether.internal.impl.TrackingFileManagerSupplier;
 import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
 import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
@@ -225,7 +225,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
     }
 
     protected TrackingFileManager createTrackingFileManager() {
-        return new TrackingFileManagerProvider(getNamedLockFactorySelector()).get();
+        return new TrackingFileManagerSupplier(getNamedLockFactorySelector()).get();
     }
 
     private LocalPathComposer localPathComposer;

--- a/maven-resolver-supplier-mvn4/pom.xml
+++ b/maven-resolver-supplier-mvn4/pom.xml
@@ -139,13 +139,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <!-- just build time -->
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -159,4 +152,30 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-javax.inject</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.inject:javax.inject</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -91,7 +91,7 @@ import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
 import org.eclipse.aether.internal.impl.Maven2RepositoryLayoutFactory;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.internal.impl.TrackingFileManager;
-import org.eclipse.aether.internal.impl.TrackingFileManagerProvider;
+import org.eclipse.aether.internal.impl.TrackingFileManagerSupplier;
 import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
 import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
 import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
@@ -229,7 +229,7 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
     }
 
     protected TrackingFileManager createTrackingFileManager() {
-        return new TrackingFileManagerProvider(getNamedLockFactorySelector()).get();
+        return new TrackingFileManagerSupplier(getNamedLockFactorySelector()).get();
     }
 
     private LocalPathComposer localPathComposer;


### PR DESCRIPTION
As it was wrongly introduced in PM #1814. Core of resolver object graph declares javax.inject as optional, but the mentioned PR made it mandatory.

Fixes #1858
