### PR TITLE
[1.9.x] Fix ApacheTransport auth cache CCEx

### DIFF
--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -366,7 +366,9 @@ final class HttpTransporter extends AbstractTransporter {
         }
 
         if (session.getCache() != null) {
-            String authCacheKey = getClass().getSimpleName() + "-" + repository.getId() + "-"
+            String authCacheKey = getClass().getName() + "@"
+                    + Integer.toHexString(System.identityHashCode(getClass().getClassLoader())) + "-"
+                    + repository.getId() + "-"
                     + StringDigestUtil.sha1(repository.toString());
             synchronized (AUTH_CACHE_MUTEX) {
                 AuthCache cache = (AuthCache) session.getCache().get(session, authCacheKey);


### PR DESCRIPTION
As proposed, make session-wide auth cache key classloader aware.

Fixes #1919
