### PR TITLE
Fix: preserve original trace data when stamping re-entrancy marker

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystem.java
@@ -223,7 +223,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (!isReentrant(request.getTrace())) {
             validateSession(session);
             repositorySystemValidator.validateVersionRequest(session, request);
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         return versionResolver.resolveVersion(session, request);
     }
@@ -235,7 +235,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (!isReentrant(request.getTrace())) {
             validateSession(session);
             repositorySystemValidator.validateVersionRangeRequest(session, request);
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         return versionRangeResolver.resolveVersionRange(session, request);
     }
@@ -248,7 +248,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (outermost) {
             validateSession(session);
             repositorySystemValidator.validateArtifactDescriptorRequest(session, request);
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         ArtifactDescriptorResult descriptorResult = artifactDescriptorReader.readArtifactDescriptor(session, request);
         if (outermost) {
@@ -266,7 +266,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (!isReentrant(request.getTrace())) {
             validateSession(session);
             repositorySystemValidator.validateArtifactRequests(session, Collections.singleton(request));
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         return artifactResolver.resolveArtifact(session, request);
     }
@@ -286,7 +286,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
             validateSession(session);
             repositorySystemValidator.validateArtifactRequests(session, requests);
             for (ArtifactRequest request : requests) {
-                request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+                request.setTrace(stampReentrancyMarker(request.getTrace()));
             }
         }
         return artifactResolver.resolveArtifacts(session, requests);
@@ -306,7 +306,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
             validateSession(session);
             repositorySystemValidator.validateMetadataRequests(session, requests);
             for (MetadataRequest request : requests) {
-                request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+                request.setTrace(stampReentrancyMarker(request.getTrace()));
             }
         }
         return metadataResolver.resolveMetadata(session, requests);
@@ -319,7 +319,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (!isReentrant(request.getTrace())) {
             validateSession(session);
             repositorySystemValidator.validateCollectRequest(session, request);
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         return dependencyCollector.collectDependencies(session, request);
     }
@@ -331,7 +331,7 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (!isReentrant(request.getTrace())) {
             validateSession(session);
             repositorySystemValidator.validateDependencyRequest(session, request);
-            request.setTrace(RequestTrace.newChild(request.getTrace(), REPOSITORY_SYSTEM_CALL));
+            request.setTrace(stampReentrancyMarker(request.getTrace()));
         }
         RequestTrace trace = RequestTrace.newChild(request.getTrace(), request);
 
@@ -555,6 +555,21 @@ public class DefaultRepositorySystem implements RepositorySystem {
         if (shutdown.compareAndSet(false, true)) {
             repositorySystemLifecycle.systemEnded();
         }
+    }
+
+    /**
+     * Stamps the {@link #REPOSITORY_SYSTEM_CALL} re-entrancy marker into the trace chain
+     * while preserving the original trace tip data. The marker is inserted <em>below</em>
+     * the tip so that code walking the trace and casting {@code getData()} to its expected
+     * type (e.g. {@code org.apache.maven.artifact.Artifact}) still finds the original data
+     * at the tip rather than the anonymous marker object.
+     *
+     * @param currentTrace the current request trace (may be {@code null})
+     * @return a new trace with the marker inserted and original tip data preserved
+     */
+    private static RequestTrace stampReentrancyMarker(RequestTrace currentTrace) {
+        RequestTrace markerTrace = RequestTrace.newChild(currentTrace, REPOSITORY_SYSTEM_CALL);
+        return currentTrace != null ? RequestTrace.newChild(markerTrace, currentTrace.getData()) : markerTrace;
     }
 
     /**

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
@@ -36,6 +36,7 @@ import org.eclipse.aether.impl.StubArtifactDescriptorReader;
 import org.eclipse.aether.internal.test.util.TestUtils;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.spi.artifact.decorator.ArtifactDecorator;
 import org.eclipse.aether.spi.artifact.decorator.ArtifactDecoratorFactory;
 import org.eclipse.aether.spi.validator.Validator;
@@ -250,5 +251,54 @@ public class DefaultRepositorySystemReentrancyTest {
         system.resolveVersionRange(session, request2);
 
         assertEquals(2, validationCount.get(), "Two independent calls should each validate");
+    }
+
+    @Test
+    void outerCallPreservesOriginalTraceData() throws Exception {
+        // Plugins (e.g. pgpverify-maven-plugin) walk the RequestTrace chain and cast
+        // getData() to Artifact without an instanceof check. The re-entrancy marker
+        // must NOT replace the original tip data — it should be inserted below it.
+        Object originalData = new Object();
+        RequestTrace originalTrace = RequestTrace.newChild(null, originalData);
+
+        VersionRequest request = new VersionRequest();
+        request.setArtifact(new DefaultArtifact("g:a:1"));
+        request.setRepositories(Collections.emptyList());
+        request.setTrace(originalTrace);
+
+        system.resolveVersion(session, request);
+
+        // After the call, the trace tip should still expose the original data
+        RequestTrace resultTrace = request.getTrace();
+        assertNotNull(resultTrace, "Request should have a trace after the call");
+        assertSame(
+                originalData,
+                resultTrace.getData(),
+                "Trace tip data should be the original data, not the re-entrancy marker");
+
+        // The marker should be present deeper in the chain (parent of the tip)
+        RequestTrace parent = resultTrace.getParent();
+        assertNotNull(parent, "Trace should have a parent containing the re-entrancy marker");
+    }
+
+    @Test
+    void outerCallWithNullTraceStillStampsMarker() throws Exception {
+        // When the original trace is null, the marker should still be stamped
+        // (as the tip, since there is no original data to preserve)
+        VersionRangeRequest request =
+                new VersionRangeRequest(new DefaultArtifact("g:a:1.0"), Collections.emptyList(), null);
+        assertNull(request.getTrace(), "Request should start with null trace");
+
+        system.resolveVersionRange(session, request);
+
+        RequestTrace resultTrace = request.getTrace();
+        assertNotNull(resultTrace, "Request should have a trace after the call");
+        // Re-entrant check should detect the marker
+        VersionRangeRequest innerRequest =
+                new VersionRangeRequest(new DefaultArtifact("g:b:2.0"), Collections.emptyList(), null);
+        innerRequest.setTrace(RequestTrace.newChild(resultTrace, "ModelResolver"));
+        int countBefore = validationCount.get();
+        system.resolveVersionRange(session, innerRequest);
+        assertEquals(countBefore, validationCount.get(), "Re-entrant call should skip validation");
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
@@ -279,6 +279,8 @@ public class DefaultRepositorySystemReentrancyTest {
         // The marker should be present deeper in the chain (parent of the tip)
         RequestTrace parent = resultTrace.getParent();
         assertNotNull(parent, "Trace should have a parent containing the re-entrancy marker");
+        assertEquals(
+                "RepositorySystem", parent.getData().toString(), "Parent trace data should be the re-entrancy marker");
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #1957 (commit e29d0cda) added re-entrancy detection to `DefaultRepositorySystem` by stamping a `REPOSITORY_SYSTEM_CALL` marker into the `RequestTrace` chain. However, it placed the marker as the trace **tip data**, replacing whatever was there before (typically an `Artifact` set by Maven core).

Plugins that walk the `RequestTrace` chain and cast `getData()` to their expected type without an `instanceof` check (e.g. `pgpverify-maven-plugin`, `maven-gpg-plugin`) get a `ClassCastException`:

```
ClassCastException: class org.eclipse.aether.internal.impl.DefaultRepositorySystem$1 
cannot be cast to class org.apache.maven.artifact.Artifact
```

This is a regression — both `maven-artifact-plugin` and `maven-gpg-plugin` were passing with rc-5 and are now failing with resolver 2.0.21-SNAPSHOT.

## Fix

Instead of placing the marker as the trace tip, insert it **one level deeper** and re-attach the original tip data on top:

```java
private static RequestTrace stampReentrancyMarker(RequestTrace currentTrace) {
    RequestTrace markerTrace = RequestTrace.newChild(currentTrace, REPOSITORY_SYSTEM_CALL);
    return currentTrace != null
            ? RequestTrace.newChild(markerTrace, currentTrace.getData())
            : markerTrace;
}
```

The `isReentrant()` method is unaffected — it walks the full chain and will still find the marker.

## Test plan

- [x] Added `outerCallPreservesOriginalTraceData` test verifying that original trace data remains at the tip after stamping
- [x] Added `outerCallWithNullTraceStillStampsMarker` test verifying the null-trace case still works correctly for re-entrancy detection
- [x] All existing re-entrancy tests continue to pass
- [x] Full `maven-resolver-impl` test suite passes (454 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)