### PR TITLE
Bug: fix IPC named lock client-side robustness for Windows

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -299,12 +299,13 @@ public class IpcClient {
                     continue;
                 }
                 if (s.isEmpty()) {
-                    throw new IllegalStateException("Protocol error");
+                    f.completeExceptionally(new IOException("Protocol error: empty response"));
+                    continue;
                 }
                 f.complete(s);
             }
         } catch (EOFException e) {
-            // server is stopped; just quit
+            close(new IOException("Server disconnected", e));
         } catch (Exception e) {
             close(e);
         }
@@ -326,6 +327,7 @@ public class IpcClient {
         try {
             return response.get(time, unit);
         } catch (InterruptedException e) {
+            responses.remove(id);
             throw (IOException) new InterruptedIOException("Interrupted").initCause(e);
         } catch (ExecutionException e) {
             throw new IOException("Execution error", e);
@@ -343,6 +345,7 @@ public class IpcClient {
     }
 
     synchronized void close(Throwable e) {
+        initialized = false;
         if (socket != null) {
             try {
                 socket.close();
@@ -353,7 +356,7 @@ public class IpcClient {
             input = null;
             output = null;
         }
-        if (receiver != null) {
+        if (receiver != null && Thread.currentThread() != receiver) {
             receiver.interrupt();
             try {
                 receiver.join(1000);
@@ -404,8 +407,7 @@ public class IpcClient {
 
     void unlock(String contextId) {
         try {
-            List<String> response =
-                    send(Arrays.asList(REQUEST_CLOSE, contextId), Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            List<String> response = send(Arrays.asList(REQUEST_CLOSE, contextId), 10, TimeUnit.SECONDS);
             if (response.size() != 1 || !RESPONSE_CLOSE.equals(response.get(0))) {
                 throw new IOException("Unexpected response: " + response);
             }
@@ -420,7 +422,7 @@ public class IpcClient {
      */
     void stopServer() {
         try {
-            List<String> response = send(List.of(REQUEST_STOP), Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            List<String> response = send(List.of(REQUEST_STOP), 30, TimeUnit.SECONDS);
             if (response.size() != 1 || !RESPONSE_STOP.equals(response.get(0))) {
                 throw new IOException("Unexpected response: " + response);
             }

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -313,16 +313,20 @@ public class IpcClient {
 
     List<String> send(List<String> request, long time, TimeUnit unit) throws TimeoutException, IOException {
         ensureInitialized();
+        DataOutputStream out = output;
+        if (out == null) {
+            throw new IOException("Connection closed");
+        }
         int id = requestId.incrementAndGet();
         CompletableFuture<List<String>> response = new CompletableFuture<>();
         responses.put(id, response);
-        synchronized (output) {
-            output.writeInt(id);
-            output.writeInt(request.size());
+        synchronized (out) {
+            out.writeInt(id);
+            out.writeInt(request.size());
             for (String s : request) {
-                output.writeUTF(s);
+                out.writeUTF(s);
             }
-            output.flush();
+            out.flush();
         }
         try {
             return response.get(time, unit);

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
@@ -58,7 +58,7 @@ class IpcNamedLock extends NamedLockSupport {
             try {
                 client.lock(Objects.requireNonNull(contextId), keys, time, unit);
             } catch (TimeoutException e) {
-                client.unlock(contextId);
+                tryUnlock(contextId);
                 return false;
             }
             contexts.push(new Ctx(true, contextId, true));
@@ -83,7 +83,7 @@ class IpcNamedLock extends NamedLockSupport {
             try {
                 client.lock(Objects.requireNonNull(contextId), keys, time, unit);
             } catch (TimeoutException e) {
-                client.unlock(contextId);
+                tryUnlock(contextId);
                 return false;
             }
             contexts.push(new Ctx(true, contextId, false));
@@ -102,6 +102,16 @@ class IpcNamedLock extends NamedLockSupport {
         Ctx ctx = contexts.pop();
         if (ctx.acted) {
             client.unlock(ctx.contextId);
+        }
+    }
+
+    private void tryUnlock(String contextId) {
+        try {
+            client.unlock(contextId);
+        } catch (Exception e) {
+            // Best-effort cleanup: if unlock fails during timeout handling,
+            // we must not propagate the exception — doing so would crash the
+            // calling thread and skip latch countdowns in tests, causing hangs.
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes Windows CI flakiness in `IpcNamedLockFactoryIT.exclusiveAccess()` (seen in PR #1909, CI run 27139141318).

**Root cause**: When the loser thread's `client.lock()` times out in `doLockExclusively()`, the cleanup call `client.unlock(contextId)` could either:
- **Hang forever** — it used `Long.MAX_VALUE` timeout, so if the server/receiver had any issue, the thread blocked indefinitely
- **Throw RuntimeException** — which propagated out of `Access.run()` (which only catches `InterruptedException`), causing the thread to terminate without calling `loser.countDown()`. The winner thread then waited on `loser.await()` forever, and the test hung until Surefire killed it at 25 seconds.

## Changes

1. **`IpcNamedLock`**: Wrap cleanup unlock in `tryUnlock()` — a try-catch that swallows exceptions so the calling thread always returns `false` instead of crashing. This is the primary fix.

2. **`IpcClient.unlock()`**: Replace `Long.MAX_VALUE` timeout with 10 seconds. Normal unlock round-trips complete in microseconds; 10 seconds is generous enough while preventing infinite hangs.

3. **`IpcClient.stopServer()`**: Replace `Long.MAX_VALUE` timeout with 30 seconds.

4. **`IpcClient.receive()`**: On empty response, complete the future exceptionally instead of throwing `IllegalStateException` — the old behavior killed the receiver thread, breaking all subsequent operations on the shared client.

5. **`IpcClient.close()`**: Call `close()` on EOF so pending futures are properly cleaned up when the server disconnects, and reset the `initialized` flag to prevent stale state.

## Test plan

- [x] All 27 IPC tests pass locally (unit + integration: `IpcNamedLockFactoryIT`, `IpcAdapterNoForkIT`, `IpcAdapterIT`)
- [ ] Windows CI should no longer hang on `exclusiveAccess`