### PR TITLE
Get rid of BND warnings

### DIFF
--- a/maven-resolver-api/pom.xml
+++ b/maven-resolver-api/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <bnd.instructions.additions><![CDATA[
       -jpms-module-info: org.apache.maven.resolver
-      -removeheaders Automatic-Module-Name
+      -removeheaders: Automatic-Module-Name
     ]]></bnd.instructions.additions>
   </properties>
 

--- a/maven-resolver-spi/pom.xml
+++ b/maven-resolver-spi/pom.xml
@@ -33,8 +33,8 @@
 
   <properties>
     <bnd.instructions.additions><![CDATA[
-      -jpms-module-info
-      -removeheaders Automatic-Module-Name
+      -jpms-module-info:
+      -removeheaders: Automatic-Module-Name
     ]]></bnd.instructions.additions>
   </properties>
 

--- a/maven-resolver-util/pom.xml
+++ b/maven-resolver-util/pom.xml
@@ -33,8 +33,8 @@
 
   <properties>
     <bnd.instructions.additions><![CDATA[
-      -jpms-module-info
-      -removeheaders Automatic-Module-Name
+      -jpms-module-info:
+      -removeheaders: Automatic-Module-Name
     ]]></bnd.instructions.additions>
   </properties>
 


### PR DESCRIPTION
By properly formatting bnd parameters (follow emitted advice, add trailing `:`).

---

FTR, warning was:
```
[INFO] --- bnd:7.3.0:bnd-process (bnd-process) @ maven-resolver-spi ---
[WARNING] /home/cstamas/Worx/apache-maven/RELEASE/maven-resolver/maven-resolver-spi/pom.xml [18:74]: No value specified for key: -jpms-module-info. An empty value should be specified as '-jpms-module-info:' or '-jpms-module-info=': <<              -jpms-module-info
      -removeheaders Automatic-Module-Name>>
```