### PR TITLE
Feat: Reuse same RemoteRepository to HTTP URI creation logic

### DIFF
--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -160,10 +160,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         this.checksumExtractor = checksumExtractor;
         this.pathProcessor = pathProcessor;
         try {
-            this.baseUri = new URI(repository.getUrl()).parseServerAuthority();
-            if (baseUri.isOpaque()) {
-                throw new URISyntaxException(repository.getUrl(), "URL must not be opaque");
-            }
+            this.baseUri = HttpTransporterUtils.getBaseUri(repository);
             this.server = URIUtils.extractHost(baseUri);
             if (server == null) {
                 throw new URISyntaxException(repository.getUrl(), "URL lacks host name");

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -177,24 +177,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
         this.checksumExtractor = checksumExtractor;
         this.pathProcessor = pathProcessor;
         try {
-            URI uri = new URI(repository.getUrl()).parseServerAuthority();
-            if (uri.isOpaque()) {
-                throw new URISyntaxException(repository.getUrl(), "URL must not be opaque");
-            }
-            if (uri.getRawFragment() != null || uri.getRawQuery() != null) {
-                throw new URISyntaxException(repository.getUrl(), "URL must not have fragment or query");
-            }
-            String path = uri.getPath();
-            if (path == null) {
-                path = "/";
-            }
-            if (!path.startsWith("/")) {
-                path = "/" + path;
-            }
-            if (!path.endsWith("/")) {
-                path = path + "/";
-            }
-            this.baseUri = URI.create(uri.getScheme() + "://" + uri.getRawAuthority() + path);
+            this.baseUri = HttpTransporterUtils.getBaseUri(repository);
         } catch (URISyntaxException e) {
             throw new NoTransporterException(repository, e.getMessage(), e);
         }

--- a/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/JettyTransporter.java
+++ b/maven-resolver-transport-jetty/src/main/java/org/eclipse/aether/transport/jetty/JettyTransporter.java
@@ -128,24 +128,7 @@ final class JettyTransporter extends AbstractTransporter implements HttpTranspor
         this.checksumExtractor = checksumExtractor;
         this.pathProcessor = pathProcessor;
         try {
-            URI uri = new URI(repository.getUrl()).parseServerAuthority();
-            if (uri.isOpaque()) {
-                throw new URISyntaxException(repository.getUrl(), "URL must not be opaque");
-            }
-            if (uri.getRawFragment() != null || uri.getRawQuery() != null) {
-                throw new URISyntaxException(repository.getUrl(), "URL must not have fragment or query");
-            }
-            String path = uri.getPath();
-            if (path == null) {
-                path = "/";
-            }
-            if (!path.startsWith("/")) {
-                path = "/" + path;
-            }
-            if (!path.endsWith("/")) {
-                path = path + "/";
-            }
-            this.baseUri = URI.create(uri.getScheme() + "://" + uri.getRawAuthority() + path);
+            this.baseUri = HttpTransporterUtils.getBaseUri(repository);
         } catch (URISyntaxException e) {
             throw new NoTransporterException(repository, e.getMessage(), e);
         }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
@@ -304,6 +304,17 @@ public final class HttpTransporterUtils {
 
     /**
      * Shared code to create "base {@link URI}" for most common HTTP remote repositories and all HTTP transports.
+     * Note: this method just applies common validation and adjustments to URI, but it does not enforce protocol
+     * to be HTTP/HTTPS!
+     * <p>
+     * Validations and adjustments applied:
+     * <ul>
+     *     <li>URI string is parsed from {@link RemoteRepository#getUrl()} returned string</li>
+     *     <li>URI must have parsable {@link URI#parseServerAuthority()}</li>
+     *     <li>URI must not be opaque</li>
+     *     <li>URI must not have fragment or query</li>
+     *     <li>URI path is adjusted to end with {@code /} (slash).</li>
+     * </ul>
      *
      * @since 2.0.18
      */

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
@@ -19,6 +19,8 @@
 package org.eclipse.aether.util.connector.transport.http;
 
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -298,5 +300,31 @@ public final class HttpTransporterUtils {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Shared code to create "base {@link URI}" for most common HTTP remote repositories and all HTTP transports.
+     *
+     * @since 2.0.18
+     */
+    public static URI getBaseUri(RemoteRepository repository) throws URISyntaxException {
+        URI uri = new URI(repository.getUrl()).parseServerAuthority();
+        if (uri.isOpaque()) {
+            throw new URISyntaxException(repository.getUrl(), "URL must not be opaque");
+        }
+        if (uri.getRawFragment() != null || uri.getRawQuery() != null) {
+            throw new URISyntaxException(repository.getUrl(), "URL must not have fragment or query");
+        }
+        String path = uri.getRawPath();
+        if (path == null) {
+            path = "/";
+        }
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        if (!path.endsWith("/")) {
+            path = path + "/";
+        }
+        return new URI(uri.getScheme() + "://" + uri.getRawAuthority() + path);
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -44,8 +44,7 @@ public class HttpTransporterUtilsTest {
                 new RemoteRepository.Builder("repo", "", "https://host.com/base").build());
         assertEquals("https://host.com/base/", uri.toASCIIString());
 
-        uri = HttpTransporterUtils.getBaseUri(
-                new RemoteRepository.Builder("fragment", "", "https://host.com").build());
+        uri = HttpTransporterUtils.getBaseUri(new RemoteRepository.Builder("fragment", "", "https://host.com").build());
         assertEquals("https://host.com/", uri.toASCIIString());
     }
 

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util.connector.transport.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttpTransporterUtilsTest {
+
+    @Test
+    void badUris() {
+        assertThrows(
+                URISyntaxException.class,
+                () -> HttpTransporterUtils.getBaseUri(new RemoteRepository.Builder("opaque", "", "is:opaque").build()));
+        assertThrows(
+                URISyntaxException.class,
+                () -> HttpTransporterUtils.getBaseUri(
+                        new RemoteRepository.Builder("query", "", "https://host.com/path?query").build()));
+        assertThrows(
+                URISyntaxException.class,
+                () -> HttpTransporterUtils.getBaseUri(
+                        new RemoteRepository.Builder("fragment", "", "https://host.com/path#fragment").build()));
+    }
+
+    @Test
+    void getBaseUriWithNonAscii() throws URISyntaxException {
+        URI uri;
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("repø", "default", "https://host.dk/repø").build());
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+        assertEquals("host.dk", uri.getHost());
+        assertEquals("/repø/", uri.getPath());
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("repø", "default", "https://host.dk/rep%C3%B8").build());
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+        assertEquals("host.dk", uri.getHost());
+        assertEquals("/repø/", uri.getPath());
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("räpo", "default", "https://host.de/räpo").build());
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+        assertEquals("host.de", uri.getHost());
+        assertEquals("/räpo/", uri.getPath());
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("räpo", "default", "https://host.de/r%C3%A4po").build());
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+        assertEquals("host.de", uri.getHost());
+        assertEquals("/räpo/", uri.getPath());
+    }
+}

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -29,6 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HttpTransporterUtilsTest {
+    @Test
+    void goodUris() throws URISyntaxException {
+        URI uri;
+
+        // URI gets:
+        // * appended / (slash) if there is no trailing slash
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("repo", "", "https://host.com/base/").build());
+        assertEquals("https://host.com/base/", uri.toASCIIString());
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("repo", "", "https://host.com/base").build());
+        assertEquals("https://host.com/base/", uri.toASCIIString());
+
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("fragment", "", "https://host.com").build());
+        assertEquals("https://host.com/", uri.toASCIIString());
+    }
 
     @Test
     void badUris() {

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -33,18 +33,18 @@ public class HttpTransporterUtilsTest {
     void goodUris() throws URISyntaxException {
         URI uri;
 
-        // URI gets:
-        // * appended / (slash) if there is no trailing slash
+        // URI gets appended / (slash), if there is no trailing slash
 
         uri = HttpTransporterUtils.getBaseUri(
-                new RemoteRepository.Builder("repo", "", "https://host.com/base/").build());
+                new RemoteRepository.Builder("as-is", "", "https://host.com/base/").build());
         assertEquals("https://host.com/base/", uri.toASCIIString());
 
         uri = HttpTransporterUtils.getBaseUri(
-                new RemoteRepository.Builder("repo", "", "https://host.com/base").build());
+                new RemoteRepository.Builder("slash-append", "", "https://host.com/base").build());
         assertEquals("https://host.com/base/", uri.toASCIIString());
 
-        uri = HttpTransporterUtils.getBaseUri(new RemoteRepository.Builder("fragment", "", "https://host.com").build());
+        uri = HttpTransporterUtils.getBaseUri(
+                new RemoteRepository.Builder("root-append", "", "https://host.com").build());
         assertEquals("https://host.com/", uri.toASCIIString());
     }
 

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -74,6 +74,7 @@ public class HttpTransporterUtilsTest {
         assertEquals("https", uri.getScheme());
         assertEquals("host.dk", uri.getHost());
         assertEquals("/repø/", uri.getPath());
+        assertEquals("https://host.dk/rep%C3%B8/", uri.toASCIIString());
 
         uri = HttpTransporterUtils.getBaseUri(
                 new RemoteRepository.Builder("repø", "default", "https://host.dk/rep%C3%B8").build());
@@ -81,6 +82,7 @@ public class HttpTransporterUtilsTest {
         assertEquals("https", uri.getScheme());
         assertEquals("host.dk", uri.getHost());
         assertEquals("/repø/", uri.getPath());
+        assertEquals("https://host.dk/rep%C3%B8/", uri.toASCIIString());
 
         uri = HttpTransporterUtils.getBaseUri(
                 new RemoteRepository.Builder("räpo", "default", "https://host.de/räpo").build());
@@ -88,6 +90,7 @@ public class HttpTransporterUtilsTest {
         assertEquals("https", uri.getScheme());
         assertEquals("host.de", uri.getHost());
         assertEquals("/räpo/", uri.getPath());
+        assertEquals("https://host.de/r%C3%A4po/", uri.toASCIIString());
 
         uri = HttpTransporterUtils.getBaseUri(
                 new RemoteRepository.Builder("räpo", "default", "https://host.de/r%C3%A4po").build());
@@ -95,5 +98,6 @@ public class HttpTransporterUtilsTest {
         assertEquals("https", uri.getScheme());
         assertEquals("host.de", uri.getHost());
         assertEquals("/räpo/", uri.getPath());
+        assertEquals("https://host.de/r%C3%A4po/", uri.toASCIIString());
     }
 }


### PR DESCRIPTION
All HTTP remote repositories have pretty much same or similar expectations regardind base URI of a HTTP remote repository.

