### PR TITLE
Bug: in certain cases Resolver caused build failure

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -414,7 +414,14 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                         if (result.getExceptions().isEmpty()) {
                             Exception exception =
                                     new ArtifactNotFoundException(request.getArtifact(), (RemoteRepository) null);
-                            result.addException(result.getRepository(), exception);
+                            // Note: result.getRepository() MAY BE null; in cases when
+                            // no artifact was not even tried by any remote repository (snapshot vs repo policy)
+                            // and local repository does not have it either
+                            result.addException(
+                                    result.getRepository() != null
+                                            ? result.getRepository()
+                                            : ArtifactResult.NO_REPOSITORY,
+                                    exception);
                         }
                         RequestTrace trace = RequestTrace.newChild(request.getTrace(), request);
                         artifactResolved(session, trace, request.getArtifact(), null, result.getExceptions());

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -415,7 +415,7 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                             Exception exception =
                                     new ArtifactNotFoundException(request.getArtifact(), (RemoteRepository) null);
                             // Note: result.getRepository() MAY BE null; in cases when
-                            // no artifact was not even tried by any remote repository (snapshot vs repo policy)
+                            // the artifact was not even tried by any remote repository (snapshot vs repo policy)
                             // and local repository does not have it either
                             result.addException(
                                     result.getRepository() != null


### PR DESCRIPTION
While it should not.

The result repository MAY be `null` in certain cases, and that resulted in omission of recording ArtifactNotFoundEx.

While not biggie, later on, if this resolution was in fact happening for a POM, despite descriptor policy would be "ignore missing" (default in Maven 3 and 4), due not recorded ANFex, this error would not be recognized as "missing POM", and would fail the build or artifact collection or anything involving reading descriptor.
