### PR TITLE
WarnChecksumPolicy: proceed on no checksums

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
@@ -39,4 +39,12 @@ final class WarnChecksumPolicy extends AbstractChecksumPolicy {
                 exception);
         return true;
     }
+
+    @Override
+    public void onNoMoreChecksums() {
+        logger.warn(
+                "Could not validate integrity of download from {}{}: no checksums available",
+                resource.getRepositoryUrl(),
+                resource.getResourceName());
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/WarnChecksumPolicyTest.java
@@ -79,11 +79,6 @@ public class WarnChecksumPolicyTest {
 
     @Test
     void testOnNoMoreChecksums() {
-        try {
-            policy.onNoMoreChecksums();
-            fail("No exception");
-        } catch (ChecksumFailureException e) {
-            assertTrue(e.getMessage().contains("no checksums available"));
-        }
+        assertDoesNotThrow(policy::onNoMoreChecksums);
     }
 }


### PR DESCRIPTION
Draft / one shape for discussion — fixes the minimal manifestation of
apache/maven-resolver#1920 while leaving the larger design question open
for `dev@maven.apache.org`.

## Change

Override `AbstractChecksumPolicy.onNoMoreChecksums()` in
`WarnChecksumPolicy` so it logs a warning and returns, instead of
inheriting the unconditional `ChecksumFailureException` throw.

`FailChecksumPolicy` is unchanged: it continues to throw via the
inherited base behavior.

`WarnChecksumPolicyTest.testOnNoMoreChecksums()` updated to assert the
new behavior (no exception).

## Scope and framing

This is the smallest possible patch that addresses #1920's reported
behavior. It does **not** touch:

- the default behavior for repos without an explicit `<checksumPolicy>`
- `file://` vs HTTP transport semantics
- the broader checksum-policy-controls space being redesigned in
  #1782 / #1784 / #1917

Other shapes (transport-aware default in `DefaultChecksumPolicyProvider`,
new opt-in property like `aether.checksums.noChecksumsOutcome` analogous
to RRF's `noInputOutcome`, Maven 4 compatibility-mode flag) are
discussed separately on `dev@maven.apache.org`. **Marking as draft so
the maintainer can decide whether this minimal shape is the right one,
or whether a broader change is preferred.**

## Verification

- New `WarnChecksumPolicyTest.testOnNoMoreChecksums()` passes locally
  (JDK 21, Maven 3.9.16, `2.0.19-SNAPSHOT`).
- Full `maven-resolver-impl` test suite passes locally.

cc @cstamas
