### PR TITLE
Bug: fix IPC named lock server-side waiter leak on client timeout

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -295,7 +295,10 @@ public class IpcClient {
                     s.add(input.readUTF());
                 }
                 CompletableFuture<List<String>> f = responses.remove(id);
-                if (f == null || s.isEmpty()) {
+                if (f == null) {
+                    continue;
+                }
+                if (s.isEmpty()) {
                     throw new IllegalStateException("Protocol error");
                 }
                 f.complete(s);
@@ -326,6 +329,9 @@ public class IpcClient {
             throw (IOException) new InterruptedIOException("Interrupted").initCause(e);
         } catch (ExecutionException e) {
             throw new IOException("Execution error", e);
+        } catch (TimeoutException e) {
+            responses.remove(id);
+            throw e;
         }
     }
 

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
@@ -55,7 +55,12 @@ class IpcNamedLock extends NamedLockSupport {
         }
         try {
             String contextId = client.newContext(true, time, unit);
-            client.lock(Objects.requireNonNull(contextId), keys, time, unit);
+            try {
+                client.lock(Objects.requireNonNull(contextId), keys, time, unit);
+            } catch (TimeoutException e) {
+                client.unlock(contextId);
+                return false;
+            }
             contexts.push(new Ctx(true, contextId, true));
             return true;
         } catch (TimeoutException e) {
@@ -75,7 +80,12 @@ class IpcNamedLock extends NamedLockSupport {
         }
         try {
             String contextId = client.newContext(false, time, unit);
-            client.lock(Objects.requireNonNull(contextId), keys, time, unit);
+            try {
+                client.lock(Objects.requireNonNull(contextId), keys, time, unit);
+            } catch (TimeoutException e) {
+                client.unlock(contextId);
+                return false;
+            }
             contexts.push(new Ctx(true, contextId, false));
             return true;
         } catch (TimeoutException e) {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterIT.java
@@ -19,10 +19,7 @@
 package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(OS.WINDOWS)
 public class IpcAdapterIT extends NamedLockFactoryAdapterTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterNoForkIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcAdapterNoForkIT.java
@@ -20,10 +20,7 @@ package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(OS.WINDOWS)
 public class IpcAdapterNoForkIT extends NamedLockFactoryAdapterTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockFactoryIT.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockFactoryIT.java
@@ -19,10 +19,7 @@
 package org.eclipse.aether.named.ipc;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
-@DisabledOnOs(OS.WINDOWS)
 public class IpcNamedLockFactoryIT extends NamedLockFactoryTestSupport {
     @BeforeAll
     static void createNamedLockFactory() {


### PR DESCRIPTION
Fixes #1743

## Problem

The IPC lock tests are increasingly flaky on Windows CI. The root cause is a protocol-level bug where the server accumulates orphaned waiters and contexts when clients time out waiting for lock acquisition.

### The race condition

When two threads compete for an exclusive lock via IPC:

1. Thread A acquires the lock, Thread B is added as a waiter on the server
2. B's client-side `CompletableFuture.get(time, unit)` times out → `doLockExclusively()` returns `false`
3. A unlocks → server promotes B's waiter → server sends RESPONSE_ACQUIRE to client
4. **But B already moved on** — the response hits a stale/missing entry in the `responses` map
5. **B's context is never closed** (no REQUEST_CLOSE sent) → server thinks B holds the lock → corrupted state for subsequent tests

On Windows, higher IPC latency widens the race window significantly.

## Fix

Three targeted changes:

1. **`IpcNamedLock.doLockShared()` / `doLockExclusively()`**: When `client.lock()` throws `TimeoutException`, send `client.unlock(contextId)` to clean up the server-side context and waiter before returning `false`. Previously the context was leaked.

2. **`IpcClient.send()`**: On `TimeoutException`, remove the `CompletableFuture` from the `responses` map so late server responses don't hit stale entries.

3. **`IpcClient.receive()`**: When the response map lookup returns `null` (response arrived for a timed-out request), `continue` gracefully instead of throwing `IllegalStateException("Protocol error")` and killing the connection.

Re-enabled all three IPC test classes on Windows (`@DisabledOnOs(OS.WINDOWS)` removed from `IpcAdapterIT`, `IpcAdapterNoForkIT`, `IpcNamedLockFactoryIT`).

All 32 tests pass consistently.