### PR TITLE
Fix: goal is to fix master

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/ConfigurationProperties.java
@@ -546,7 +546,7 @@ public final class ConfigurationProperties {
      *
      * @since 2.0.21
      */
-    public static final HttpVersion DEFAULT_HTTP_VERSION = HttpVersion.DEFAULT;
+    public static final String DEFAULT_HTTP_VERSION = "DEFAULT";
 
     /**
      * A flag indicating which visitor should be used to "flatten" the dependency graph into list. In Maven 4

--- a/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
+++ b/maven-resolver-transport-jdk-parent/maven-resolver-transport-jdk11/src/main/java/org/eclipse/aether/transport/jdk/JdkTransporter.java
@@ -503,7 +503,7 @@ final class JdkTransporter extends AbstractTransporter implements HttpTransporte
 
     HttpClient.Version getHttpVersion(RepositorySystemSession session, RemoteRepository repository) {
         HttpVersion httpVersion = HttpTransporterUtils.getHttpVersion(session, repository);
-        if (httpVersion == ConfigurationProperties.DEFAULT_HTTP_VERSION) {
+        if (httpVersion.name().equals(ConfigurationProperties.DEFAULT_HTTP_VERSION)) {
             // Fall back to legacy JDK Transporter specific property when it is explicitly configured.
             String configuredLegacyHttpVersion = ConfigUtils.getString(
                     session, null, CONFIG_PROP_HTTP_VERSION + "." + repository.getId(), CONFIG_PROP_HTTP_VERSION);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/ConfigUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/ConfigUtils.java
@@ -357,7 +357,7 @@ public final class ConfigUtils {
      * @since 2.0.21
      */
     public static <T extends Enum<T>> T getEnum(
-            Map<?, ?> properties, Class<T> enumClass, T defaultValue, String... keys) {
+            Map<?, ?> properties, Class<T> enumClass, String defaultValue, String... keys) {
         for (String key : keys) {
             Object value = properties.get(key);
 
@@ -367,7 +367,7 @@ public final class ConfigUtils {
                 return Enum.valueOf(enumClass, (String) value);
             }
         }
-        return defaultValue;
+        return Enum.valueOf(enumClass, defaultValue);
     }
 
     /**
@@ -384,7 +384,7 @@ public final class ConfigUtils {
      * @since 2.0.21
      */
     public static <T extends Enum<T>> T getEnum(
-            RepositorySystemSession session, Class<T> enumClass, T defaultValue, String... keys) {
+            RepositorySystemSession session, Class<T> enumClass, String defaultValue, String... keys) {
         return getEnum(session.getConfigProperties(), enumClass, defaultValue, keys);
     }
 

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/ConfigUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/ConfigUtilsTest.java
@@ -208,13 +208,13 @@ public class ConfigUtilsTest {
     @Test
     void testGetEnum() {
         config.put("some-enum", TestEnum.SECOND);
-        assertEquals(TestEnum.SECOND, ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST, "some-enum"));
+        assertEquals(TestEnum.SECOND, ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST.name(), "some-enum"));
     }
 
     @Test
     void testGetEnum_StringConversion() {
         config.put("some-enum", "SECOND");
-        assertEquals(TestEnum.SECOND, ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST, "some-enum"));
+        assertEquals(TestEnum.SECOND, ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST.name(), "some-enum"));
     }
 
     @Test
@@ -222,6 +222,6 @@ public class ConfigUtilsTest {
         config.put("some-enum", "second");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST, "some-enum"));
+                () -> ConfigUtils.getEnum(config, TestEnum.class, TestEnum.FIRST.name(), "some-enum"));
     }
 }


### PR DESCRIPTION
Do not use Enum in default values, as it broke the build on master. Instead, convert it to enum name (as all enum were handled so far). Once the enum fix lands on master, this can be undone.

Configuration is never "hot", so the back-and-forth conversion, while kinda ugly, is really not a penalty here.
