### PR TITLE
Fix ApacheTransport auth cache CCEx

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
@@ -28,15 +28,15 @@ import static java.util.Objects.requireNonNull;
  * long as they are used by components loaded once in system. As we saw, some subsystems like transports can be
  * loaded multiple times. For example, in case of Maven, some transport may be present in Maven core, but also loaded up
  * by some extension. In this case, key should distinguish between their {@link ClassLoader}s.
- * <p/>
+ * <p>
  * It is this class caller responsibility to use proper objects as keys, this class merely helps one to create composite
- * keys our of object instances that are expected to be anyway good candidates as key. Examples of these objects are
+ * keys out of object instances that are expected to be anyway good candidates as key. Examples of these objects are
  * {@link String} instances but also {@link Class} instances, and many other types also usable as keys.
- * <p/>
+ * <p>
  * Important: never forget to perform {@code null}-check, when getting cache from {@link RepositorySystemSession#getCache()}
  * method as it may return {@code null}, when cache is disabled session-wise.
- * <p/>
- * Historical note: As mentioned above, use od {@link String} instances for keys is perfect match, and it worked from
+ * <p>
+ * Historical note: As mentioned above, use of {@link String} instances for keys is perfect match, and it worked from
  * very start. But, as use cases got more and more complex and keys used started to be constructed in more and more
  * sophisticated ways, but were still {@link String} instances. Believe, or not, the sole purpose of string keys
  * was easier debugging. By using this helper class, this convenience should remain.
@@ -53,11 +53,13 @@ public final class Keys {
     /**
      * Creates object instance usable as key in session data and cache. Objects passed to this method may or may
      * not implement equals/hashCode, but it is responsibility of caller to understand what is she or he doing.
-     * <p/>
-     * If the first instance of key elements is an object instance that was returned by this same method, creation of
-     * "subkeys" happens, where original key elements are concatenated with new ones. If the arguments contain only
-     * one argument, and it is an object instance that was returned by this same method, passed in instance is returned.
-     * <p/>
+     * <p>
+     * If the first element of key elements is an object instance that was created by this method, creation of
+     * "subkeys" happens, where original key elements expanded from first element and are concatenated with new ones.
+     * This expansion happens <em>only, if the first key element was already a key created by this class</em>.
+     * If the arguments contain only one argument, and it is an object instance that was created by this method,
+     * the passed in instance is returned unmodified.
+     * <p>
      * Based on what kind of elements are used, one can create multiple kind of keys:
      * <ul>
      *     <li>To create <em>globally matched keys</em>, preferred is to use {@link String} key elements</li>
@@ -89,7 +91,7 @@ public final class Keys {
         private final int hashCode;
 
         private Key(Object[] keys) {
-            this.keys = keys;
+            this.keys = keys.clone();
             this.hashCode = Arrays.hashCode(keys);
         }
 

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
@@ -19,58 +19,88 @@
 package org.eclipse.aether;
 
 import java.util.Arrays;
-import java.util.Collection;
 
 import static java.util.Objects.requireNonNull;
 
 /**
  * A helper class to create keys, to be used with {@link SessionData} and {@link RepositoryCache} instances as keys.
- *
- * It is this class user responsibility to use proper objects as keys, this class merely helps one to create composite
- * keys.
- *
+ * Resolver codebase started with {@link String} keys, that are generally perfect for keys in these constructs, as
+ * long as they are used by components loaded once in system. As we saw, some subsystems like transports can be
+ * loaded multiple times. For example, in case of Maven, some transport may be present in Maven core, but also loaded up
+ * by some extension. In this case, key should distinguish between their {@link ClassLoader}s.
+ * <p/>
+ * It is this class caller responsibility to use proper objects as keys, this class merely helps one to create composite
+ * keys our of object instances that are expected to be anyway good candidates as key. Examples of these objects are
+ * {@link String} instances but also {@link Class} instances, and many other types also usable as keys.
+ * <p/>
  * Important: never forget to perform {@code null}-check, when getting cache from {@link RepositorySystemSession#getCache()}
- * as it may be disabled session-wise.
+ * method as it may return {@code null}, when cache is disabled session-wise.
+ * <p/>
+ * Historical note: As mentioned above, use od {@link String} instances for keys is perfect match, and it worked from
+ * very start. But, as use cases got more and more complex and keys used started to be constructed in more and more
+ * sophisticated ways, but were still {@link String} instances. Believe, or not, the sole purpose of string keys
+ * was easier debugging. By using this helper class, this convenience should remain.
  *
  * @see RepositorySystemSession#getData()
+ * @see SessionData
  * @see RepositorySystemSession#getCache()
+ * @see RepositoryCache
  * @since 2.0.19
  */
 public final class Keys {
     private Keys() {}
 
+    /**
+     * Creates object instance usable as key in session data and cache. Objects passed to this method may or may
+     * not implement equals/hashCode, but it is responsibility of caller to understand what is she or he doing.
+     * <p/>
+     * If the first instance of key elements is an object instance that was returned by this same method, creation of
+     * "subkeys" happens, where original key elements are concatenated with new ones. If the arguments contain only
+     * one argument, and it is an object instance that was returned by this same method, passed in instance is returned.
+     * <p/>
+     * Based on what kind of elements are used, one can create multiple kind of keys:
+     * <ul>
+     *     <li>To create <em>globally matched keys</em>, preferred is to use {@link String} key elements</li>
+     *     <li>To create <em>ClassLoader wide matched keys</em>, make sure at least one key element is {@link Class} that needs to be scoped to ClassLoader</li>
+     *     <li>To create <em>private, matched by creator only keys</em>, make sure to have one key element, that requires instance equality matching, and there is no other same instance of element</li>
+     * </ul>
+     *
+     * @param keys The key elements, it may not be {@code null} and may not have zero elements.
+     * @return An object instance usable as key.
+     */
     public static Object of(Object... keys) {
-        return new CompositeKey(keys);
+        requireNonNull(keys, "keys cannot be null");
+        if (keys.length == 0) {
+            throw new IllegalArgumentException("keys must have at least one element");
+        } else if (keys[0] instanceof Key) {
+            Key head = (Key) keys[0];
+            if (keys.length == 1) {
+                return head;
+            } else {
+                return new Key(concat(head.keys, Arrays.copyOfRange(keys, 1, keys.length)));
+            }
+        } else {
+            return new Key(keys);
+        }
     }
 
-    private static final class CompositeKey {
+    private static final class Key {
         private final Object[] keys;
         private final int hashCode;
 
-        private CompositeKey append(Object... appendedKeys) {
-            requireNonNull(appendedKeys, "appended keys cannot be null");
-            Object[] newKeys = new Object[this.keys.length + appendedKeys.length];
-            System.arraycopy(this.keys, 0, newKeys, 0, this.keys.length);
-            System.arraycopy(appendedKeys, 0, newKeys, this.keys.length, appendedKeys.length);
-            return new CompositeKey(newKeys);
-        }
-
-        private CompositeKey(Object... keys) {
-            this.keys = requireNonNull(keys, "keys cannot be null");
+        private Key(Object[] keys) {
+            this.keys = keys;
             this.hashCode = Arrays.hashCode(keys);
-            if (this.keys.length == 0) {
-                throw new IllegalArgumentException("composite key must have at least one element");
-            }
         }
 
         @Override
         public boolean equals(Object obj) {
             if (this == obj) {
                 return true;
-            } else if (!(obj instanceof CompositeKey)) {
+            } else if (!(obj instanceof Key)) {
                 return false;
             }
-            CompositeKey that = (CompositeKey) obj;
+            Key that = (Key) obj;
             return Arrays.equals(keys, that.keys);
         }
 
@@ -78,5 +108,16 @@ public final class Keys {
         public int hashCode() {
             return hashCode;
         }
+
+        @Override
+        public String toString() {
+            return Arrays.toString(keys);
+        }
+    }
+
+    private static Object[] concat(Object[] one, Object[] two) {
+        Object[] result = Arrays.copyOf(one, one.length + two.length);
+        System.arraycopy(two, 0, result, one.length, two.length);
+        return result;
     }
 }

--- a/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/Keys.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A helper class to create keys, to be used with {@link SessionData} and {@link RepositoryCache} instances as keys.
+ *
+ * It is this class user responsibility to use proper objects as keys, this class merely helps one to create composite
+ * keys.
+ *
+ * Important: never forget to perform {@code null}-check, when getting cache from {@link RepositorySystemSession#getCache()}
+ * as it may be disabled session-wise.
+ *
+ * @see RepositorySystemSession#getData()
+ * @see RepositorySystemSession#getCache()
+ * @since 2.0.19
+ */
+public final class Keys {
+    private Keys() {}
+
+    public static Object of(Object... keys) {
+        return new CompositeKey(keys);
+    }
+
+    private static final class CompositeKey {
+        private final Object[] keys;
+        private final int hashCode;
+
+        private CompositeKey append(Object... appendedKeys) {
+            requireNonNull(appendedKeys, "appended keys cannot be null");
+            Object[] newKeys = new Object[this.keys.length + appendedKeys.length];
+            System.arraycopy(this.keys, 0, newKeys, 0, this.keys.length);
+            System.arraycopy(appendedKeys, 0, newKeys, this.keys.length, appendedKeys.length);
+            return new CompositeKey(newKeys);
+        }
+
+        private CompositeKey(Object... keys) {
+            this.keys = requireNonNull(keys, "keys cannot be null");
+            this.hashCode = Arrays.hashCode(keys);
+            if (this.keys.length == 0) {
+                throw new IllegalArgumentException("composite key must have at least one element");
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (!(obj instanceof CompositeKey)) {
+                return false;
+            }
+            CompositeKey that = (CompositeKey) obj;
+            return Arrays.equals(keys, that.keys);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+}

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/KeysTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/KeysTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KeysTest {
+    @Test
+    void noElement() {
+        assertThrows(IllegalArgumentException.class, Keys::of);
+    }
+
+    @Test
+    void nullVararg() {
+        assertThrows(NullPointerException.class, () -> Keys.of((Object[]) null));
+    }
+
+    @Test
+    void globalKeys() {
+        Object key1 = Keys.of("one", "two", "three");
+        Object key2 = Keys.of("one", "two", "three");
+        Object key3 = Keys.of("one", "two");
+        assertNotSame(key1, key2);
+        assertNotSame(key2, key3);
+        assertNotSame(key1, key3);
+
+        assertEquals(key1, key2);
+        assertNotEquals(key1, key3);
+        assertEquals(key1.hashCode(), key2.hashCode());
+        assertNotEquals(key1.hashCode(), key3.hashCode());
+    }
+
+    @Test
+    void classLoaderAwareKeys() throws Exception {
+        String classBinaryName = Keys.class.getName();
+        try (URLClassLoader altLoader = new URLClassLoader(
+                new URL[] {Paths.get("target/classes").toUri().toURL()}, null)) {
+            Class<?> thisClass = Keys.class.getClassLoader().loadClass(classBinaryName);
+            Class<?> otherClass = altLoader.loadClass(classBinaryName);
+
+            Object key1 = Keys.of(thisClass, "one", "two");
+            Object key2 = Keys.of(thisClass, "one", "two");
+            Object key3 = Keys.of(otherClass, "one", "two");
+            assertNotSame(key1, key2);
+            assertNotSame(key2, key3);
+            assertNotSame(key1, key3);
+
+            assertEquals(key1, key2);
+            assertNotEquals(key1, key3);
+            assertEquals(key1.hashCode(), key2.hashCode());
+            assertNotEquals(key1.hashCode(), key3.hashCode());
+        }
+    }
+
+    @Test
+    void privateKeys() {
+        Object one = new Object();
+        Object two = new Object();
+        Object key1 = Keys.of(one, "one", "two");
+        Object key2 = Keys.of(one, "one", "two");
+        Object key3 = Keys.of(two, "one", "two");
+        assertNotSame(key1, key2);
+        assertNotSame(key2, key3);
+        assertNotSame(key1, key3);
+
+        assertEquals(key1, key2);
+        assertNotEquals(key1, key3);
+        assertEquals(key1.hashCode(), key2.hashCode());
+        assertNotEquals(key1.hashCode(), key3.hashCode());
+    }
+}

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/KeysTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/KeysTest.java
@@ -93,4 +93,20 @@ public class KeysTest {
         assertEquals(key1.hashCode(), key2.hashCode());
         assertNotEquals(key1.hashCode(), key3.hashCode());
     }
+
+    @Test
+    void subKey() {
+        Object key1 = Keys.of("one", "two", "three");
+        Object key2 = Keys.of("one", "two");
+        assertNotSame(key1, key2);
+
+        assertNotEquals(key1, key2);
+        assertNotEquals(key1.hashCode(), key2.hashCode());
+
+        Object key3 = Keys.of(key2, "three");
+        assertNotSame(key1, key3);
+
+        assertEquals(key1, key3);
+        assertEquals(key1.hashCode(), key3.hashCode());
+    }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -159,7 +159,7 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager {
         }
         RepositoryCache cache = session.getCache();
         if (cache != null) {
-            Object key = Keys.of(original, mirror);
+            Object key = Keys.of(mirror.getId(), mirror.getUrl(), original.getId(), original.getUrl());
             if (cache.get(session, key) != null) {
                 return;
             }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -23,11 +23,11 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositoryCache;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -52,31 +52,6 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 @Named
 public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager {
-
-    private static final class LoggedMirror {
-
-        private final Object[] keys;
-
-        LoggedMirror(RemoteRepository original, RemoteRepository mirror) {
-            keys = new Object[] {mirror.getId(), mirror.getUrl(), original.getId(), original.getUrl()};
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            } else if (!(obj instanceof LoggedMirror)) {
-                return false;
-            }
-            LoggedMirror that = (LoggedMirror) obj;
-            return Arrays.equals(keys, that.keys);
-        }
-
-        @Override
-        public int hashCode() {
-            return Arrays.hashCode(keys);
-        }
-    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRemoteRepositoryManager.class);
 
@@ -184,7 +159,7 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager {
         }
         RepositoryCache cache = session.getCache();
         if (cache != null) {
-            Object key = new LoggedMirror(original, mirror);
+            Object key = Keys.of(original, mirror);
             if (cache.get(session, key) != null) {
                 return;
             }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryKeyFunctionFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositoryKeyFunctionFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryKeyFunction;
@@ -75,9 +76,7 @@ public class DefaultRepositoryKeyFunctionFactory implements RepositoryKeyFunctio
             return (repository, context) -> ((ConcurrentMap<RemoteRepository, ConcurrentMap<String, String>>)
                             session.getCache()
                                     .computeIfAbsent(
-                                            session,
-                                            owner.getName() + ".repositoryKeyFunction",
-                                            ConcurrentHashMap::new))
+                                            session, Keys.of(owner, "repositoryKeyFunction"), ConcurrentHashMap::new))
                     .computeIfAbsent(repository, k1 -> new ConcurrentHashMap<>())
                     .computeIfAbsent(
                             context == null ? "" : context, k2 -> repositoryKeyFunction.apply(repository, context));

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.SessionData;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.impl.UpdateCheck;
 import org.eclipse.aether.impl.UpdateCheckManager;
@@ -434,12 +433,11 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
         }
     }
 
-    private boolean isAlreadyUpdated(RepositorySystemSession session, Object updateKey) {
+    private boolean isAlreadyUpdated(RepositorySystemSession session, String updateKey) {
         if (getSessionState(session) >= STATE_BYPASS) {
             return false;
         }
-        SessionData data = session.getData();
-        Object checkedFiles = data.get(SESSION_CHECKS);
+        Object checkedFiles = session.getData().get(SESSION_CHECKS);
         if (!(checkedFiles instanceof Map)) {
             return false;
         }
@@ -447,13 +445,12 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
     }
 
     @SuppressWarnings("unchecked")
-    private void setUpdated(RepositorySystemSession session, Object updateKey) {
+    private void setUpdated(RepositorySystemSession session, String updateKey) {
         if (getSessionState(session) >= STATE_DISABLED) {
             return;
         }
-        SessionData data = session.getData();
-        Object checkedFiles = data.computeIfAbsent(SESSION_CHECKS, () -> new ConcurrentHashMap<>(256));
-        ((Map<Object, Boolean>) checkedFiles).put(updateKey, Boolean.TRUE);
+        Object checkedFiles = session.getData().computeIfAbsent(SESSION_CHECKS, () -> new ConcurrentHashMap<>(256));
+        ((Map<String, Boolean>) checkedFiles).put(updateKey, Boolean.TRUE);
     }
 
     private boolean isUpdatedRequired(RepositorySystemSession session, long lastModified, String policy) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.impl.UpdateCheck;
@@ -68,12 +69,13 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
 
     private static final String NOT_FOUND = "";
 
-    static final Object SESSION_CHECKS = new Object() {
+    // instance bound private key
+    static final Object SESSION_CHECKS = Keys.of(new Object() {
         @Override
         public String toString() {
             return "updateCheckManager.checks";
         }
-    };
+    });
 
     /**
      * Manages the session state, i.e. influences if the same download requests to artifacts/metadata will happen

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -59,7 +59,10 @@ public final class PrioritizedComponents<T> {
             return (PrioritizedComponents<C>) session.getCache()
                     .computeIfAbsent(
                             session,
-                            Keys.of(PrioritizedComponents.class, discriminator, "pc-" + Integer.toHexString(components.hashCode())),
+                            Keys.of(
+                                    PrioritizedComponents.class,
+                                    discriminator,
+                                    "pc-" + Integer.toHexString(components.hashCode())),
                             () -> create(session, components, priorityFunction));
         } else {
             return create(session, components, priorityFunction);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.util.ConfigUtils;
 
@@ -55,10 +56,11 @@ public final class PrioritizedComponents<T> {
         boolean cached = ConfigUtils.getBoolean(
                 session, ConfigurationProperties.DEFAULT_CACHED_PRIORITIES, ConfigurationProperties.CACHED_PRIORITIES);
         if (cached && session.getCache() != null) {
-            String key = PrioritizedComponents.class.getName() + ".pc." + discriminator.getName()
-                    + Integer.toHexString(components.hashCode());
             return (PrioritizedComponents<C>) session.getCache()
-                    .computeIfAbsent(session, key, () -> create(session, components, priorityFunction));
+                    .computeIfAbsent(
+                            session,
+                            Keys.of(discriminator, "pc-" + Integer.toHexString(components.hashCode())),
+                            () -> create(session, components, priorityFunction));
         } else {
             return create(session, components, priorityFunction);
         }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/PrioritizedComponents.java
@@ -59,7 +59,7 @@ public final class PrioritizedComponents<T> {
             return (PrioritizedComponents<C>) session.getCache()
                     .computeIfAbsent(
                             session,
-                            Keys.of(discriminator, "pc-" + Integer.toHexString(components.hashCode())),
+                            Keys.of(PrioritizedComponents.class, discriminator, "pc-" + Integer.toHexString(components.hashCode())),
                             () -> create(session, components, priorityFunction));
         } else {
             return create(session, components, priorityFunction);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositoryCache;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -125,13 +126,13 @@ public final class DataPool {
     public static final String CONFIG_PROP_COLLECTOR_POOL_INTERN_ARTIFACT_DESCRIPTOR_MANAGED_DEPENDENCIES =
             "aether.dependencyCollector.pool.internArtifactDescriptorManagedDependencies";
 
-    private static final String ARTIFACT_POOL = DataPool.class.getName() + "$Artifact";
+    private static final Object ARTIFACT_POOL = Keys.of(DataPool.class, "artifact");
 
-    private static final String DEPENDENCY_POOL = DataPool.class.getName() + "$Dependency";
+    private static final Object DEPENDENCY_POOL = Keys.of(DataPool.class, "dependency");
 
-    private static final String DESCRIPTORS = DataPool.class.getName() + "$Descriptors";
+    private static final Object DESCRIPTORS = Keys.of(DataPool.class, "descriptors");
 
-    private static final String DEPENDENCY_LISTS_POOL = DataPool.class.getName() + "$DependencyLists";
+    private static final Object DEPENDENCY_LISTS_POOL = Keys.of(DataPool.class, "dependencyLists");
 
     public static final ArtifactDescriptorResult NO_DESCRIPTOR =
             new ArtifactDescriptorResult(new ArtifactDescriptorRequest());

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
@@ -48,8 +49,6 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 @Named
 public final class DefaultRemoteRepositoryFilterManager implements RemoteRepositoryFilterManager {
-    private static final String INSTANCE_KEY = DefaultRemoteRepositoryFilterManager.class.getName() + ".instance";
-
     private final Map<String, RemoteRepositoryFilterSource> sources;
 
     @Inject
@@ -60,21 +59,22 @@ public final class DefaultRemoteRepositoryFilterManager implements RemoteReposit
     @Override
     public RemoteRepositoryFilter getRemoteRepositoryFilter(RepositorySystemSession session) {
         // use session specific key to distinguish between "derived" sessions
-        String instanceSpecificKey = INSTANCE_KEY + "." + session.hashCode();
-        return (RemoteRepositoryFilter) session.getData().computeIfAbsent(instanceSpecificKey, () -> {
-            HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
-            for (Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet()) {
-                RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter(session);
-                if (filter != null) {
-                    filters.put(entry.getKey(), filter);
-                }
-            }
-            if (!filters.isEmpty()) {
-                return new Participants(filters);
-            } else {
-                return null;
-            }
-        });
+        return (RemoteRepositoryFilter) session.getData()
+                .computeIfAbsent(
+                        Keys.of(DefaultRemoteRepositoryFilterManager.class, "instance", session.hashCode()), () -> {
+                            HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
+                            for (Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet()) {
+                                RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter(session);
+                                if (filter != null) {
+                                    filters.put(entry.getKey(), filter);
+                                }
+                            }
+                            if (!filters.isEmpty()) {
+                                return new Participants(filters);
+                            } else {
+                                return null;
+                            }
+                        });
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
@@ -59,9 +59,15 @@ public final class DefaultRemoteRepositoryFilterManager implements RemoteReposit
     @Override
     public RemoteRepositoryFilter getRemoteRepositoryFilter(RepositorySystemSession session) {
         // use session specific key to distinguish between "derived" sessions
+        Object sessionDiscriminator;
+        if (session instanceof RepositorySystemSession.CloseableSession) {
+            sessionDiscriminator = ((RepositorySystemSession.CloseableSession) session).sessionId();
+        } else {
+            sessionDiscriminator = System.identityHashCode(session);
+        }
         return (RemoteRepositoryFilter) session.getData()
                 .computeIfAbsent(
-                        Keys.of(DefaultRemoteRepositoryFilterManager.class, "instance", session.hashCode()), () -> {
+                        Keys.of(DefaultRemoteRepositoryFilterManager.class, sessionDiscriminator), () -> {
                             HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
                             for (Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet()) {
                                 RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter(session);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager.java
@@ -66,21 +66,20 @@ public final class DefaultRemoteRepositoryFilterManager implements RemoteReposit
             sessionDiscriminator = System.identityHashCode(session);
         }
         return (RemoteRepositoryFilter) session.getData()
-                .computeIfAbsent(
-                        Keys.of(DefaultRemoteRepositoryFilterManager.class, sessionDiscriminator), () -> {
-                            HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
-                            for (Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet()) {
-                                RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter(session);
-                                if (filter != null) {
-                                    filters.put(entry.getKey(), filter);
-                                }
-                            }
-                            if (!filters.isEmpty()) {
-                                return new Participants(filters);
-                            } else {
-                                return null;
-                            }
-                        });
+                .computeIfAbsent(Keys.of(DefaultRemoteRepositoryFilterManager.class, sessionDiscriminator), () -> {
+                    HashMap<String, RemoteRepositoryFilter> filters = new HashMap<>();
+                    for (Map.Entry<String, RemoteRepositoryFilterSource> entry : sources.entrySet()) {
+                        RemoteRepositoryFilter filter = entry.getValue().getRemoteRepositoryFilter(session);
+                        if (filter != null) {
+                            filters.put(entry.getKey(), filter);
+                        }
+                    }
+                    if (!filters.isEmpty()) {
+                        return new Participants(filters);
+                    } else {
+                        return null;
+                    }
+                });
     }
 
     /**

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.MultiRuntimeException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -182,27 +183,35 @@ public final class GroupIdRemoteRepositoryFilterSource extends RemoteRepositoryF
         this.pathProcessor = requireNonNull(pathProcessor);
     }
 
+    private static final Object RULES = Keys.of(GroupIdRemoteRepositoryFilterSource.class, "rules");
+
     @SuppressWarnings("unchecked")
     private ConcurrentMap<RemoteRepository, GroupTree> rules(RepositorySystemSession session) {
         return (ConcurrentMap<RemoteRepository, GroupTree>)
-                session.getData().computeIfAbsent(getClass().getName() + ".rules", ConcurrentHashMap::new);
+                session.getData().computeIfAbsent(RULES, ConcurrentHashMap::new);
     }
+
+    private static final Object RULE_FILES = Keys.of(GroupIdRemoteRepositoryFilterSource.class, "ruleFiles");
 
     @SuppressWarnings("unchecked")
     private ConcurrentMap<RemoteRepository, Path> ruleFiles(RepositorySystemSession session) {
         return (ConcurrentMap<RemoteRepository, Path>)
-                session.getData().computeIfAbsent(getClass().getName() + ".ruleFiles", ConcurrentHashMap::new);
+                session.getData().computeIfAbsent(RULE_FILES, ConcurrentHashMap::new);
     }
+
+    private static final Object RECORDED_RULES = Keys.of(GroupIdRemoteRepositoryFilterSource.class, "recordedRules");
 
     @SuppressWarnings("unchecked")
     private ConcurrentMap<RemoteRepository, Set<String>> recordedRules(RepositorySystemSession session) {
         return (ConcurrentMap<RemoteRepository, Set<String>>)
-                session.getData().computeIfAbsent(getClass().getName() + ".recordedRules", ConcurrentHashMap::new);
+                session.getData().computeIfAbsent(RECORDED_RULES, ConcurrentHashMap::new);
     }
 
+    private static final Object SHUTDOWN_HANDLER_REGISTERED =
+            Keys.of(GroupIdRemoteRepositoryFilterSource.class, "onShutdownHandlerRegistered");
+
     private AtomicBoolean onShutdownHandlerRegistered(RepositorySystemSession session) {
-        return (AtomicBoolean) session.getData()
-                .computeIfAbsent(getClass().getName() + ".onShutdownHandlerRegistered", AtomicBoolean::new);
+        return (AtomicBoolean) session.getData().computeIfAbsent(SHUTDOWN_HANDLER_REGISTERED, AtomicBoolean::new);
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.impl.MetadataResolver;
@@ -238,16 +239,20 @@ public final class PrefixesRemoteRepositoryFilterSource extends RemoteRepository
         this.repositoryLayoutProvider = requireNonNull(repositoryLayoutProvider);
     }
 
+    private static final Object PREFIXES_KEY = Keys.of(PrefixesRemoteRepositoryFilterSource.class, "prefixes");
+
     @SuppressWarnings("unchecked")
     private ConcurrentMap<RemoteRepository, PrefixTree> prefixes(RepositorySystemSession session) {
         return (ConcurrentMap<RemoteRepository, PrefixTree>)
-                session.getData().computeIfAbsent(getClass().getName() + ".prefixes", ConcurrentHashMap::new);
+                session.getData().computeIfAbsent(PREFIXES_KEY, ConcurrentHashMap::new);
     }
+
+    private static final Object LAYOUTS_KEY = Keys.of(PrefixesRemoteRepositoryFilterSource.class, "layouts");
 
     @SuppressWarnings("unchecked")
     private ConcurrentMap<RemoteRepository, RepositoryLayout> layouts(RepositorySystemSession session) {
         return (ConcurrentMap<RemoteRepository, RepositoryLayout>)
-                session.getData().computeIfAbsent(getClass().getName() + ".layouts", ConcurrentHashMap::new);
+                session.getData().computeIfAbsent(LAYOUTS_KEY, ConcurrentHashMap::new);
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.internal.impl.checksum.FileTrustedChecksumsSourceSupport;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
 import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
@@ -119,7 +118,7 @@ public abstract class RemoteRepositoryFilterSourceSupport implements RemoteRepos
     protected String repositoryKey(RepositorySystemSession session, RemoteRepository repository) {
         return repositoryKeyFunctionFactory
                 .repositoryKeyFunction(
-                        FileTrustedChecksumsSourceSupport.class,
+                        RemoteRepositoryFilterSourceSupport.class,
                         session,
                         DEFAULT_REPOSITORY_KEY_FUNCTION,
                         CONFIG_PROP_REPOSITORY_KEY_FUNCTION)

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.ArtifactRepository;
@@ -146,8 +147,8 @@ public final class TrustedChecksumsArtifactResolverPostProcessor extends Artifac
      */
     public static final String CONFIG_PROP_RECORD = CONFIG_PROPS_PREFIX + "record";
 
-    private static final String CHECKSUM_ALGORITHMS_CACHE_KEY =
-            TrustedChecksumsArtifactResolverPostProcessor.class.getName() + ".checksumAlgorithms";
+    private static final Object CHECKSUM_ALGORITHMS_CACHE_KEY =
+            Keys.of(TrustedChecksumsArtifactResolverPostProcessor.class, "checksumAlgorithms");
 
     private final ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector;
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/scope/OptionalDependencySelector.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl.scope;
 import java.util.Collection;
 import java.util.Objects;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.collection.DependencyCollectionContext;
 import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.graph.Dependency;
@@ -37,8 +38,8 @@ import static java.util.Objects.requireNonNull;
  * @see Dependency#isOptional()
  */
 public final class OptionalDependencySelector implements DependencySelector {
-    public static final String IGNORED_KEYS = OptionalDependencySelector.class.getName() + ".ignored";
-    public static final String UNSELECTED_KEYS = OptionalDependencySelector.class.getName() + ".unselected";
+    public static final Object IGNORED_KEYS = Keys.of(OptionalDependencySelector.class, "ignored");
+    public static final Object UNSELECTED_KEYS = Keys.of(OptionalDependencySelector.class, "unselected");
 
     /**
      * Excludes optional dependencies always (from root).

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.NamedLockFactorySelector;
 import org.eclipse.aether.named.NamedLockFactory;
@@ -110,7 +111,7 @@ public class NamedLockFactoryAdapterFactoryImpl implements NamedLockFactoryAdapt
                 nameMappers.keySet());
     }
 
-    private static final String ADAPTER_KEY = NamedLockFactoryAdapterFactoryImpl.class.getName() + ".adapter";
+    private static final Object ADAPTER_KEY = Keys.of(NamedLockFactoryAdapterFactoryImpl.class, "adapter");
 
     /**
      * Current implementation memoize instance in session or delegates to {@link #createAdapter(RepositorySystemSession)}.

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -81,6 +81,7 @@ import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.Proxy;
@@ -287,11 +288,13 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
 
         if (session.getCache() != null) {
-            String authCacheKey = getClass().getName() + "@"
-                    + Integer.toHexString(System.identityHashCode(getClass().getClassLoader())) + "-"
-                    + repository.getId() + "-"
-                    + StringDigestUtil.sha1(repository.toString());
-            this.authCache = (AuthCache) session.getCache().computeIfAbsent(session, authCacheKey, BasicAuthCache::new);
+            this.authCache = (AuthCache) session.getCache()
+                    .computeIfAbsent(
+                            session,
+                            Keys.of(
+                                    getClass(),
+                                    repository.getId() + "-" + StringDigestUtil.sha1(repository.toString())),
+                            BasicAuthCache::new);
         } else {
             this.authCache = new BasicAuthCache();
         }

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/ApacheTransporter.java
@@ -287,7 +287,9 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
 
         if (session.getCache() != null) {
-            String authCacheKey = getClass().getSimpleName() + "-" + repository.getId() + "-"
+            String authCacheKey = getClass().getName() + "@"
+                    + Integer.toHexString(System.identityHashCode(getClass().getClassLoader())) + "-"
+                    + repository.getId() + "-"
                     + StringDigestUtil.sha1(repository.toString());
             this.authCache = (AuthCache) session.getCache().computeIfAbsent(session, authCacheKey, BasicAuthCache::new);
         } else {

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
@@ -43,6 +43,7 @@ import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLInitializationException;
 import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositoryCache;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.util.ConfigUtils;
@@ -86,7 +87,7 @@ final class GlobalState implements Closeable {
         }
     }
 
-    private static final String KEY = GlobalState.class.getName();
+    private static final Object KEY = Keys.of(GlobalState.class);
 
     private static final String CONFIG_PROP_CACHE_STATE =
             ApacheTransporterConfigurationKeys.CONFIG_PROPS_PREFIX + "cacheState";

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutorUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutorUtils.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.util.concurrency;
 
 import java.util.concurrent.Executors;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 
 import static java.util.Objects.requireNonNull;
@@ -91,12 +92,11 @@ public final class SmartExecutorUtils {
     public static SmartExecutor smartExecutor(
             RepositorySystemSession session, Integer tasks, int maxConcurrentTasks, String namePrefix) {
         if (tasks == null && maxConcurrentTasks > 1) {
-            return (SmartExecutor) session.getData()
-                    .computeIfAbsent(SmartExecutor.class.getSimpleName() + "-" + namePrefix, () -> {
-                        SmartExecutor smartExecutor = newSmartExecutor(null, maxConcurrentTasks, namePrefix);
-                        session.addOnSessionEndedHandler(smartExecutor::close);
-                        return new SmartExecutor.NonClosing(smartExecutor);
-                    });
+            return (SmartExecutor) session.getData().computeIfAbsent(Keys.of(SmartExecutor.class, namePrefix), () -> {
+                SmartExecutor smartExecutor = newSmartExecutor(null, maxConcurrentTasks, namePrefix);
+                session.addOnSessionEndedHandler(smartExecutor::close);
+                return new SmartExecutor.NonClosing(smartExecutor);
+            });
         } else {
             return newSmartExecutor(tasks, maxConcurrentTasks, namePrefix);
         }


### PR DESCRIPTION
Started as proposed, to make session-wide auth cache string key classloader aware. Then realized, we have "classloader aware" class, that we make into string, with tricks, to make it "classloader aware", and this sounds awkward. Hence, `Keys` helper class.

This PR also revealed a bug, hidden deep, where (probably a copy pasted) code snippet used wrong key, see `RemoteRepositoryFilterSourceSupport`.

---

Back story: originally Resolver used `String` as keys that as we know, are perfect candidates for keys. But, if we stick to Maven, same component may end up loaded twice in Maven, and if key value contains something that is component specific (like the issue mentioned Apache transport value is Apache transport specific class), this will cause inevitably `ClassCastEx` if one instance puts something into map, and other one from the other classloader discovers it (and tries to cast it). In Maven, the resolver api, spi, util, impl and basic connector modules cannot be replaced (is prevented by Maven; circumvention is relocation or uber jar, changing the GAV), but other resolver modules can be loaded up multiple times, see https://github.com/apache/maven/blob/4106910f94e92a0967c61c62b4dbbcd6294c97a0/maven-core/src/main/resources/META-INF/maven/extension.xml#L185-L189

Hence the `Keys`, where user still has to decide how "scoped" the key should be, if using `String`s as key element, it will be global, and that is fine for keys mapped to values that are usable across class loaders as well (ie. value is consisted of `java.base` classes only). If we want class loader awareness (like in the issue, for Apache transport we do), then all user should do, is to use class loader specific class as one key element, and it will distinguish it from duplicate class loaded by another class loader. Finally, as update check manager does, "instance bound" keys are still possible too.

This change, while may look "radical" or even breaking, is in fact limited and does not cause API breakage in public surface of modules: api, spi and util.

Fixes #1919
