### PR TITLE
Bugfix: Fix NPE in PathConflictResolver

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -51,7 +51,7 @@ public class ResolveTransitiveDependencies {
                 CloseableSession session = Booter.newRepositorySystemSession(system, Booter.selectFs(args))
                         .build()) {
             // An "interesting" artifact that depends on itself (different version). All Maven versions
-            // released so far contained dom4j:dom4j:1.5.2 on classpath for dom4j:dom4j:1.5.2.
+            // released so far contained dom4j:dom4j:1.5.2 on classpath for dom4j:dom4j:1.6.1
             // In Resolver 2.0.19 this is fixed.
             Artifact artifact = new DefaultArtifact("dom4j:dom4j:1.6.1");
 

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -50,6 +50,7 @@ public class ResolveTransitiveDependencies {
         try (RepositorySystem system = Booter.newRepositorySystem(Booter.selectFactory(args));
                 CloseableSession session = Booter.newRepositorySystemSession(system, Booter.selectFs(args))
                         .build()) {
+            // Artifact artifact = new DefaultArtifact("dom4j:dom4j:1.6.1");
             Artifact artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-impl:1.3.3");
 
             DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -52,7 +52,7 @@ public class ResolveTransitiveDependencies {
                         .build()) {
             // An "interesting" artifact that depends on itself (different version). All Maven versions
             // released so far contained dom4j:dom4j:1.5.2 on classpath for dom4j:dom4j:1.6.1
-            // In Resolver 2.0.19 this is fixed.
+            // In Resolver 2.0.19+ this is fixed.
             Artifact artifact = new DefaultArtifact("dom4j:dom4j:1.6.1");
 
             DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);

--- a/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
+++ b/maven-resolver-demos/maven-resolver-demo-snippets/src/main/java/org/apache/maven/resolver/examples/ResolveTransitiveDependencies.java
@@ -50,8 +50,10 @@ public class ResolveTransitiveDependencies {
         try (RepositorySystem system = Booter.newRepositorySystem(Booter.selectFactory(args));
                 CloseableSession session = Booter.newRepositorySystemSession(system, Booter.selectFs(args))
                         .build()) {
-            // Artifact artifact = new DefaultArtifact("dom4j:dom4j:1.6.1");
-            Artifact artifact = new DefaultArtifact("org.apache.maven.resolver:maven-resolver-impl:1.3.3");
+            // An "interesting" artifact that depends on itself (different version). All Maven versions
+            // released so far contained dom4j:dom4j:1.5.2 on classpath for dom4j:dom4j:1.5.2.
+            // In Resolver 2.0.19 this is fixed.
+            Artifact artifact = new DefaultArtifact("dom4j:dom4j:1.6.1");
 
             DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
@@ -614,9 +614,9 @@ public final class PathConflictResolver extends ConflictResolver {
         /**
          * Adds node children: this method should be "batch" used, as all (potential) children should be added at once.
          * Method will return really added ones, as this class avoids cycles. Those forming a cycle are added to {@link Path}
-         * structure but are bot recursed, keeping {@link Path} cycle free.
+         * structure but are not recursed (returned in list), keeping {@link Path} cycle free.
          * This method also maintains "conflictIdPath", that is a list of "conflict partition IDs" leading from root
-         * toward given instance. This implies that this conflict resolver, by its nature "recalculates" the
+         * toward given instance. This implies that this conflict resolver, by its nature "redoes" the
          * {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} calculated by {@link ConflictIdSorter}.
          */
         private List<Path> addChildren(List<DependencyNode> children) throws RepositoryException {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
@@ -624,10 +624,11 @@ public final class PathConflictResolver extends ConflictResolver {
 
         /**
          * Adds node children: this method should be "batch" used, as all (potential) children should be added at once.
-         * Method will return really added ones, as this class avoids cycles. Those forming a cycle are added to {@link Path}
-         * structure but are not recursed (returned in list), keeping {@link Path} cycle free.
-         * This method also maintains "conflictIdPath", that is a list of "conflict partition IDs" leading from root
-         * toward given instance. This implies that this conflict resolver, by its nature "redoes" the
+         * Method will return really added {@link Path} instances, as this class avoids cycles. Those forming a cycle
+         * are added to {@link Path} structure but are not recursed (not returned in list), keeping {@link Path} cycle
+         * free. This method also maintains "conflictIdsSinceRoot", that is a set of "conflict IDs" that were touched
+         * while going from tree root to current node instance.
+         * This implies that this conflict resolver, by its nature "redoes" the
          * {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} calculated by {@link ConflictIdSorter}.
          */
         private List<Path> addChildren(List<DependencyNode> children) throws RepositoryException {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
@@ -22,9 +22,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.aether.ConfigurationProperties;
@@ -320,7 +322,12 @@ public final class PathConflictResolver extends ConflictResolver {
          */
         private Path build(DependencyNode node) throws RepositoryException {
             String nodeConflictId = this.conflictIds.get(node);
-            Path root = new Path(this, node, nodeConflictId, Collections.singletonList(nodeConflictId), null);
+            Path root = new Path(
+                    this,
+                    node,
+                    nodeConflictId,
+                    nodeConflictId != null ? Collections.singleton(nodeConflictId) : Collections.emptySet(),
+                    null);
             gatherCRNodes(root);
             return root;
         }
@@ -374,7 +381,11 @@ public final class PathConflictResolver extends ConflictResolver {
         private DependencyNode dn;
         private final String conflictId;
         private final Path parent;
-        private final List<String> conflictIdPath;
+        // Set of conflictIds that we "stepped over" from root to here; is a set, and if duplicate element addition is
+        // attempted, it signals we deal with a cycle, as we are about to enter into same tree partition (nodes with
+        // same conflictId) we already have been. This could be a list, but for our purposes "duplication detection"
+        // (loop) is perfectly enough.
+        private final Set<String> conflictIdsSinceRoot;
         // derived
         private final int depth;
         private final List<Path> children;
@@ -382,12 +393,12 @@ public final class PathConflictResolver extends ConflictResolver {
         private String scope;
         private boolean optional;
 
-        private Path(State state, DependencyNode dn, String conflictId, List<String> conflictIdPath, Path parent) {
+        private Path(State state, DependencyNode dn, String conflictId, Set<String> conflictIdsSinceRoot, Path parent) {
             this.state = state;
             this.dn = dn;
             this.conflictId = conflictId;
             this.parent = parent;
-            this.conflictIdPath = conflictIdPath;
+            this.conflictIdsSinceRoot = conflictIdsSinceRoot;
             this.depth = parent != null ? parent.depth + 1 : 0;
             this.children = new ArrayList<>();
             pull(0);
@@ -623,10 +634,9 @@ public final class PathConflictResolver extends ConflictResolver {
             ArrayList<Path> added = new ArrayList<>(children.size());
             for (DependencyNode child : children) {
                 String childConflictId = this.state.conflictIds.get(child);
-                List<String> newPath = new ArrayList<>(this.conflictIdPath);
-                boolean cycle = newPath.contains(childConflictId);
-                newPath.add(childConflictId);
-                Path c = new Path(this.state, child, childConflictId, newPath, this);
+                Set<String> conflictIdsSinceRoot = new HashSet<>(this.conflictIdsSinceRoot);
+                boolean cycle = !conflictIdsSinceRoot.add(childConflictId);
+                Path c = new Path(this.state, child, childConflictId, conflictIdsSinceRoot, this);
                 this.children.add(c);
                 c.derive(0, false);
                 if (!cycle) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/graph/transformer/PathConflictResolver.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -152,25 +151,10 @@ public final class PathConflictResolver extends ConflictResolver {
         Map<String, Object> stats = (Map<String, Object>) context.get(TransformationContextKeys.STATS);
         long time1 = System.nanoTime();
 
-        @SuppressWarnings("unchecked")
-        Collection<Collection<String>> conflictIdCycles =
-                (Collection<Collection<String>>) context.get(TransformationContextKeys.CYCLIC_CONFLICT_IDS);
-        if (conflictIdCycles == null) {
-            throw new RepositoryException("conflict id cycles have not been identified");
-        }
-
         Map<DependencyNode, String> conflictIds =
                 (Map<DependencyNode, String>) context.get(TransformationContextKeys.CONFLICT_IDS);
         if (conflictIds == null) {
             throw new RepositoryException("conflict groups have not been identified");
-        }
-
-        Map<String, Collection<String>> cyclicPredecessors = new HashMap<>();
-        for (Collection<String> cycle : conflictIdCycles) {
-            for (String conflictId : cycle) {
-                Collection<String> predecessors = cyclicPredecessors.computeIfAbsent(conflictId, k -> new HashSet<>());
-                predecessors.addAll(cycle);
-            }
         }
 
         State state = new State(
@@ -183,7 +167,6 @@ public final class PathConflictResolver extends ConflictResolver {
                 scopeSelector.getInstance(node, context),
                 scopeDeriver.getInstance(node, context),
                 optionalitySelector.getInstance(node, context),
-                cyclicPredecessors,
                 conflictIds,
                 node);
 
@@ -287,11 +270,6 @@ public final class PathConflictResolver extends ConflictResolver {
         private final ConflictResolver.OptionalitySelector optionalitySelector;
 
         /**
-         * The conflict predecessors by conflictId.
-         */
-        private final Map<String, Collection<String>> cyclicPredecessors;
-
-        /**
          * The node to conflictId mapping from {@link ConflictMarker}.
          */
         private final Map<DependencyNode, String> conflictIds;
@@ -320,7 +298,6 @@ public final class PathConflictResolver extends ConflictResolver {
                 ConflictResolver.ScopeSelector scopeSelector,
                 ConflictResolver.ScopeDeriver scopeDeriver,
                 ConflictResolver.OptionalitySelector optionalitySelector,
-                Map<String, Collection<String>> cyclicPredecessors,
                 Map<DependencyNode, String> conflictIds,
                 DependencyNode node)
                 throws RepositoryException {
@@ -330,7 +307,6 @@ public final class PathConflictResolver extends ConflictResolver {
             this.scopeSelector = scopeSelector;
             this.scopeDeriver = scopeDeriver;
             this.optionalitySelector = optionalitySelector;
-            this.cyclicPredecessors = cyclicPredecessors;
             this.conflictIds = conflictIds;
             this.partitions = new HashMap<>();
             this.resolvedIds = new HashMap<>();
@@ -343,7 +319,8 @@ public final class PathConflictResolver extends ConflictResolver {
          * sorted conflictIds can serve as a starting to point to walk the graph.
          */
         private Path build(DependencyNode node) throws RepositoryException {
-            Path root = new Path(this, node, null, false);
+            String nodeConflictId = this.conflictIds.get(node);
+            Path root = new Path(this, node, nodeConflictId, Collections.singletonList(nodeConflictId), null);
             gatherCRNodes(root);
             return root;
         }
@@ -392,22 +369,25 @@ public final class PathConflictResolver extends ConflictResolver {
      * and the conflict resolution algorithm can efficiently process each group independently.
      */
     private static class Path {
+        // given
         private final State state;
         private DependencyNode dn;
         private final String conflictId;
         private final Path parent;
-        private final boolean cycle;
+        private final List<String> conflictIdPath;
+        // derived
         private final int depth;
         private final List<Path> children;
+        // mutated
         private String scope;
         private boolean optional;
 
-        private Path(State state, DependencyNode dn, Path parent, boolean cycle) {
+        private Path(State state, DependencyNode dn, String conflictId, List<String> conflictIdPath, Path parent) {
             this.state = state;
             this.dn = dn;
-            this.conflictId = state.conflictIds.get(dn);
+            this.conflictId = conflictId;
             this.parent = parent;
-            this.cycle = cycle;
+            this.conflictIdPath = conflictIdPath;
             this.depth = parent != null ? parent.depth + 1 : 0;
             this.children = new ArrayList<>();
             pull(0);
@@ -633,19 +613,23 @@ public final class PathConflictResolver extends ConflictResolver {
 
         /**
          * Adds node children: this method should be "batch" used, as all (potential) children should be added at once.
-         * Method will return really added ones, as this class avoids cycles.
+         * Method will return really added ones, as this class avoids cycles. Those forming a cycle are added to {@link Path}
+         * structure but are bot recursed, keeping {@link Path} cycle free.
+         * This method also maintains "conflictIdPath", that is a list of "conflict partition IDs" leading from root
+         * toward given instance. This implies that this conflict resolver, by its nature "recalculates" the
+         * {@link TransformationContextKeys#CYCLIC_CONFLICT_IDS} calculated by {@link ConflictIdSorter}.
          */
         private List<Path> addChildren(List<DependencyNode> children) throws RepositoryException {
             ArrayList<Path> added = new ArrayList<>(children.size());
             for (DependencyNode child : children) {
-                boolean cycle = this.state
-                        .cyclicPredecessors
-                        .getOrDefault(this.state.conflictIds.get(child), Collections.emptySet())
-                        .contains(this.conflictId);
-                Path c = new Path(this.state, child, this, cycle);
+                String childConflictId = this.state.conflictIds.get(child);
+                List<String> newPath = new ArrayList<>(this.conflictIdPath);
+                boolean cycle = newPath.contains(childConflictId);
+                newPath.add(childConflictId);
+                Path c = new Path(this.state, child, childConflictId, newPath, this);
                 this.children.add(c);
                 c.derive(0, false);
-                if (c.parent != null && !c.parent.cycle) {
+                if (!cycle) {
                     added.add(c);
                 }
             }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/graph/transformer/ConflictResolverTest.java
@@ -673,6 +673,53 @@ public final class ConflictResolverTest extends AbstractConflictResolverTest {
         assertEquals(2, occurrence.get()); // st3 must be present only once in tree
     }
 
+    @ParameterizedTest
+    @MethodSource("conflictResolverSource")
+    void issue1903(ConflictResolver conflictResolver) throws RepositoryException {
+        // The "dom4j:dom4j:1.6.1" case
+        // root -> A -> B (in cycle with A via cyclicPredecessors) -> C (unique, only reachable through B)
+        //                                                         -> A' (same conflictId as A, actual cycle)
+        DependencyNode root = makeDependencyNode("some-group", "root", "1.0");
+        DependencyNode aPrim = makeDependencyNode("some-group", "a", "1.0", "compile");
+        DependencyNode aSec = makeDependencyNode("some-group", "a", "1.1", "compile");
+        DependencyNode b = makeDependencyNode("some-group", "b", "1.0", "compile");
+        DependencyNode c = makeDependencyNode("some-group", "c", "1.0", "compile");
+
+        root.setChildren(mutableList(aPrim));
+        aPrim.setChildren(mutableList(b));
+        b.setChildren(mutableList(c, aSec));
+        aSec.setChildren(mutableList(b));
+
+        System.out.println();
+        System.out.println("Input node:");
+        root.accept(new TreeDependencyVisitor(DUMPER_SOUT)); // we have a cycle, so must wrap it
+
+        DependencyNode transformedRoot = transform(conflictResolver, root);
+
+        System.out.println();
+        System.out.println("Transformed node:");
+        transformedRoot.accept(DUMPER_SOUT);
+
+        assertSame(transformedRoot, root);
+        AtomicInteger occurrence = new AtomicInteger(0);
+        root.accept(new DependencyVisitor() {
+            @Override
+            public boolean visitEnter(DependencyNode node) {
+                if (node.getArtifact() != null
+                        && node.getArtifact().getArtifactId().equals("a")) {
+                    occurrence.incrementAndGet();
+                }
+                return true;
+            }
+
+            @Override
+            public boolean visitLeave(DependencyNode node) {
+                return true;
+            }
+        });
+        assertEquals(1, occurrence.get()); // a must be present only once in tree
+    }
+
     private static DependencyNode makeDependencyNode(String groupId, String artifactId, String version) {
         return makeDependencyNode(groupId, artifactId, version, "compile");
     }


### PR DESCRIPTION
Fixes #1903 bug in `PathConflictResolver` (PCR).

Also, the fix in 5e97fd15f8dbc562c481252bc8ea1037992e6407 is wrong, and this PR redoes now all.

Problem was cycle detection. Original (2.0.18) PCR did left "uncovered" nodes, still causing cycles, that should have been removed by PCR (causing SO in client code). The commit above remedied it, but caused another issue how cycles were detected (it opted to reuse existing `CYCLIC_CONFLICT_IDS`), but was again wrong.

Then I realized: PCR by its design is "rebuilding" tree with `conflictIds` on Path instances, so it can easily spot properly when a cycle is about to happen (when a next node is partitioned into same `CONFLICT_ID` that is already contained in the path to root.

Proof: the demo code (added comment) is now working as expected, plus, Quarkus build is buildable with Maven 3.10-SNAPSHOT using Resolver with this patch.

As an interesting side-effect, this PR also fixes an issue applicable to _all released maven versions so far_:
https://gist.github.com/cstamas/e24577162083f1e100d78a3e5d398cd3

As the demo now produces "proper" tree as:
```
dom4j:dom4j:jar:1.6.1 [compile]
+- jaxme:jaxme-api:jar:0.3 [compile, optional]
+- jaxen:jaxen:jar:1.1-beta-6 [compile, optional]
|  +- jdom:jdom:jar:1.0 [compile, optional]
|  +- xerces:xmlParserAPIs:jar:2.6.2 [compile, optional]
|  +- xerces:xercesImpl:jar:2.6.2 [compile, optional]
|  \- xom:xom:jar:1.0b3 [compile, optional]
|     +- com.ibm.icu:icu4j:jar:2.6.1 [compile, optional]
|     +- xalan:xalan:jar:2.6.0 [compile, optional]
|     \- org.ccil.cowan.tagsoup:tagsoup:jar:0.9.7 [compile, optional]
+- msv:xsdlib:jar:20030807 [compile, optional]
+- msv:relaxngDatatype:jar:20030807 [compile, optional]
+- pull-parser:pull-parser:jar:2 [compile, optional]
+- xpp3:xpp3:jar:1.1.3.3 [compile, optional]
+- stax:stax-api:jar:1.0 [compile, optional]
\- xml-apis:xml-apis:jar:1.0.b2 [compile]
```

The duplicate `dom4j:dom4j:jar:1.5.2` is gone from the tree (but is present in Maven 3.9, Maven 3.8 and all other versions).