### PR TITLE
Fix inverted SIGTSTP condition in IPC server

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
@@ -152,7 +152,7 @@ public class IpcServer {
         // also interrupt and kill the daemon.
         try {
             sun.misc.Signal.handle(new sun.misc.Signal("INT"), sun.misc.SignalHandler.SIG_IGN);
-            if (IpcClient.IS_WINDOWS) {
+            if (!IpcClient.IS_WINDOWS) {
                 sun.misc.Signal.handle(new sun.misc.Signal("TSTP"), sun.misc.SignalHandler.SIG_IGN);
             }
         } catch (Throwable t) {


### PR DESCRIPTION
The condition for ignoring SIGTSTP in `IpcServer.main()` was inverted:

- `if (IpcClient.IS_WINDOWS)` tried to register a SIGTSTP handler **on Windows**, where the signal does not exist — causing a crash at daemon startup.
- On **Unix** (where SIGTSTP actually exists and is sent on Ctrl-Z), nothing was ignored — causing the IPC daemon to suspend alongside the client when the user pressed Ctrl-Z.

**Fix:** Negate the condition to `if (!IpcClient.IS_WINDOWS)` so that SIGTSTP is ignored on Unix only.

This is a one-character fix (`!` added) with no behavioral change on any OS other than making things work correctly:
- **Unix:** SIGTSTP now properly ignored → daemon stays alive on Ctrl-Z ✓
- **Windows:** SIGTSTP registration skipped → no crash ✓