### PR TITLE
Tidy up suppliers

### DIFF
--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/Maven3ScopeManagerConfiguration.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/Maven3ScopeManagerConfiguration.java
@@ -33,6 +33,7 @@ import org.eclipse.aether.impl.scope.ScopeManagerConfiguration;
 import org.eclipse.aether.internal.impl.scope.ScopeManagerDump;
 import org.eclipse.aether.scope.DependencyScope;
 import org.eclipse.aether.scope.ResolutionScope;
+import org.eclipse.aether.util.artifact.JavaScopes;
 
 import static org.eclipse.aether.impl.scope.BuildScopeQuery.all;
 import static org.eclipse.aether.impl.scope.BuildScopeQuery.byBuildPath;
@@ -44,22 +45,24 @@ import static org.eclipse.aether.impl.scope.BuildScopeQuery.union;
 /**
  * Maven3 scope configurations. Configures scope manager to support Maven3 scopes.
  * <p>
- * This manager supports the old Maven 3 dependency scopes + new "compile-only".
+ * This manager supports the old Maven 3 dependency scopes + new scopes.
  * <p>
- * Note: Maven3 CANNOT support Maven 4 scopes "test-only" and "test-runtime", as it does not distinguish
+ * Note: Maven3 CANNOT support new scopes "test-only" and "test-runtime", as it does not distinguish
  * resolution scope (the class {@code ResolutionScope} has only "TEST", instead of "TEST_COMPILE" and "TEST_RUNTIME").
+ * <em>This scope manager configuration is not used in Maven 3!</em>
  *
  * @since 2.0.11
  */
 public final class Maven3ScopeManagerConfiguration implements ScopeManagerConfiguration {
     public static final Maven3ScopeManagerConfiguration INSTANCE = new Maven3ScopeManagerConfiguration();
     public static final String DS_NONE = "none";
-    public static final String DS_COMPILE = "compile"; // JavaScopes.COMPILE;
+    public static final String DS_COMPILE = JavaScopes.COMPILE;
+    public static final String DS_RUNTIME = JavaScopes.RUNTIME;
+    public static final String DS_PROVIDED = JavaScopes.PROVIDED;
+    public static final String DS_SYSTEM = JavaScopes.SYSTEM;
+    public static final String DS_TEST = JavaScopes.TEST;
+
     public static final String DS_COMPILE_ONLY = "compile-only";
-    public static final String DS_RUNTIME = "runtime"; // JavaScopes.RUNTIME;
-    public static final String DS_PROVIDED = "provided"; // JavaScopes.PROVIDED;
-    public static final String DS_SYSTEM = "system"; // JavaScopes.SYSTEM;
-    public static final String DS_TEST = "test"; // JavaScopes.TEST;
     public static final String DS_TEST_ONLY = "test-only";
     public static final String DS_TEST_RUNTIME = "test-runtime";
 

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -33,6 +33,7 @@ import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.DependencyTraverser;
 import org.eclipse.aether.impl.scope.InternalScopeManager;
+import org.eclipse.aether.impl.scope.ScopeManagerConfiguration;
 import org.eclipse.aether.internal.impl.scope.ManagedDependencyContextRefiner;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeDeriver;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeSelector;
@@ -41,12 +42,17 @@ import org.eclipse.aether.internal.impl.scope.ScopeDependencySelector;
 import org.eclipse.aether.internal.impl.scope.ScopeManagerImpl;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.util.artifact.DefaultArtifactTypeRegistry;
+import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.manager.ClassicDependencyManager;
+import org.eclipse.aether.util.graph.manager.TransitiveDependencyManager;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
 import org.eclipse.aether.util.graph.transformer.ConfigurableVersionSelector;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.graph.traverser.FatArtifactTraverser;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
@@ -60,7 +66,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Extend this class and override methods to customize, if needed.
  * <p>
- * Resolver created as this is NOT using {@link org.eclipse.aether.scope.ScopeManager}!
+ * Resolver session created as this may or may not use {@link org.eclipse.aether.scope.ScopeManager}.
  *
  * @since 2.0.0
  */
@@ -68,9 +74,21 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     protected final RepositorySystem repositorySystem;
     protected final InternalScopeManager scopeManager;
 
+    /**
+     * Creates Resolver 2 session using Maven 3 elements without {@link InternalScopeManager}.
+     */
     public SessionBuilderSupplier(RepositorySystem repositorySystem) {
+        this(repositorySystem, null);
+    }
+
+    /**
+     * Creates Resolver 2 session using Maven 3 elements with or without {@link InternalScopeManager}.
+     */
+    public SessionBuilderSupplier(
+            RepositorySystem repositorySystem, ScopeManagerConfiguration scopeManagerConfiguration) {
         this.repositorySystem = requireNonNull(repositorySystem);
-        this.scopeManager = new ScopeManagerImpl(Maven3ScopeManagerConfiguration.INSTANCE);
+        this.scopeManager =
+                scopeManagerConfiguration == null ? null : new ScopeManagerImpl(scopeManagerConfiguration); // nullable
     }
 
     protected void configureSessionBuilder(SessionBuilder session) {
@@ -80,7 +98,9 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
             key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
             session.setSystemProperty(key, value);
         });
-        session.setScopeManager(scopeManager);
+        if (getScopeManager() != null) {
+            session.setScopeManager(getScopeManager());
+        }
         session.setDependencyTraverser(getDependencyTraverser());
         session.setDependencyManager(getDependencyManager());
         session.setDependencySelector(getDependencySelector());
@@ -98,27 +118,55 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
     }
 
     protected DependencyManager getDependencyManager() {
-        return new ClassicDependencyManager(getScopeManager());
+        return this.getDependencyManager(false);
+    }
+
+    protected DependencyManager getDependencyManager(boolean transitive) {
+        if (getScopeManager() == null) {
+            return transitive ? new TransitiveDependencyManager() : new ClassicDependencyManager();
+        } else {
+            return transitive
+                    ? new TransitiveDependencyManager(getScopeManager())
+                    : new ClassicDependencyManager(getScopeManager());
+        }
     }
 
     protected DependencySelector getDependencySelector() {
-        return new AndDependencySelector(
-                ScopeDependencySelector.legacy(
-                        null,
-                        Arrays.asList(
-                                Maven3ScopeManagerConfiguration.DS_TEST, Maven3ScopeManagerConfiguration.DS_PROVIDED)),
-                OptionalDependencySelector.fromDirect(),
-                new ExclusionDependencySelector());
+        if (getScopeManager() == null) {
+            return new AndDependencySelector(
+                    ScopeDependencySelector.legacy(null, Arrays.asList(JavaScopes.TEST, JavaScopes.PROVIDED)),
+                    OptionalDependencySelector.fromDirect(),
+                    new ExclusionDependencySelector());
+        } else {
+            return new AndDependencySelector(
+                    ScopeDependencySelector.legacy(
+                            null,
+                            Arrays.asList(
+                                    Maven3ScopeManagerConfiguration.DS_TEST,
+                                    Maven3ScopeManagerConfiguration.DS_PROVIDED)),
+                    OptionalDependencySelector.fromDirect(),
+                    new ExclusionDependencySelector());
+        }
     }
 
     protected DependencyGraphTransformer getDependencyGraphTransformer() {
-        return new ChainedDependencyGraphTransformer(
-                new ConflictResolver(
-                        new ConfigurableVersionSelector(),
-                        new ManagedScopeSelector(getScopeManager()),
-                        new SimpleOptionalitySelector(),
-                        new ManagedScopeDeriver(getScopeManager())),
-                new ManagedDependencyContextRefiner(getScopeManager()));
+        if (getScopeManager() == null) {
+            return new ChainedDependencyGraphTransformer(
+                    new ConflictResolver(
+                            new ConfigurableVersionSelector(),
+                            new JavaScopeSelector(),
+                            new SimpleOptionalitySelector(),
+                            new JavaScopeDeriver()),
+                    new JavaDependencyContextRefiner());
+        } else {
+            return new ChainedDependencyGraphTransformer(
+                    new ConflictResolver(
+                            new ConfigurableVersionSelector(),
+                            new ManagedScopeSelector(getScopeManager()),
+                            new SimpleOptionalitySelector(),
+                            new ManagedScopeDeriver(getScopeManager())),
+                    new ManagedDependencyContextRefiner(getScopeManager()));
+        }
     }
 
     protected ArtifactTypeRegistry getArtifactTypeRegistry() {
@@ -131,6 +179,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         stereotypes.add(new DefaultArtifactType("test-jar", "jar", "tests", "java"));
         stereotypes.add(new DefaultArtifactType("javadoc", "jar", "javadoc", "java"));
         stereotypes.add(new DefaultArtifactType("java-source", "jar", "sources", "java", false, false));
+        stereotypes.add(new DefaultArtifactType("fatjar", "jar", "", "java", true, true));
         stereotypes.add(new DefaultArtifactType("war", "war", "", "java", false, true));
         stereotypes.add(new DefaultArtifactType("ear", "ear", "", "java", false, true));
         stereotypes.add(new DefaultArtifactType("rar", "rar", "", "java", false, true));

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -26,7 +26,6 @@ import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
-import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -91,7 +91,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
                 scopeManagerConfiguration == null ? null : new ScopeManagerImpl(scopeManagerConfiguration); // nullable
     }
 
-    protected void configureSessionBuilder(SessionBuilder session) {
+    public void configureSessionBuilder(SessionBuilder session) {
         session.setSystemProperties(System.getProperties());
         boolean caseSensitive = !Os.IS_WINDOWS;
         System.getenv().forEach((key, value) -> {
@@ -109,19 +109,19 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         session.setArtifactDescriptorPolicy(getArtifactDescriptorPolicy());
     }
 
-    protected InternalScopeManager getScopeManager() {
+    public InternalScopeManager getScopeManager() {
         return this.scopeManager;
     }
 
-    protected DependencyTraverser getDependencyTraverser() {
+    public DependencyTraverser getDependencyTraverser() {
         return new FatArtifactTraverser();
     }
 
-    protected DependencyManager getDependencyManager() {
+    public DependencyManager getDependencyManager() {
         return this.getDependencyManager(false);
     }
 
-    protected DependencyManager getDependencyManager(boolean transitive) {
+    public DependencyManager getDependencyManager(boolean transitive) {
         if (getScopeManager() == null) {
             return transitive ? new TransitiveDependencyManager() : new ClassicDependencyManager();
         } else {
@@ -131,7 +131,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         }
     }
 
-    protected DependencySelector getDependencySelector() {
+    public DependencySelector getDependencySelector() {
         if (getScopeManager() == null) {
             return new AndDependencySelector(
                     ScopeDependencySelector.legacy(null, Arrays.asList(JavaScopes.TEST, JavaScopes.PROVIDED)),
@@ -149,7 +149,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         }
     }
 
-    protected DependencyGraphTransformer getDependencyGraphTransformer() {
+    public DependencyGraphTransformer getDependencyGraphTransformer() {
         if (getScopeManager() == null) {
             return new ChainedDependencyGraphTransformer(
                     new ConflictResolver(
@@ -169,7 +169,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         }
     }
 
-    protected ArtifactTypeRegistry getArtifactTypeRegistry() {
+    public DefaultArtifactTypeRegistry getArtifactTypeRegistry() {
         DefaultArtifactTypeRegistry stereotypes = new DefaultArtifactTypeRegistry();
         stereotypes.add(new DefaultArtifactType("pom"));
         stereotypes.add(new DefaultArtifactType("maven-plugin", "jar", "", "java"));
@@ -187,7 +187,7 @@ public class SessionBuilderSupplier implements Supplier<SessionBuilder> {
         return stereotypes;
     }
 
-    protected ArtifactDescriptorPolicy getArtifactDescriptorPolicy() {
+    public ArtifactDescriptorPolicy getArtifactDescriptorPolicy() {
         return new SimpleArtifactDescriptorPolicy(true, true);
     }
 

--- a/maven-resolver-supplier-mvn3/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
+++ b/maven-resolver-supplier-mvn3/src/test/java/org/eclipse/aether/supplier/RepositorySystemSupplierTest.java
@@ -44,7 +44,7 @@ public class RepositorySystemSupplierTest {
     @Test
     void smoke() throws Exception {
         try (RepositorySystem system = new RepositorySystemSupplier().get();
-                CloseableSession session = new SessionBuilderSupplier(system)
+                CloseableSession session = new SessionBuilderSupplier(system, Maven3ScopeManagerConfiguration.INSTANCE)
                         .get()
                         .withLocalRepositoryBaseDirectories(new File("target/local-repo").toPath())
                         .build()) {
@@ -66,7 +66,7 @@ public class RepositorySystemSupplierTest {
     @Test
     void smokeV2Feature() throws Exception {
         try (RepositorySystem system = new RepositorySystemSupplier().get();
-                CloseableSession session = new SessionBuilderSupplier(system)
+                CloseableSession session = new SessionBuilderSupplier(system, Maven3ScopeManagerConfiguration.INSTANCE)
                         .get()
                         .withLocalRepositoryBaseDirectories(new File("target/local-repo").toPath())
                         .build()) {

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -20,12 +20,10 @@ package org.eclipse.aether.supplier;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.apache.maven.api.DependencyScope;
 import org.apache.maven.repository.internal.artifact.FatArtifactTraverser;
-import org.apache.maven.repository.internal.scopes.Maven4ScopeManagerConfiguration;
 import org.apache.maven.repository.internal.type.DefaultTypeProvider;
 import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
@@ -38,6 +36,7 @@ import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.collection.DependencyTraverser;
 import org.eclipse.aether.impl.scope.InternalScopeManager;
+import org.eclipse.aether.impl.scope.ScopeManagerConfiguration;
 import org.eclipse.aether.internal.impl.scope.ManagedDependencyContextRefiner;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeDeriver;
 import org.eclipse.aether.internal.impl.scope.ManagedScopeSelector;
@@ -53,8 +52,13 @@ import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
 import org.eclipse.aether.util.graph.transformer.ChainedDependencyGraphTransformer;
 import org.eclipse.aether.util.graph.transformer.ConfigurableVersionSelector;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaDependencyContextRefiner;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
 import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.repository.SimpleArtifactDescriptorPolicy;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A simple {@link Supplier} of {@link SessionBuilder} instances, that on each call supplies newly
@@ -69,16 +73,38 @@ public class SessionBuilderSupplier {
     protected final RepositorySystem repositorySystem;
     protected final InternalScopeManager scopeManager;
 
+    /**
+     * Creates Resolver 2 session using Maven 4 elements without {@link InternalScopeManager}.
+     */
     public SessionBuilderSupplier(RepositorySystem repositorySystem) {
-        this.repositorySystem = Objects.requireNonNull(repositorySystem);
-        this.scopeManager = new ScopeManagerImpl(Maven4ScopeManagerConfiguration.INSTANCE);
+        this(repositorySystem, null);
     }
 
-    /** @deprecated */
-    @Deprecated
-    public SessionBuilderSupplier() {
-        this.repositorySystem = null;
-        this.scopeManager = new ScopeManagerImpl(Maven4ScopeManagerConfiguration.INSTANCE);
+    /**
+     * Creates Resolver 2 session using Maven 4 elements with or without {@link InternalScopeManager}.
+     */
+    public SessionBuilderSupplier(
+            RepositorySystem repositorySystem, ScopeManagerConfiguration scopeManagerConfiguration) {
+        this.repositorySystem = requireNonNull(repositorySystem);
+        this.scopeManager = scopeManagerConfiguration == null ? null : new ScopeManagerImpl(scopeManagerConfiguration);
+    }
+
+    protected void configureSessionBuilder(RepositorySystemSession.SessionBuilder session) {
+        session.setSystemProperties(System.getProperties());
+        boolean caseSensitive = !Os.IS_WINDOWS;
+        System.getenv().forEach((key, value) -> {
+            key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
+            session.setSystemProperty(key, value);
+        });
+        if (getScopeManager() != null) {
+            session.setScopeManager(getScopeManager());
+        }
+        session.setDependencyTraverser(getDependencyTraverser());
+        session.setDependencyManager(getDependencyManager());
+        session.setDependencySelector(getDependencySelector());
+        session.setDependencyGraphTransformer(getDependencyGraphTransformer());
+        session.setArtifactTypeRegistry(getArtifactTypeRegistry());
+        session.setArtifactDescriptorPolicy(getArtifactDescriptorPolicy());
     }
 
     protected InternalScopeManager getScopeManager() {
@@ -93,29 +119,50 @@ public class SessionBuilderSupplier {
         return this.getDependencyManager(true);
     }
 
-    public DependencyManager getDependencyManager(boolean transitive) {
-        return transitive
-                ? new TransitiveDependencyManager(getScopeManager())
-                : new ClassicDependencyManager(getScopeManager());
+    protected DependencyManager getDependencyManager(boolean transitive) {
+        if (getScopeManager() == null) {
+            return transitive ? new TransitiveDependencyManager() : new ClassicDependencyManager();
+        } else {
+            return transitive
+                    ? new TransitiveDependencyManager(getScopeManager())
+                    : new ClassicDependencyManager(getScopeManager());
+        }
     }
 
     protected DependencySelector getDependencySelector() {
-        return new AndDependencySelector(new DependencySelector[] {
-            ScopeDependencySelector.legacy(
-                    null, Arrays.asList(DependencyScope.TEST.id(), DependencyScope.PROVIDED.id())),
-            OptionalDependencySelector.fromDirect(),
-            new ExclusionDependencySelector()
-        });
+        if (getScopeManager() == null) {
+            return new AndDependencySelector(
+                    ScopeDependencySelector.legacy(
+                            null, Arrays.asList(DependencyScope.TEST.id(), DependencyScope.PROVIDED.id())),
+                    OptionalDependencySelector.fromDirect(),
+                    new ExclusionDependencySelector());
+        } else {
+            return new AndDependencySelector(
+                    ScopeDependencySelector.legacy(
+                            null, Arrays.asList(DependencyScope.TEST.id(), DependencyScope.PROVIDED.id())),
+                    OptionalDependencySelector.fromDirect(),
+                    new ExclusionDependencySelector());
+        }
     }
 
     protected DependencyGraphTransformer getDependencyGraphTransformer() {
-        return new ChainedDependencyGraphTransformer(
-                new ConflictResolver(
-                        new ConfigurableVersionSelector(),
-                        new ManagedScopeSelector(getScopeManager()),
-                        new SimpleOptionalitySelector(),
-                        new ManagedScopeDeriver(getScopeManager())),
-                new ManagedDependencyContextRefiner(getScopeManager()));
+        if (getScopeManager() == null) {
+            return new ChainedDependencyGraphTransformer(
+                    new ConflictResolver(
+                            new ConfigurableVersionSelector(),
+                            new JavaScopeSelector(),
+                            new SimpleOptionalitySelector(),
+                            new JavaScopeDeriver()),
+                    new JavaDependencyContextRefiner());
+        } else {
+            return new ChainedDependencyGraphTransformer(
+                    new ConflictResolver(
+                            new ConfigurableVersionSelector(),
+                            new ManagedScopeSelector(getScopeManager()),
+                            new SimpleOptionalitySelector(),
+                            new ManagedScopeDeriver(getScopeManager())),
+                    new ManagedDependencyContextRefiner(getScopeManager()));
+        }
     }
 
     protected ArtifactTypeRegistry getArtifactTypeRegistry() {
@@ -128,27 +175,19 @@ public class SessionBuilderSupplier {
         return new SimpleArtifactDescriptorPolicy(true, true);
     }
 
-    protected void configureSessionBuilder(RepositorySystemSession.SessionBuilder session) {
-        session.setDependencyTraverser(this.getDependencyTraverser());
-        session.setDependencyManager(this.getDependencyManager());
-        session.setDependencySelector(this.getDependencySelector());
-        session.setDependencyGraphTransformer(this.getDependencyGraphTransformer());
-        session.setArtifactTypeRegistry(this.getArtifactTypeRegistry());
-        session.setArtifactDescriptorPolicy(this.getArtifactDescriptorPolicy());
-        session.setScopeManager(this.getScopeManager());
-
-        session.setSystemProperties(System.getProperties());
-        boolean caseSensitive = !Os.IS_WINDOWS;
-        System.getenv().forEach((key, value) -> {
-            key = "env." + (caseSensitive ? key : key.toUpperCase(Locale.ENGLISH));
-            session.setSystemProperty(key, value);
-        });
-    }
-
+    /**
+     * Creates a new Maven-like repository system session by initializing the session with values typical for
+     * Maven-based resolution. In more detail, this method configures settings relevant for the processing of dependency
+     * graphs, most other settings remain at their generic default value. Use the various setters to further configure
+     * the session with authentication, mirror, proxy and other information required for your environment. At least,
+     * local repository manager needs to be configured to make session be able to create session instance.
+     *
+     * @return SessionBuilder configured with minimally required things for "Maven-based resolution". At least LRM must
+     * be set on builder to make it able to create session instances.
+     */
     public RepositorySystemSession.SessionBuilder get() {
-        Objects.requireNonNull(this.repositorySystem, "repositorySystem");
-        RepositorySystemSession.SessionBuilder builder = this.repositorySystem.createSessionBuilder();
-        this.configureSessionBuilder(builder);
+        RepositorySystemSession.SessionBuilder builder = repositorySystem.createSessionBuilder();
+        configureSessionBuilder(builder);
         return builder;
     }
 }

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/SessionBuilderSupplier.java
@@ -24,13 +24,12 @@ import java.util.function.Supplier;
 
 import org.apache.maven.api.DependencyScope;
 import org.apache.maven.repository.internal.artifact.FatArtifactTraverser;
-import org.apache.maven.repository.internal.type.DefaultTypeProvider;
 import org.apache.maven.utils.Os;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
-import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -89,7 +88,7 @@ public class SessionBuilderSupplier {
         this.scopeManager = scopeManagerConfiguration == null ? null : new ScopeManagerImpl(scopeManagerConfiguration);
     }
 
-    protected void configureSessionBuilder(RepositorySystemSession.SessionBuilder session) {
+    public void configureSessionBuilder(RepositorySystemSession.SessionBuilder session) {
         session.setSystemProperties(System.getProperties());
         boolean caseSensitive = !Os.IS_WINDOWS;
         System.getenv().forEach((key, value) -> {
@@ -107,19 +106,19 @@ public class SessionBuilderSupplier {
         session.setArtifactDescriptorPolicy(getArtifactDescriptorPolicy());
     }
 
-    protected InternalScopeManager getScopeManager() {
+    public InternalScopeManager getScopeManager() {
         return this.scopeManager;
     }
 
-    protected DependencyTraverser getDependencyTraverser() {
+    public DependencyTraverser getDependencyTraverser() {
         return new FatArtifactTraverser();
     }
 
-    protected DependencyManager getDependencyManager() {
+    public DependencyManager getDependencyManager() {
         return this.getDependencyManager(true);
     }
 
-    protected DependencyManager getDependencyManager(boolean transitive) {
+    public DependencyManager getDependencyManager(boolean transitive) {
         if (getScopeManager() == null) {
             return transitive ? new TransitiveDependencyManager() : new ClassicDependencyManager();
         } else {
@@ -129,7 +128,7 @@ public class SessionBuilderSupplier {
         }
     }
 
-    protected DependencySelector getDependencySelector() {
+    public DependencySelector getDependencySelector() {
         if (getScopeManager() == null) {
             return new AndDependencySelector(
                     ScopeDependencySelector.legacy(
@@ -145,7 +144,7 @@ public class SessionBuilderSupplier {
         }
     }
 
-    protected DependencyGraphTransformer getDependencyGraphTransformer() {
+    public DependencyGraphTransformer getDependencyGraphTransformer() {
         if (getScopeManager() == null) {
             return new ChainedDependencyGraphTransformer(
                     new ConflictResolver(
@@ -165,13 +164,25 @@ public class SessionBuilderSupplier {
         }
     }
 
-    protected ArtifactTypeRegistry getArtifactTypeRegistry() {
+    public DefaultArtifactTypeRegistry getArtifactTypeRegistry() {
         DefaultArtifactTypeRegistry stereotypes = new DefaultArtifactTypeRegistry();
-        new DefaultTypeProvider().types().forEach(stereotypes::add);
+        stereotypes.add(new DefaultArtifactType("pom"));
+        stereotypes.add(new DefaultArtifactType("maven-plugin", "jar", "", "java"));
+        stereotypes.add(new DefaultArtifactType("jar", "jar", "", "java"));
+        stereotypes.add(new DefaultArtifactType("ejb", "jar", "", "java"));
+        stereotypes.add(new DefaultArtifactType("ejb-client", "jar", "client", "java"));
+        stereotypes.add(new DefaultArtifactType("test-jar", "jar", "tests", "java"));
+        stereotypes.add(new DefaultArtifactType("javadoc", "jar", "javadoc", "java"));
+        stereotypes.add(new DefaultArtifactType("java-source", "jar", "sources", "java", false, false));
+        stereotypes.add(new DefaultArtifactType("fatjar", "jar", "", "java", true, true));
+        stereotypes.add(new DefaultArtifactType("war", "war", "", "java", false, true));
+        stereotypes.add(new DefaultArtifactType("ear", "ear", "", "java", false, true));
+        stereotypes.add(new DefaultArtifactType("rar", "rar", "", "java", false, true));
+        stereotypes.add(new DefaultArtifactType("par", "par", "", "java", false, true));
         return stereotypes;
     }
 
-    protected ArtifactDescriptorPolicy getArtifactDescriptorPolicy() {
+    public ArtifactDescriptorPolicy getArtifactDescriptorPolicy() {
         return new SimpleArtifactDescriptorPolicy(true, true);
     }
 

--- a/src/site/markdown/third-party-integrations.md
+++ b/src/site/markdown/third-party-integrations.md
@@ -39,10 +39,6 @@ and supplies new, ready-to-use `RepositorySystem` instance for each call. Class 
 no instance caching or anything alike is present: all that is concern of caller, just like proper shutdown 
 of the created resolver instances is.
 
-The `RepositorySystemSession` should be created using the 
-`org.apache.maven.repository.internal.MavenRepositorySystemUtils#newSession()` method
-and local repository added to it in usual way (there is no change in this area).
-
 The supplier class is written in a way, to allow easy customization if needed: just extend the class and override
 method as needed (all methods are protected).
 


### PR DESCRIPTION
Clean up, make scope manager optional, and hence, make them really reusable.

This prepares dedup in Maven 3.10+ as those counterparts (duplicates) can now be dropped.

Finally, open up suppliers, making them extension and integration friendly.
