### PR TITLE
Validate path components

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -25,6 +25,8 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validateArtifactComponents;
+import static org.eclipse.aether.util.PathUtils.validateMetadataComponents;
 
 /**
  * Default implementation of {@link LocalPathComposer}.
@@ -37,6 +39,7 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
     @Override
     public String getPathForArtifact(Artifact artifact, boolean local) {
         requireNonNull(artifact);
+        validateArtifactComponents(artifact);
 
         StringBuilder path = new StringBuilder(128);
 
@@ -68,6 +71,7 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
     public String getPathForMetadata(Metadata metadata, String repositoryKey) {
         requireNonNull(metadata);
         requireNonNull(repositoryKey);
+        validateMetadataComponents(metadata);
 
         StringBuilder path = new StringBuilder(128);
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultLocalPathComposerTest {
+
+    private final DefaultLocalPathComposer composer = new DefaultLocalPathComposer();
+
+    @Test
+    void testGetPathForArtifact() {
+        String path = composer.getPathForArtifact(new DefaultArtifact("g.id", "a-id", "jar", "1.0"), true);
+        assertEquals("g/id/a-id/1.0/a-id-1.0.jar", path);
+    }
+
+    @Test
+    void testGetPathForMetadata() {
+        Metadata metadata = new DefaultMetadata("g.id", "a-id", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        String path = composer.getPathForMetadata(metadata, "central");
+        assertEquals("g/id/a-id/1.0/maven-metadata-central.xml", path);
+    }
+
+    @Test
+    void testGetPathForMetadataRejectsTraversalInVersion() {
+        Metadata metadata = new DefaultMetadata(
+                "g.id", "a-id", "../../../../tmp/PWNED-SNAPSHOT", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        assertThrows(IllegalArgumentException.class, () -> composer.getPathForMetadata(metadata, "central"));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsTraversalInVersion() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id", "a-id", "jar", "../../escape"), true));
+    }
+
+    @Test
+    void testGetPathForMetadataRejectsSlashInVersion() {
+        Metadata metadata =
+                new DefaultMetadata("g.id", "a-id", "1.0/../../etc", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        assertThrows(IllegalArgumentException.class, () -> composer.getPathForMetadata(metadata, "central"));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsBackslashInVersion() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id", "a-id", "jar", "1.0\\..\\escape"), true));
+    }
+
+    @Test
+    void testGetPathForMetadataAcceptsNormalVersions() {
+        // Verify that normal version strings with dots and dashes are still accepted
+        Metadata metadata =
+                new DefaultMetadata("g.id", "a-id", "1.0.0-SNAPSHOT", "maven-metadata.xml", Metadata.Nature.SNAPSHOT);
+        String path = composer.getPathForMetadata(metadata, "central");
+        assertEquals("g/id/a-id/1.0.0-SNAPSHOT/maven-metadata-central.xml", path);
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -71,5 +74,51 @@ public final class PathUtils {
             }
         }
         return result.toString();
+    }
+
+    /**
+     * Validates that a coordinate component does not contain path traversal sequences
+     * or path separator characters that could cause the composed path to escape
+     * the local repository directory.
+     *
+     * @since 2.0.21
+     */
+    public static void validatePathComponent(String value, String label) {
+        if (value != null && !value.isEmpty()) {
+            // Important: "equals .." and not "contains ..", as if escape attempted, it will contain path separators
+            // OTOH: version "1.." is valid version string!
+            if (value.equals("..") || value.contains("/") || value.contains("\\")) {
+                throw new IllegalArgumentException(
+                        "Invalid " + label + ": must not contain '..', '/' or '\\': " + value);
+            }
+        }
+    }
+
+    /**
+     * Validates all coordinate components of an {@link Artifact}.
+     *
+     * @see #validatePathComponent(String, String)
+     * @since 2.0.21
+     */
+    public static void validateArtifactComponents(Artifact artifact) {
+        validatePathComponent(artifact.getGroupId(), "groupId");
+        validatePathComponent(artifact.getArtifactId(), "artifactId");
+        validatePathComponent(artifact.getVersion(), "version");
+        validatePathComponent(artifact.getBaseVersion(), "baseVersion");
+        validatePathComponent(artifact.getClassifier(), "classifier");
+        validatePathComponent(artifact.getExtension(), "extension");
+    }
+
+    /**
+     * Validates all coordinate components of a {@link Metadata}.
+     *
+     * @see #validatePathComponent(String, String)
+     * @since 2.0.21
+     */
+    public static void validateMetadataComponents(Metadata metadata) {
+        validatePathComponent(metadata.getGroupId(), "groupId");
+        validatePathComponent(metadata.getArtifactId(), "artifactId");
+        validatePathComponent(metadata.getVersion(), "version");
+        // note: type may contain string like ".meta/prefixes.txt"!
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import org.eclipse.aether.version.Version;
 
 import static java.util.Objects.requireNonNull;
-import static org.eclipse.aether.util.PathUtils.validatePathComponent;
 
 /**
  * A generic version, that is a version that accepts any input string and tries to apply common sense sorting. See
@@ -48,7 +47,6 @@ public final class GenericVersion implements Version {
      */
     GenericVersion(String version) {
         this.version = requireNonNull(version, "version cannot be null");
-        validatePathComponent(version, "version");
         items = parse(version);
         hash = items.hashCode();
     }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import org.eclipse.aether.version.Version;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validatePathComponent;
 
 /**
  * A generic version, that is a version that accepts any input string and tries to apply common sense sorting. See
@@ -47,6 +48,7 @@ public final class GenericVersion implements Version {
      */
     GenericVersion(String version) {
         this.version = requireNonNull(version, "version cannot be null");
+        validatePathComponent(version, "version");
         items = parse(version);
         hash = items.hashCode();
     }


### PR DESCRIPTION
But make it reusable as well. When 2.0.21 released, Maven codebase of `DefaultVersionResolver` and `DefaultVersionRangeResolver` should be updated too, and use this util method.

Supersedes (and based on) #1958
