### PR TITLE
Fix reporting of HTTP/3 in JdkTransporter

### DIFF
--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -388,7 +388,12 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
             case HTTP_2:
                 return HttpTransportProperty.HttpVersion.HTTP_2;
             default:
-                throw new IllegalArgumentException("Unsupported HTTP version: " + version);
+                // support HTTP_3 via name (as only part of Java 26+ API)
+                if ("HTTP_3".equals(version.name())) {
+                    return HttpTransportProperty.HttpVersion.HTTP_3;
+                } else {
+                    throw new IllegalArgumentException("Unsupported HTTP version: " + version);
+                }
         }
     }
 


### PR DESCRIPTION
Use enum name, as HttpVersion.HTTP_3 was only added in Java26+

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
