### PR TITLE
Feat: Expose scope related bits via scope manager

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/scope/ScopeManager.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/scope/ScopeManager.java
@@ -21,6 +21,10 @@ package org.eclipse.aether.scope;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.DependencyFilter;
+
 /**
  * Scope manager.
  *
@@ -67,4 +71,24 @@ public interface ScopeManager {
      * Returns the "universe" (all) of resolution scopes as immutable collection.
      */
     Collection<ResolutionScope> getResolutionScopeUniverse();
+
+    /**
+     * Resolver scope configuration specific: dependency selector to be used to support this scope (with its dependency
+     * and resolution scopes).
+     * <p>
+     * Important: Resolver 2.x when used with {@link ScopeManager}, the scope semantics is defined by client code.
+     * Hence, the scopes cannot be interpreted with fixed logic as it was the case in Maven 3.9 and before, instead
+     * the {@link ScopeManager} has to be asked to create selector based on scope configuration.
+     */
+    DependencySelector getDependencySelector(RepositorySystemSession session, ResolutionScope resolutionScope);
+
+    /**
+     * Resolver scope configuration specific: dependency filter to be used to support this scope (with its dependency
+     * and resolution scopes).
+     * <p>
+     * Important: Resolver 2.x when used with {@link ScopeManager}, the scope semantics is defined by client code.
+     * Hence, the scopes cannot be interpreted with fixed logic as it was the case in Maven 3.9 and before, instead
+     * the {@link ScopeManager} has to be asked to create filter based on scope configuration.
+     */
+    DependencyFilter getDependencyFilter(RepositorySystemSession session, ResolutionScope resolutionScope);
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/scope/InternalScopeManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/scope/InternalScopeManager.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.CollectResult;
-import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.scope.DependencyScope;
 import org.eclipse.aether.scope.ResolutionScope;
 import org.eclipse.aether.scope.ScopeManager;
@@ -52,12 +51,6 @@ public interface InternalScopeManager extends ScopeManager {
      * Returns the {@link BuildScope} that this scope deem as main.
      */
     Optional<BuildScope> getDependencyScopeMainProjectBuildScope(DependencyScope dependencyScope);
-
-    /**
-     * Resolver specific: dependency selector to be used to support this scope (with its dependency
-     * and resolution scopes).
-     */
-    DependencySelector getDependencySelector(RepositorySystemSession session, ResolutionScope resolutionScope);
 
     /**
      * Resolver specific: post-processing to be used to support this scope (with its dependency

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/ScopeManagerImpl.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/ScopeManagerImpl.java
@@ -34,6 +34,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.impl.scope.BuildPath;
 import org.eclipse.aether.impl.scope.BuildScope;
 import org.eclipse.aether.impl.scope.BuildScopeQuery;
@@ -160,6 +161,11 @@ public final class ScopeManagerImpl implements InternalScopeManager {
                     OptionalDependencySelector.fromDirect(),
                     new ExclusionDependencySelector());
         }
+    }
+
+    @Override
+    public DependencyFilter getDependencyFilter(RepositorySystemSession session, ResolutionScope resolutionScope) {
+        return new ScopeDependencyFilter(null, getDirectlyExcludedLabels(translate(resolutionScope)));
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
@@ -23,7 +23,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.scope.ResolutionScope;
 import org.eclipse.aether.util.artifact.JavaScopes;
 
 /**
@@ -115,6 +117,7 @@ public final class DependencyFilterUtils {
      * @deprecated resolver is oblivious about "scopes", it is consumer project which needs to lay these down and
      * also assign proper semantics. Moreover, Resolver is oblivious about notions of "classpath", "modulepath", and
      * any other similar uses. These should be handled by consumer project.
+     * @see org.eclipse.aether.scope.ScopeManager#getDependencyFilter(RepositorySystemSession, ResolutionScope)
      */
     @Deprecated
     public static DependencyFilter classpathFilter(String... classpathTypes) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/DependencyFilterUtils.java
@@ -23,9 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.scope.ResolutionScope;
 import org.eclipse.aether.util.artifact.JavaScopes;
 
 /**
@@ -117,7 +115,7 @@ public final class DependencyFilterUtils {
      * @deprecated resolver is oblivious about "scopes", it is consumer project which needs to lay these down and
      * also assign proper semantics. Moreover, Resolver is oblivious about notions of "classpath", "modulepath", and
      * any other similar uses. These should be handled by consumer project.
-     * @see org.eclipse.aether.scope.ScopeManager#getDependencyFilter(RepositorySystemSession, ResolutionScope)
+     * @see org.eclipse.aether.scope.ScopeManager#getDependencyFilter(org.eclipse.aether.RepositorySystemSession, org.eclipse.aether.scope.ResolutionScope)
      */
     @Deprecated
     public static DependencyFilter classpathFilter(String... classpathTypes) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/ScopeDependencyFilter.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/filter/ScopeDependencyFilter.java
@@ -66,6 +66,7 @@ public final class ScopeDependencyFilter implements DependencyFilter {
         }
     }
 
+    @Override
     public boolean accept(DependencyNode node, List<DependencyNode> parents) {
         Dependency dependency = node.getDependency();
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/selector/ScopeDependencySelector.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/selector/ScopeDependencySelector.java
@@ -25,11 +25,9 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.TreeSet;
 
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.scope.ResolutionScope;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,7 +38,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see Dependency#getScope()
  * @deprecated this class is deprecated. Use same named class from impl module instead.
- * @see org.eclipse.aether.scope.ScopeManager#getDependencySelector(RepositorySystemSession, ResolutionScope)
+ * @see org.eclipse.aether.scope.ScopeManager#getDependencySelector(org.eclipse.aether.RepositorySystemSession, org.eclipse.aether.scope.ResolutionScope)
  */
 @Deprecated
 public final class ScopeDependencySelector implements DependencySelector {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/selector/ScopeDependencySelector.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/selector/ScopeDependencySelector.java
@@ -25,9 +25,11 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.TreeSet;
 
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.scope.ResolutionScope;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +40,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see Dependency#getScope()
  * @deprecated this class is deprecated. Use same named class from impl module instead.
+ * @see org.eclipse.aether.scope.ScopeManager#getDependencySelector(RepositorySystemSession, ResolutionScope)
  */
 @Deprecated
 public final class ScopeDependencySelector implements DependencySelector {


### PR DESCRIPTION
When Resolver 2.x is used with `ScopeManager`, the scope semantics cannot be taken for granted as it was in Maven 3.9 and before, as in this case, scope manager configuration is the one who defines them, and their semantics as well.

Hence, any scope related operation, like filtering and selecting (during collection) must be done in with scope manager prepared filter or selector.

This PR fixes an issue never addressed in Resolver 2.x so far: it deprecated all the old "utils" that had wired-in scope semantics from Maven 3.9 and before times, but did not provide functionally equivalent replacement.