### PR TITLE
DependencyCollectionChecker: new session member

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/AbstractForwardingRepositorySystemSession.java
@@ -21,6 +21,7 @@ package org.eclipse.aether;
 import java.util.Map;
 
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -196,6 +197,11 @@ public abstract class AbstractForwardingRepositorySystemSession implements Repos
     @Override
     public ScopeManager getScopeManager() {
         return getSession().getScopeManager();
+    }
+
+    @Override
+    public DependencyCollectionChecker getDependencyCollectionChecker() {
+        return getSession().getDependencyCollectionChecker();
     }
 
     @Override

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import org.eclipse.aether.artifact.ArtifactType;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -128,6 +129,8 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
 
     private ScopeManager scopeManager;
 
+    private DependencyCollectionChecker dependencyCollectionChecker;
+
     private final Function<Runnable, Boolean> onSessionEndedRegistrar;
 
     /**
@@ -165,6 +168,7 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
         proxySelector = PassthroughProxySelector.INSTANCE;
         authenticationSelector = PassthroughAuthenticationSelector.INSTANCE;
         artifactTypeRegistry = NullArtifactTypeRegistry.INSTANCE;
+        dependencyCollectionChecker = DependencyCollectionChecker.NOOP;
         data = new DefaultSessionData();
         this.onSessionEndedRegistrar = requireNonNull(onSessionEndedRegistrar, "onSessionEndedRegistrar");
     }
@@ -206,6 +210,7 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
         setData(session.getData());
         setCache(session.getCache());
         setScopeManager(session.getScopeManager());
+        setDependencyCollectionChecker(session.getDependencyCollectionChecker());
         this.onSessionEndedRegistrar = session::addOnSessionEndedHandler;
     }
 
@@ -830,6 +835,24 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
         } else {
             return SystemDependencyScope.LEGACY;
         }
+    }
+
+    @Override
+    public DependencyCollectionChecker getDependencyCollectionChecker() {
+        return dependencyCollectionChecker;
+    }
+
+    /**
+     * Sets the dependency collection checker, may not be {@code null}.
+     *
+     * @param dependencyCollectionChecker The dependency collection checker, never {@code null}.
+     * @return The session for chaining, never {@code null}.
+     * @since 2.0.19
+     */
+    public DefaultRepositorySystemSession setDependencyCollectionChecker(
+            DependencyCollectionChecker dependencyCollectionChecker) {
+        this.dependencyCollectionChecker = requireNonNull(dependencyCollectionChecker);
+        return this;
     }
 
     /**

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/DefaultRepositorySystemSession.java
@@ -168,7 +168,6 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
         proxySelector = PassthroughProxySelector.INSTANCE;
         authenticationSelector = PassthroughAuthenticationSelector.INSTANCE;
         artifactTypeRegistry = NullArtifactTypeRegistry.INSTANCE;
-        dependencyCollectionChecker = DependencyCollectionChecker.NOOP;
         data = new DefaultSessionData();
         this.onSessionEndedRegistrar = requireNonNull(onSessionEndedRegistrar, "onSessionEndedRegistrar");
     }
@@ -843,15 +842,15 @@ public final class DefaultRepositorySystemSession implements RepositorySystemSes
     }
 
     /**
-     * Sets the dependency collection checker, may not be {@code null}.
+     * Sets the dependency collection checker, may be {@code null}.
      *
-     * @param dependencyCollectionChecker The dependency collection checker, never {@code null}.
+     * @param dependencyCollectionChecker The dependency collection checker, may be {@code null}.
      * @return The session for chaining, never {@code null}.
      * @since 2.0.19
      */
     public DefaultRepositorySystemSession setDependencyCollectionChecker(
             DependencyCollectionChecker dependencyCollectionChecker) {
-        this.dependencyCollectionChecker = requireNonNull(dependencyCollectionChecker);
+        this.dependencyCollectionChecker = dependencyCollectionChecker;
         return this;
     }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -406,6 +407,15 @@ public interface RepositorySystemSession {
         SessionBuilder setScopeManager(ScopeManager scopeManager);
 
         /**
+         * Sets the dependency collection checker, never {@code null}.
+         *
+         * @param dependencyCollectionChecker The checker instance, may not be {@code null}.
+         * @return The session for chaining, never {@code null}.
+         * @since 2.0.19
+         */
+        SessionBuilder setDependencyCollectionChecker(DependencyCollectionChecker dependencyCollectionChecker);
+
+        /**
          * Adds on session ended handler to be immediately registered when this builder creates session.
          *
          * @param handler The on session ended handler, may not be {@code null}.
@@ -781,6 +791,14 @@ public interface RepositorySystemSession {
      * @since 2.0.0
      */
     SystemDependencyScope getSystemDependencyScope();
+
+    /**
+     * Returns the dependency collector checker, never {@code null}.
+     *
+     * @return The effective {@link DependencyCollectionChecker} instance, never {@code null}.
+     * @since 2.0.19
+     */
+    DependencyCollectionChecker getDependencyCollectionChecker();
 
     /**
      * Registers a handler to execute when this session closed.

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/RepositorySystemSession.java
@@ -407,10 +407,10 @@ public interface RepositorySystemSession {
         SessionBuilder setScopeManager(ScopeManager scopeManager);
 
         /**
-         * Sets the dependency collection checker, never {@code null}.
+         * Sets the dependency collection checker, may be {@code null}.
          *
-         * @param dependencyCollectionChecker The checker instance, may not be {@code null}.
-         * @return The session for chaining, never {@code null}.
+         * @param dependencyCollectionChecker The checker instance, may be {@code null}.
+         * @return The session for chaining, may be {@code null}.
          * @since 2.0.19
          */
         SessionBuilder setDependencyCollectionChecker(DependencyCollectionChecker dependencyCollectionChecker);
@@ -793,9 +793,9 @@ public interface RepositorySystemSession {
     SystemDependencyScope getSystemDependencyScope();
 
     /**
-     * Returns the dependency collector checker, never {@code null}.
+     * Returns the dependency collector checker, may be {@code null}.
      *
-     * @return The effective {@link DependencyCollectionChecker} instance, never {@code null}.
+     * @return The effective {@link DependencyCollectionChecker} instance, may be {@code null}.
      * @since 2.0.19
      */
     DependencyCollectionChecker getDependencyCollectionChecker();

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyCollectionChecker.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/DependencyCollectionChecker.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.collection;
+
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Dependency collector checker. It is able to check dependency collection result, deem it "satisfiable" or
+ * augment collection and re-execute it.
+ *
+ * @since 2.0.19
+ */
+public interface DependencyCollectionChecker {
+    /**
+     * A default "no op" implementation.
+     */
+    DependencyCollectionChecker NOOP = new DependencyCollectionChecker() {};
+
+    /**
+     * Config property for collector checker suppression. Presence of this key will suppress collection checking.
+     * This key is not meant for users, but to programmatically signal collection suppression.
+     */
+    String COLLECTOR_CHECKER_SUPPRESSED = "aether.dependencyCollector.checker.suppressed";
+
+    /**
+     * Prepares for dependency collection.
+     */
+    default RepositorySystemSession prepare(RepositorySystemSession session, CollectRequest request) {
+        return session;
+    }
+
+    /**
+     * Performs checks on finished dependency collection. It should return {@code true} if the collection was deemed
+     * "satisfactory". If should return {@code false} <em>only, if collection was not satisfactory, and checker
+     * was able to modify resolution parameters (to not repeat same work)</em>. In other cases (not satisfactory
+     * but no param change would help) it should throw {@link DependencyCollectionException}.
+     */
+    default boolean isSatisfactory(RepositorySystemSession session, CollectRequest request, CollectResult result)
+            throws DependencyCollectionException {
+        return true;
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -145,7 +145,9 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         final InternalScopeManager scopeManager = (InternalScopeManager) originalSession.getScopeManager();
         final RepositorySystemSession setUpSession = setUpSession(originalSession, request, scopeManager);
         final DependencyCollectionChecker dependencyCollectionChecker =
-                originalSession.getDependencyCollectionChecker();
+                originalSession.getDependencyCollectionChecker() == null
+                        ? DependencyCollectionChecker.NOOP
+                        : originalSession.getDependencyCollectionChecker();
 
         final RequestTrace trace = RequestTrace.newChild(request.getTrace(), request);
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -98,6 +98,19 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
 
     public static final int DEFAULT_MAX_CYCLES = 10;
 
+    /**
+     * The allowed runs of collection (and re-collection). By default, there must be at least 1 run, so values smaller
+     * than 1 are considered configuration errors and will fail dependency collection.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Integer}
+     * @configurationDefaultValue {@link #DEFAULT_MAX_RUNS}
+     * @since 2.0.19
+     */
+    public static final String CONFIG_PROP_MAX_RUNS = DefaultDependencyCollector.CONFIG_PROPS_PREFIX + "maxRuns";
+
+    public static final int DEFAULT_MAX_RUNS = 5;
+
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final RemoteRepositoryManager remoteRepositoryManager;
@@ -138,13 +151,24 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
 
         final Map<String, Object> stats = new LinkedHashMap<>();
         final AtomicInteger runs = new AtomicInteger(0);
+        final int maxRuns = ConfigUtils.getInteger(originalSession, DEFAULT_MAX_RUNS, CONFIG_PROP_MAX_RUNS);
+        if (maxRuns < 1) {
+            throw new DependencyCollectionException(
+                    new CollectResult(request),
+                    "Invalid configuration: '" + CONFIG_PROP_MAX_RUNS
+                            + "' configuration must be equal or grater than 1");
+        }
 
         CollectResult result = null;
 
         boolean finished = false;
         while (!finished) {
             final long time1 = System.nanoTime();
-            runs.incrementAndGet();
+            if (runs.incrementAndGet() > maxRuns) {
+                throw new DependencyCollectionException(
+                        new CollectResult(request),
+                        "Too many collection attempts (bug of used DependencyCollectionChecker?)");
+            }
 
             RepositorySystemSession session = dependencyCollectionChecker.prepare(setUpSession, request);
             final DependencyTraverser depTraverser = session.getDependencyTraverser();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryException;
@@ -33,6 +34,7 @@ import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyTraverser;
@@ -121,153 +123,168 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
 
     @SuppressWarnings("checkstyle:methodlength")
     @Override
-    public final CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)
+    public final CollectResult collectDependencies(
+            final RepositorySystemSession originalSession, final CollectRequest request)
             throws DependencyCollectionException {
-        requireNonNull(session, "session cannot be null");
+        requireNonNull(originalSession, "session cannot be null");
         requireNonNull(request, "request cannot be null");
 
-        InternalScopeManager scopeManager = (InternalScopeManager) session.getScopeManager();
-        session = setUpSession(session, request, scopeManager);
+        final InternalScopeManager scopeManager = (InternalScopeManager) originalSession.getScopeManager();
+        final RepositorySystemSession setUpSession = setUpSession(originalSession, request, scopeManager);
+        final DependencyCollectionChecker dependencyCollectionChecker =
+                originalSession.getDependencyCollectionChecker();
 
-        RequestTrace trace = RequestTrace.newChild(request.getTrace(), request);
+        final RequestTrace trace = RequestTrace.newChild(request.getTrace(), request);
 
-        CollectResult result = new CollectResult(request);
+        final Map<String, Object> stats = new LinkedHashMap<>();
+        final AtomicInteger runs = new AtomicInteger(0);
 
-        DependencyTraverser depTraverser = session.getDependencyTraverser();
-        VersionFilter verFilter = session.getVersionFilter();
+        CollectResult result = null;
 
-        Dependency root = request.getRoot();
-        List<RemoteRepository> repositories = request.getRepositories();
-        List<Dependency> dependencies = request.getDependencies();
-        List<Dependency> managedDependencies = request.getManagedDependencies();
+        boolean finished = false;
+        while (!finished) {
+            final long time1 = System.nanoTime();
+            runs.incrementAndGet();
 
-        Map<String, Object> stats = new LinkedHashMap<>();
-        long time1 = System.nanoTime();
+            RepositorySystemSession session = dependencyCollectionChecker.prepare(setUpSession, request);
+            final DependencyTraverser depTraverser = session.getDependencyTraverser();
+            final VersionFilter verFilter = session.getVersionFilter();
 
-        DefaultDependencyNode node;
-        if (root != null) {
-            List<? extends Version> versions;
-            VersionRangeResult rangeResult;
-            try {
-                VersionRangeRequest rangeRequest = new VersionRangeRequest(
-                        root.getArtifact(), request.getRepositories(), request.getRequestContext());
-                rangeRequest.setTrace(trace);
-                rangeResult = versionRangeResolver.resolveVersionRange(session, rangeRequest);
-                versions = filterVersions(root, rangeResult, verFilter, new DefaultVersionFilterContext(session));
-            } catch (VersionRangeResolutionException e) {
-                result.addException(e);
-                throw new DependencyCollectionException(result, e.getMessage());
-            }
+            Dependency root = request.getRoot();
+            List<RemoteRepository> repositories = request.getRepositories();
+            List<Dependency> dependencies = request.getDependencies();
+            List<Dependency> managedDependencies = request.getManagedDependencies();
 
-            Version version = versions.get(versions.size() - 1);
-            root = root.setArtifact(root.getArtifact().setVersion(version.toString()));
-
-            ArtifactDescriptorResult descriptorResult;
-            try {
-                ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();
-                descriptorRequest.setArtifact(root.getArtifact());
-                descriptorRequest.setRepositories(request.getRepositories());
-                descriptorRequest.setRequestContext(request.getRequestContext());
-                descriptorRequest.setTrace(trace);
-                if (isLackingDescriptor(session, root.getArtifact())) {
-                    descriptorResult = new ArtifactDescriptorResult(descriptorRequest);
-                } else {
-                    descriptorResult = descriptorReader.readArtifactDescriptor(session, descriptorRequest);
-                    for (ArtifactDecorator decorator :
-                            Utils.getArtifactDecorators(session, artifactDecoratorFactories)) {
-                        descriptorResult.setArtifact(decorator.decorateArtifact(descriptorResult));
-                    }
+            result = new CollectResult(request);
+            DefaultDependencyNode node;
+            if (root != null) {
+                List<? extends Version> versions;
+                VersionRangeResult rangeResult;
+                try {
+                    VersionRangeRequest rangeRequest = new VersionRangeRequest(
+                            root.getArtifact(), request.getRepositories(), request.getRequestContext());
+                    rangeRequest.setTrace(trace);
+                    rangeResult = versionRangeResolver.resolveVersionRange(session, rangeRequest);
+                    versions = filterVersions(root, rangeResult, verFilter, new DefaultVersionFilterContext(session));
+                } catch (VersionRangeResolutionException e) {
+                    result.addException(e);
+                    throw new DependencyCollectionException(result, e.getMessage());
                 }
-            } catch (ArtifactDescriptorException e) {
-                result.addException(e);
-                throw new DependencyCollectionException(result, e.getMessage());
+
+                Version version = versions.get(versions.size() - 1);
+                root = root.setArtifact(root.getArtifact().setVersion(version.toString()));
+
+                ArtifactDescriptorResult descriptorResult;
+                try {
+                    ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();
+                    descriptorRequest.setArtifact(root.getArtifact());
+                    descriptorRequest.setRepositories(request.getRepositories());
+                    descriptorRequest.setRequestContext(request.getRequestContext());
+                    descriptorRequest.setTrace(trace);
+                    if (isLackingDescriptor(session, root.getArtifact())) {
+                        descriptorResult = new ArtifactDescriptorResult(descriptorRequest);
+                    } else {
+                        descriptorResult = descriptorReader.readArtifactDescriptor(session, descriptorRequest);
+                        for (ArtifactDecorator decorator :
+                                Utils.getArtifactDecorators(session, artifactDecoratorFactories)) {
+                            descriptorResult.setArtifact(decorator.decorateArtifact(descriptorResult));
+                        }
+                    }
+                } catch (ArtifactDescriptorException e) {
+                    result.addException(e);
+                    throw new DependencyCollectionException(result, e.getMessage());
+                }
+
+                root = root.setArtifact(descriptorResult.getArtifact());
+
+                if (!session.isIgnoreArtifactDescriptorRepositories()) {
+                    repositories = remoteRepositoryManager.aggregateRepositories(
+                            session, repositories, descriptorResult.getRepositories(), true);
+                }
+                dependencies = mergeDeps(dependencies, descriptorResult.getDependencies());
+                managedDependencies = mergeDeps(managedDependencies, descriptorResult.getManagedDependencies());
+
+                node = new DefaultDependencyNode(root);
+                node.setRequestContext(request.getRequestContext());
+                node.setRelocations(descriptorResult.getRelocations());
+                node.setVersionConstraint(rangeResult.getVersionConstraint());
+                node.setVersion(version);
+                node.setAliases(descriptorResult.getAliases());
+                node.setRepositories(request.getRepositories());
+            } else {
+                node = new DefaultDependencyNode(request.getRootArtifact());
+                node.setRequestContext(request.getRequestContext());
+                node.setRepositories(request.getRepositories());
             }
 
-            root = root.setArtifact(descriptorResult.getArtifact());
+            result.setRoot(node);
 
-            if (!session.isIgnoreArtifactDescriptorRepositories()) {
-                repositories = remoteRepositoryManager.aggregateRepositories(
-                        session, repositories, descriptorResult.getRepositories(), true);
+            boolean traverse = root == null || depTraverser == null || depTraverser.traverseDependency(root);
+            String errorPath = null;
+            if (traverse && !dependencies.isEmpty()) {
+                DataPool pool = new DataPool(session);
+
+                DefaultDependencyCollectionContext context = new DefaultDependencyCollectionContext(
+                        session, request.getRootArtifact(), root, managedDependencies);
+
+                DefaultVersionFilterContext versionContext = new DefaultVersionFilterContext(session);
+
+                Results results = new Results(result, session);
+
+                doCollectDependencies(
+                        session,
+                        trace,
+                        pool,
+                        context,
+                        versionContext,
+                        request,
+                        node,
+                        repositories,
+                        dependencies,
+                        managedDependencies,
+                        results);
+
+                errorPath = results.getErrorPath();
             }
-            dependencies = mergeDeps(dependencies, descriptorResult.getDependencies());
-            managedDependencies = mergeDeps(managedDependencies, descriptorResult.getManagedDependencies());
 
-            node = new DefaultDependencyNode(root);
-            node.setRequestContext(request.getRequestContext());
-            node.setRelocations(descriptorResult.getRelocations());
-            node.setVersionConstraint(rangeResult.getVersionConstraint());
-            node.setVersion(version);
-            node.setAliases(descriptorResult.getAliases());
-            node.setRepositories(request.getRepositories());
-        } else {
-            node = new DefaultDependencyNode(request.getRootArtifact());
-            node.setRequestContext(request.getRequestContext());
-            node.setRepositories(request.getRepositories());
-        }
+            final long time2 = System.nanoTime();
 
-        result.setRoot(node);
-
-        boolean traverse = root == null || depTraverser == null || depTraverser.traverseDependency(root);
-        String errorPath = null;
-        if (traverse && !dependencies.isEmpty()) {
-            DataPool pool = new DataPool(session);
-
-            DefaultDependencyCollectionContext context = new DefaultDependencyCollectionContext(
-                    session, request.getRootArtifact(), root, managedDependencies);
-
-            DefaultVersionFilterContext versionContext = new DefaultVersionFilterContext(session);
-
-            Results results = new Results(result, session);
-
-            doCollectDependencies(
-                    session,
-                    trace,
-                    pool,
-                    context,
-                    versionContext,
-                    request,
-                    node,
-                    repositories,
-                    dependencies,
-                    managedDependencies,
-                    results);
-
-            errorPath = results.getErrorPath();
-        }
-
-        long time2 = System.nanoTime();
-
-        DependencyGraphTransformer transformer = session.getDependencyGraphTransformer();
-        if (transformer != null) {
-            try {
-                DefaultDependencyGraphTransformationContext context =
-                        new DefaultDependencyGraphTransformationContext(session);
-                context.put(TransformationContextKeys.STATS, stats);
-                result.setRoot(transformer.transformGraph(node, context));
-            } catch (RepositoryException e) {
-                result.addException(e);
+            DependencyGraphTransformer transformer = session.getDependencyGraphTransformer();
+            if (transformer != null) {
+                try {
+                    DefaultDependencyGraphTransformationContext context =
+                            new DefaultDependencyGraphTransformationContext(session);
+                    context.put(TransformationContextKeys.STATS, stats);
+                    result.setRoot(transformer.transformGraph(node, context));
+                } catch (RepositoryException e) {
+                    result.addException(e);
+                }
             }
-        }
 
-        long time3 = System.nanoTime();
-        if (logger.isDebugEnabled()) {
+            if (errorPath != null) {
+                throw new DependencyCollectionException(result, "Failed to collect dependencies at " + errorPath);
+            }
+            if (!result.getExceptions().isEmpty()) {
+                throw new DependencyCollectionException(result);
+            }
+
+            if (request.getResolutionScope() != null) {
+                result = scopeManager.postProcess(session, request.getResolutionScope(), result);
+            }
+
+            long time3 = System.nanoTime();
             stats.put(getClass().getSimpleName() + ".collectTime", time2 - time1);
             stats.put(getClass().getSimpleName() + ".transformTime", time3 - time2);
+
+            finished = dependencyCollectionChecker.isSatisfactory(session, request, result);
+        }
+
+        stats.put(getClass().getSimpleName() + ".runs", runs.get());
+        if (logger.isDebugEnabled()) {
             logger.debug("Dependency collection stats {}", stats);
         }
 
-        if (errorPath != null) {
-            throw new DependencyCollectionException(result, "Failed to collect dependencies at " + errorPath);
-        }
-        if (!result.getExceptions().isEmpty()) {
-            throw new DependencyCollectionException(result);
-        }
-
-        if (request.getResolutionScope() != null) {
-            return scopeManager.postProcess(session, request.getResolutionScope(), result);
-        } else {
-            return result;
-        }
+        return result;
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
@@ -19,10 +19,12 @@
 package org.eclipse.aether.internal.impl.scope;
 
 import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,6 +37,9 @@ import static java.util.Objects.requireNonNull;
  * @see Dependency#isOptional()
  */
 public final class OptionalDependencySelector implements DependencySelector {
+    public static final String IGNORED_KEYS = OptionalDependencySelector.class.getName() + ".ignored";
+    public static final String UNSELECTED_KEYS = OptionalDependencySelector.class.getName() + ".unselected";
+
     /**
      * Excludes optional dependencies always (from root).
      */
@@ -56,29 +61,53 @@ public final class OptionalDependencySelector implements DependencySelector {
         if (applyFrom < 1) {
             throw new IllegalArgumentException("applyFrom must be non-zero and positive");
         }
-        return new OptionalDependencySelector(Objects.hash(applyFrom), 0, applyFrom);
+        return new OptionalDependencySelector(Objects.hash(applyFrom), 0, applyFrom, null, null);
     }
 
     private final int seed;
     private final int depth;
     private final int applyFrom;
+    private final Set<String> ignoredKeys;
+    private final Set<String> unselectedKeys;
 
-    private OptionalDependencySelector(int seed, int depth, int applyFrom) {
+    private OptionalDependencySelector(
+            int seed, int depth, int applyFrom, Set<String> ignoredKeys, Set<String> unselectedKeys) {
         this.seed = seed;
         this.depth = depth;
         this.applyFrom = applyFrom;
+        this.ignoredKeys = ignoredKeys; // nullable
+        this.unselectedKeys = unselectedKeys; // nullable
     }
 
     @Override
     public boolean selectDependency(Dependency dependency) {
         requireNonNull(dependency, "dependency cannot be null");
-        return depth < applyFrom || !dependency.isOptional();
+        String key = null;
+        if (ignoredKeys != null || unselectedKeys != null) {
+            key = ArtifactIdUtils.toId(dependency.getArtifact());
+        }
+        if (ignoredKeys != null) {
+            if (ignoredKeys.contains(key)) {
+                return true;
+            }
+        }
+        boolean result = depth < applyFrom || !dependency.isOptional();
+        if (!result && unselectedKeys != null) {
+            unselectedKeys.add(key);
+        }
+        return result;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
         requireNonNull(context, "context cannot be null");
-        return new OptionalDependencySelector(seed, depth + 1, applyFrom);
+        return new OptionalDependencySelector(
+                seed,
+                depth + 1,
+                applyFrom,
+                (Set<String>) context.getSession().getData().get(IGNORED_KEYS),
+                (Set<String>) context.getSession().getData().get(UNSELECTED_KEYS));
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.aether.internal.impl.scope;
 
+import java.util.Collection;
 import java.util.Objects;
-import java.util.Set;
 
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
@@ -67,11 +67,11 @@ public final class OptionalDependencySelector implements DependencySelector {
     private final int seed;
     private final int depth;
     private final int applyFrom;
-    private final Set<String> ignoredKeys;
-    private final Set<String> unselectedKeys;
+    private final Collection<String> ignoredKeys;
+    private final Collection<String> unselectedKeys;
 
     private OptionalDependencySelector(
-            int seed, int depth, int applyFrom, Set<String> ignoredKeys, Set<String> unselectedKeys) {
+            int seed, int depth, int applyFrom, Collection<String> ignoredKeys, Collection<String> unselectedKeys) {
         this.seed = seed;
         this.depth = depth;
         this.applyFrom = applyFrom;
@@ -106,8 +106,8 @@ public final class OptionalDependencySelector implements DependencySelector {
                 seed,
                 depth + 1,
                 applyFrom,
-                (Set<String>) context.getSession().getData().get(IGNORED_KEYS),
-                (Set<String>) context.getSession().getData().get(UNSELECTED_KEYS));
+                (Collection<String>) context.getSession().getData().get(IGNORED_KEYS),
+                (Collection<String>) context.getSession().getData().get(UNSELECTED_KEYS));
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultCloseableSession.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultCloseableSession.java
@@ -31,6 +31,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.SessionData;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -113,6 +114,8 @@ public final class DefaultCloseableSession implements CloseableSession {
 
     private final ScopeManager scopeManager;
 
+    private final DependencyCollectionChecker dependencyCollectionChecker;
+
     private final RepositorySystem repositorySystem;
 
     private final RepositorySystemLifecycle repositorySystemLifecycle;
@@ -147,6 +150,7 @@ public final class DefaultCloseableSession implements CloseableSession {
             SessionData data,
             RepositoryCache cache,
             ScopeManager scopeManager,
+            DependencyCollectionChecker dependencyCollectionChecker,
             List<Runnable> onSessionEndedHandlers,
             RepositorySystem repositorySystem,
             RepositorySystemLifecycle repositorySystemLifecycle) {
@@ -177,6 +181,7 @@ public final class DefaultCloseableSession implements CloseableSession {
         this.data = requireNonNull(data);
         this.cache = cache;
         this.scopeManager = scopeManager;
+        this.dependencyCollectionChecker = requireNonNull(dependencyCollectionChecker);
 
         this.repositorySystem = requireNonNull(repositorySystem);
         this.repositorySystemLifecycle = requireNonNull(repositorySystemLifecycle);
@@ -341,6 +346,11 @@ public final class DefaultCloseableSession implements CloseableSession {
     @Override
     public ScopeManager getScopeManager() {
         return scopeManager;
+    }
+
+    @Override
+    public DependencyCollectionChecker getDependencyCollectionChecker() {
+        return dependencyCollectionChecker;
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultCloseableSession.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultCloseableSession.java
@@ -181,7 +181,7 @@ public final class DefaultCloseableSession implements CloseableSession {
         this.data = requireNonNull(data);
         this.cache = cache;
         this.scopeManager = scopeManager;
-        this.dependencyCollectionChecker = requireNonNull(dependencyCollectionChecker);
+        this.dependencyCollectionChecker = dependencyCollectionChecker;
 
         this.repositorySystem = requireNonNull(repositorySystem);
         this.repositorySystemLifecycle = requireNonNull(repositorySystemLifecycle);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultSessionBuilder.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultSessionBuilder.java
@@ -35,6 +35,7 @@ import org.eclipse.aether.RepositorySystemSession.CloseableSession;
 import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
 import org.eclipse.aether.SessionData;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.DependencyCollectionChecker;
 import org.eclipse.aether.collection.DependencyGraphTransformer;
 import org.eclipse.aether.collection.DependencyManager;
 import org.eclipse.aether.collection.DependencySelector;
@@ -132,6 +133,8 @@ public final class DefaultSessionBuilder implements SessionBuilder {
     private Supplier<RepositoryCache> repositoryCacheSupplier = DEFAULT_REPOSITORY_CACHE_SUPPLIER;
 
     private ScopeManager scopeManager;
+
+    private DependencyCollectionChecker dependencyCollectionChecker = DependencyCollectionChecker.NOOP;
 
     private final ArrayList<Runnable> onSessionCloseHandlers = new ArrayList<>();
 
@@ -364,6 +367,13 @@ public final class DefaultSessionBuilder implements SessionBuilder {
     }
 
     @Override
+    public SessionBuilder setDependencyCollectionChecker(DependencyCollectionChecker dependencyCollectionChecker) {
+        requireNonNull(dependencyCollectionChecker, "null dependencyCollectionChecker");
+        this.dependencyCollectionChecker = dependencyCollectionChecker;
+        return null;
+    }
+
+    @Override
     public SessionBuilder addOnSessionEndedHandler(Runnable handler) {
         requireNonNull(handler, "null handler");
         onSessionCloseHandlers.add(handler);
@@ -485,6 +495,7 @@ public final class DefaultSessionBuilder implements SessionBuilder {
                 sessionDataSupplier.get(),
                 repositoryCacheSupplier.get(),
                 scopeManager,
+                dependencyCollectionChecker,
                 onSessionCloseHandlers,
                 repositorySystem,
                 repositorySystemLifecycle);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultSessionBuilder.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/session/DefaultSessionBuilder.java
@@ -134,7 +134,7 @@ public final class DefaultSessionBuilder implements SessionBuilder {
 
     private ScopeManager scopeManager;
 
-    private DependencyCollectionChecker dependencyCollectionChecker = DependencyCollectionChecker.NOOP;
+    private DependencyCollectionChecker dependencyCollectionChecker;
 
     private final ArrayList<Runnable> onSessionCloseHandlers = new ArrayList<>();
 
@@ -368,7 +368,6 @@ public final class DefaultSessionBuilder implements SessionBuilder {
 
     @Override
     public SessionBuilder setDependencyCollectionChecker(DependencyCollectionChecker dependencyCollectionChecker) {
-        requireNonNull(dependencyCollectionChecker, "null dependencyCollectionChecker");
         this.dependencyCollectionChecker = dependencyCollectionChecker;
         return null;
     }


### PR DESCRIPTION
Introduce DependencyCollectionChecker, that is able to augment and re-collect the graph. By default, there is only NOOP implementation and this PR causes no change in Resolver behaviour, but this leaves ability to Resolver integrator to use this feature.

Also, prepare OptionDependencySelector to be parameterized (by default is not) to be able to ignore or collect optional/excluded artifacts.

Note: DependencyCollectorDelegate may be best seen without whitespace, change is only about putting existing logic into loop w/ some cleanup.
