### PR TITLE
Extend AuthenticationBuilder to support SSLContext for mTLS authentication

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/AuthenticationBuilder.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/AuthenticationBuilder.java
@@ -155,6 +155,8 @@ public final class AuthenticationBuilder {
      *
      * @param sslContext the SSL context, may be {@code null}
      * @return this builder for chaining, never {@code null}
+     * @see AuthenticationContext#SSL_CONTEXT
+     * @since 2.0.19
      */
     public AuthenticationBuilder addSslContext(SSLContext sslContext) {
         if (sslContext != null) {

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/AuthenticationBuilder.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/repository/AuthenticationBuilder.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.util.repository;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -142,6 +143,22 @@ public final class AuthenticationBuilder {
     public AuthenticationBuilder addHostnameVerifier(HostnameVerifier verifier) {
         if (verifier != null) {
             authentications.add(new ComponentAuthentication(AuthenticationContext.SSL_HOSTNAME_VERIFIER, verifier));
+        }
+        return this;
+    }
+
+    /**
+     * Adds an SSL context for SSL/TLS connections. <strong>Note:</strong> This method assumes that all possible
+     * instances of the SSL context's runtime type exhibit the exact same behavior, i.e. the behavior of the SSL
+     * context depends solely on the runtime type and not on any configuration. For SSL contexts that do not fit
+     * this assumption, use {@link #addCustom(Authentication)} with a suitable implementation instead.
+     *
+     * @param sslContext the SSL context, may be {@code null}
+     * @return this builder for chaining, never {@code null}
+     */
+    public AuthenticationBuilder addSslContext(SSLContext sslContext) {
+        if (sslContext != null) {
+            authentications.add(new ComponentAuthentication(AuthenticationContext.SSL_CONTEXT, sslContext));
         }
         return this;
     }


### PR DESCRIPTION
### Problem

`AuthenticationBuilder` currently has no way to set an `SSLContext` for 
client certificate / mTLS based authentication.

Although HTTP transporters already consume `AuthenticationContext.SSL_CONTEXT`, 
for example in `JdkTransporter`:

```java
sslContext = repoAuthContext.get(AuthenticationContext.SSL_CONTEXT, SSLContext.class);
```

there was no way for callers to actually set it via `AuthenticationBuilder`. 
The only workaround was via system properties as described in 
https://maven.apache.org/guides/mini/guide-repository-ssl.html

Closes #1851

---

### Solution

Adds a new `addSslContext(SSLContext)` method to `AuthenticationBuilder`, 
consistent with the existing `addHostnameVerifier(HostnameVerifier)` pattern, 
so that mTLS credentials can be set and consumed through 
`AuthenticationContext.SSL_CONTEXT`.

### Usage

```java
Authentication auth = new AuthenticationBuilder()
    .addSslContext(mySSLContext)
    .build();
```

---

### Testing

- `mvn verify` passes locally — 422 tests, 0 failures, 0 errors.
- Unit test for `addSslContext()` can be added if maintainer requests it.

---

### Checklist

- [x] Pull request addresses just one issue
- [x] Description explains what, how, and why
- [x] Commit has a meaningful subject line and body
- [ ] Unit tests written
- [x] `mvn verify` passed locally
- [ ] Integration tests run
- [x] I hereby declare this contribution to be licenced under the 
      Apache License Version 2.0, January 2004