### PR TITLE
Bug: Apache transport deadlock in concurrent use case

### DIFF
--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
@@ -54,6 +54,13 @@ import org.eclipse.aether.util.ConfigUtils;
  */
 final class GlobalState implements Closeable {
 
+    static {
+        // force initialization of SSLConnectionSocketFactory class:
+        // ensure that the connection socket factory is initialized before we start using it in any multithreaded
+        // environment, otherwise we may run into a deadlock (see https://github.com/quarkusio/quarkus/pull/55345)
+        SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+    }
+
     static class CompoundKey {
 
         private final Object[] keys;

--- a/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
+++ b/maven-resolver-transport-apache/src/main/java/org/eclipse/aether/transport/apache/GlobalState.java
@@ -57,7 +57,10 @@ final class GlobalState implements Closeable {
     static {
         // force initialization of SSLConnectionSocketFactory class:
         // ensure that the connection socket factory is initialized before we start using it in any multithreaded
-        // environment, otherwise we may run into a deadlock (see https://github.com/quarkusio/quarkus/pull/55345)
+        // environment, otherwise we may run into a deadlock.
+        // References:
+        // https://github.com/quarkusio/quarkus/issues/55317
+        // https://github.com/quarkusio/quarkus/pull/55345
         SSLConnectionSocketFactory.getDefaultHostnameVerifier();
     }
 


### PR DESCRIPTION
Make sure the class SSLConnectionSocketFactory is initialized early, instead lazily in ConcurrentHashMap.computeIfAbsent, as latter may cause deadlock.

Refs:
* https://github.com/quarkusio/quarkus/issues/55317
* https://github.com/quarkusio/quarkus/pull/55345
