### PR TITLE
Bump Jetty to 12.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <bouncycastleVersion>1.85</bouncycastleVersion>
 
     <!-- Used by Jetty Transport (client) and Test HTTP (server), 12.1 introduced support for different compressions (https://github.com/jetty/jetty.project/issues/8769) -->
-    <jettyVersion>12.1.10</jettyVersion>
+    <jettyVersion>12.1.11</jettyVersion>
     <!-- used by supplier and demo only -->
     <maven3Version>3.9.16</maven3Version>
     <maven4Version>4.0.0-rc-5</maven4Version>


### PR DESCRIPTION
Release notes:
https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.11
