### PR TITLE
Fix potential NPEs in IpcClient and resource leak in DependencyGraphParser

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -29,6 +29,7 @@ import java.io.InterruptedIOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.net.SocketAddress;
+import java.net.URL;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.FileLock;
@@ -262,7 +263,15 @@ public class IpcClient {
     private String getJarPath(Class<?> clazz) {
         String classpath;
         String className = clazz.getName().replace('.', '/') + ".class";
-        String url = clazz.getClassLoader().getResource(className).toString();
+        ClassLoader classLoader = clazz.getClassLoader();
+        if (classLoader == null) {
+            classLoader = ClassLoader.getSystemClassLoader();
+        }
+        URL resource = classLoader.getResource(className);
+        if (resource == null) {
+            throw new IllegalStateException("Unable to find resource for class " + clazz.getName());
+        }
+        String url = resource.toString();
         if (url.startsWith("jar:")) {
             url = url.substring("jar:".length(), url.indexOf("!/"));
             if (url.startsWith("file:")) {
@@ -288,11 +297,15 @@ public class IpcClient {
     void receive() {
         try {
             while (true) {
-                int id = input.readInt();
-                int sz = input.readInt();
+                DataInputStream in = input;
+                if (in == null) {
+                    throw new IOException("Connection closed");
+                }
+                int id = in.readInt();
+                int sz = in.readInt();
                 List<String> s = new ArrayList<>(sz);
                 for (int i = 0; i < sz; i++) {
-                    s.add(input.readUTF());
+                    s.add(in.readUTF());
                 }
                 CompletableFuture<List<String>> f = responses.remove(id);
                 if (f == null) {
@@ -445,8 +458,12 @@ public class IpcClient {
     }
 
     private String getAddress() {
+        SocketChannel s = socket;
+        if (s == null) {
+            return "[closed]";
+        }
         try {
-            return SocketFamily.toString(socket.getLocalAddress());
+            return SocketFamily.toString(s.getLocalAddress());
         } catch (IOException e) {
             return "[not bound]";
         }

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -263,11 +263,7 @@ public class IpcClient {
     private String getJarPath(Class<?> clazz) {
         String classpath;
         String className = clazz.getName().replace('.', '/') + ".class";
-        ClassLoader classLoader = clazz.getClassLoader();
-        if (classLoader == null) {
-            classLoader = ClassLoader.getSystemClassLoader();
-        }
-        URL resource = classLoader.getResource(className);
+        URL resource = clazz.getResource("/" + className);
         if (resource == null) {
             throw new IllegalStateException("Unable to find resource for class " + clazz.getName());
         }

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
@@ -158,14 +158,15 @@ public class DependencyGraphParser {
             throw new IOException("Could not find classpath resource " + prefix + resource);
         }
 
-        BufferedReader reader = new BufferedReader(new InputStreamReader(res.openStream(), StandardCharsets.UTF_8));
-
-        List<DependencyNode> ret = new ArrayList<>();
-        DependencyNode root = null;
-        while ((root = parse(reader)) != null) {
-            ret.add(root);
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(res.openStream(), StandardCharsets.UTF_8))) {
+            List<DependencyNode> ret = new ArrayList<>();
+            DependencyNode root = null;
+            while ((root = parse(reader)) != null) {
+                ret.add(root);
+            }
+            return ret;
         }
-        return ret;
     }
 
     /**


### PR DESCRIPTION
## Summary

- **IpcClient.getJarPath()**: `getClassLoader()` returns `null` for bootstrap classes, and `getResource()` returns `null` when the resource is not found. Either causes an NPE on the chained `.toString()` call. Added explicit null checks with fallback to system classloader and a clear error message.
- **IpcClient.receive()**: The volatile `input` field is read and used without a local copy. A concurrent `close()` call can null the field between the read and the method invocation, causing an NPE. Fixed by capturing the volatile read in a local variable.
- **IpcClient.getAddress()**: The volatile `socket` field can be nulled by a concurrent `close()` call. The resulting NPE is not an `IOException` and propagates uncaught. Fixed by capturing in a local variable with a null check.
- **DependencyGraphParser.parseMultiResource()**: The `BufferedReader` (and its underlying `InputStream`) is never closed. If `parse(reader)` throws, the stream leaks. Wrapped in try-with-resources, consistent with the existing `parse(URL)` method at line 174.

## Test plan
- [x] `mvn compile` passes for both modified modules
- [x] `mvn test` passes for `maven-resolver-named-locks-ipc`
- [x] `mvn test` passes for `maven-resolver-test-util`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #1987 