### PR TITLE
Limit internal retries to 1 with Java 26+

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/test/java/org/eclipse/aether/transport/jdk/JdkTransporterTest.java
@@ -81,8 +81,11 @@ class JdkTransporterTest extends HttpTransporterTest {
     @Override
     @Test
     protected void testRetryHandler_defaultCount_negative() throws Exception {
-        // internally JDK client uses its own retry mechanism with 1 retry for ConnectionExpiredException, therefore
-        // close more connections to trigger failed retries
+        // internally JDK client uses its own retry mechanism with
+        // 2 attempts for ConnectionExpiredException (prior Java 26) and 5 (default for
+        // system property "jdk.httpclient.redirects.retrylimit") attempts after,
+        // therefore explicitly limit the internal retry count to 1
+        System.setProperty("jdk.httpclient.redirects.retrylimit", "1"); // this only affects Java 26+
         // Compare with https://github.com/mizosoft/methanol/issues/174
         httpServer.setConnectionsToClose(8);
         try {


### PR DESCRIPTION
This only affects IT and Java26+. The internal retry handling changed with Java 26 (https://github.com/openjdk/jdk/commit/e8db14f584fa92db170e056bc68074ccabae82c9#diff-41e3c3f66a6d78612e230f2546ac15e3f82619efe333a731b64f59a9e4991816). Previously for connection closed exceptions there were always 2 attempts while with Java 26 this defaults to system property "jdk.httpclient.redirects.retrylimit" now.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
