### PR TITLE
Disable IPC lock tests on Windows

### DIFF
--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterIT.java
@@ -19,7 +19,10 @@
 package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.WINDOWS)
 public class IpcAdapterIT extends NamedLockFactoryAdapterTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterNoForkIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterNoForkIT.java
@@ -20,7 +20,10 @@ package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.WINDOWS)
 public class IpcAdapterNoForkIT extends NamedLockFactoryAdapterTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockFactoryIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockFactoryIT.java
@@ -19,7 +19,10 @@
 package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@DisabledOnOs(OS.WINDOWS)
 public class IpcNamedLockFactoryIT extends NamedLockFactoryTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {


### PR DESCRIPTION
The are unstable and flakey and just cause noise. Am unsure how much are they used on Windows anyway. Until someone on Windows fixes them, they are disabled.
