### PR TITLE
Align generators

### DIFF
--- a/maven-resolver-generator-gnupg/src/main/java/org/eclipse/aether/generator/gnupg/GnupgSignatureArtifactGenerator.java
+++ b/maven-resolver-generator-gnupg/src/main/java/org/eclipse/aether/generator/gnupg/GnupgSignatureArtifactGenerator.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
@@ -56,6 +57,7 @@ final class GnupgSignatureArtifactGenerator implements ArtifactGenerator {
     private final PGPSignatureSubpacketVector hashSubPackets;
     private final String keyInfo;
     private final List<Path> signatureTempFiles;
+    private final AtomicBoolean closed;
 
     GnupgSignatureArtifactGenerator(
             Collection<Artifact> artifacts,
@@ -71,6 +73,7 @@ final class GnupgSignatureArtifactGenerator implements ArtifactGenerator {
         this.hashSubPackets = hashSubPackets;
         this.keyInfo = keyInfo;
         this.signatureTempFiles = new ArrayList<>();
+        this.closed = new AtomicBoolean(false);
         logger.debug("Created generator using key {}", keyInfo);
     }
 
@@ -115,14 +118,16 @@ final class GnupgSignatureArtifactGenerator implements ArtifactGenerator {
     }
 
     @Override
-    public synchronized void close() {
-        signatureTempFiles.forEach(p -> {
-            try {
-                Files.deleteIfExists(p);
-            } catch (IOException e) {
-                p.toFile().deleteOnExit();
-            }
-        });
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            signatureTempFiles.forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    p.toFile().deleteOnExit();
+                }
+            });
+        }
     }
 
     private void sign(InputStream content, OutputStream signature) throws IOException {

--- a/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
+++ b/maven-resolver-generator-sigstore/src/main/java/org/eclipse/aether/generator/sigstore/SigstoreSignatureArtifactGenerator.java
@@ -28,6 +28,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import dev.sigstore.KeylessSigner;
@@ -47,10 +49,11 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
     private static final String ARTIFACT_EXTENSION = ".sigstore.json";
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final PathProcessor pathProcessor;
-    private final ArrayList<Artifact> artifacts;
+    private final List<Artifact> artifacts;
     private final Predicate<Artifact> signableArtifactPredicate;
     private final boolean publicStaging;
-    private final ArrayList<Path> signatureTempFiles;
+    private final List<Path> signatureTempFiles;
+    private final AtomicBoolean closed;
 
     SigstoreSignatureArtifactGenerator(
             PathProcessor pathProcessor,
@@ -62,6 +65,7 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
         this.signableArtifactPredicate = signableArtifactPredicate;
         this.publicStaging = publicStaging;
         this.signatureTempFiles = new ArrayList<>();
+        this.closed = new AtomicBoolean(false);
         logger.debug("Created sigstore generator (publicStaging={})", publicStaging);
     }
 
@@ -71,7 +75,7 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
     }
 
     @Override
-    public Collection<? extends Artifact> generate(Collection<? extends Artifact> generatedArtifacts) {
+    public synchronized Collection<? extends Artifact> generate(Collection<? extends Artifact> generatedArtifacts) {
         try {
             artifacts.addAll(generatedArtifacts);
 
@@ -148,12 +152,14 @@ final class SigstoreSignatureArtifactGenerator implements ArtifactGenerator {
 
     @Override
     public void close() {
-        signatureTempFiles.forEach(p -> {
-            try {
-                Files.deleteIfExists(p);
-            } catch (IOException e) {
-                p.toFile().deleteOnExit();
-            }
-        });
+        if (closed.compareAndSet(false, true)) {
+            signatureTempFiles.forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException e) {
+                    p.toFile().deleteOnExit();
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
After #1902 only one had changes, but they always used together.

Also, rather make `close()` idempotent than synchronized.
