### PR TITLE
Do not check UrlTransporter for open connections after close

### DIFF
--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
@@ -307,13 +307,23 @@ public abstract class HttpTransporterTest {
             closer = null;
         }
         if (httpServer != null) {
-            // check for leaked connections (e.g., due to not closing response body streams)
-            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> httpServer.getNumConnectedEndPoints() == 0);
+            if (closesAllConnectionsOnTransporterClose()) {
+                // check for leaked connections (e.g., due to not closing response body streams)
+                Awaitility.await().atMost(3, TimeUnit.SECONDS).until(() -> httpServer.getNumConnectedEndPoints() == 0);
+            }
             httpServer.stop();
             httpServer = null;
         }
         factory = null;
         session = null;
+    }
+
+    /**
+     * Indicates whether the transporter implementation closes all connections when the transporter is closed.
+     * @return {@code true} if all connections are closed on transporter close, {@code false} otherwise.
+     */
+    protected boolean closesAllConnectionsOnTransporterClose() {
+        return true;
     }
 
     /**

--- a/maven-resolver-transport-url/src/test/java/org/eclipse/aether/transport/url/UrlTransporterTest.java
+++ b/maven-resolver-transport-url/src/test/java/org/eclipse/aether/transport/url/UrlTransporterTest.java
@@ -35,6 +35,12 @@ class UrlTransporterTest extends HttpTransporterTest {
     }
 
     @Override
+    protected boolean closesAllConnectionsOnTransporterClose() {
+        // compare with https://docs.oracle.com/javase/6/docs/technotes/guides/net/http-keepalive.html
+        return false;
+    }
+
+    @Override
     protected Stream<String> supportedCompressionAlgorithms() {
         return Stream.of("gzip", "deflate");
     }
@@ -203,6 +209,11 @@ class UrlTransporterTest extends HttpTransporterTest {
     @Disabled("PUT unsupported")
     @Test
     protected void testPut_Unauthenticated() {}
+
+    @Override
+    @Disabled("PUT unsupported")
+    @Test
+    protected void testPut_WithResponseBody() {}
 
     @Override
     @Disabled


### PR DESCRIPTION
Connection pooling for HttpUrlTransporter is managed by JRE with no way to explicitly close idle connections
(compare with
https://docs.oracle.com/javase/6/docs/technotes/guides/net/http-keepalive.html)

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
