### PR TITLE
Replace printStackTrace with proper error handling

### DIFF
--- a/maven-resolver-demos/maven-resolver-demo-simple/maven-resolver-demo-simple-settings/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
+++ b/maven-resolver-demos/maven-resolver-demo-simple/maven-resolver-demo-simple-settings/src/main/java/org/apache/maven/resolver/examples/util/Booter.java
@@ -1,0 +1,1 @@
+fatal: path 'maven-resolver-demos/maven-resolver-demo-simple/maven-resolver-demo-simple-settings/src/main/java/org/apache/maven/resolver/examples/util/Booter.java' does not exist in '85c561c2'

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -1,5 +1,3 @@
-package org.eclipse.aether.internal.impl;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -8,9 +6,9 @@ package org.eclipse.aether.internal.impl;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
- *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,29 +16,29 @@ package org.eclipse.aether.internal.impl;
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import static org.junit.Assert.*;
+package org.eclipse.aether.internal.impl;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent.EventType;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.RemoteRepositoryFilterManager;
 import org.eclipse.aether.impl.UpdateCheckManager;
 import org.eclipse.aether.impl.VersionResolver;
-import org.eclipse.aether.internal.impl.DefaultArtifactResolver;
-import org.eclipse.aether.internal.impl.DefaultUpdateCheckManager;
-import org.eclipse.aether.internal.test.util.TestFileProcessor;
+import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
+import org.eclipse.aether.internal.impl.filter.Filters;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
 import org.eclipse.aether.internal.test.util.TestLocalRepositoryManager;
 import org.eclipse.aether.internal.test.util.TestUtils;
@@ -65,17 +63,21 @@ import org.eclipse.aether.resolution.VersionResolutionException;
 import org.eclipse.aether.resolution.VersionResult;
 import org.eclipse.aether.spi.connector.ArtifactDownload;
 import org.eclipse.aether.spi.connector.MetadataDownload;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilter;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.eclipse.aether.transfer.ArtifactTransferException;
 import org.eclipse.aether.util.repository.SimpleResolutionErrorPolicy;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  */
-public class DefaultArtifactResolverTest
-{
+public class DefaultArtifactResolverTest {
     private DefaultArtifactResolver resolver;
 
     private DefaultRepositorySystemSession session;
@@ -88,822 +90,918 @@ public class DefaultArtifactResolverTest
 
     private RecordingRepositoryConnector connector;
 
-    @Before
-    public void setup()
-        throws IOException
-    {
-        UpdateCheckManager updateCheckManager = new StaticUpdateCheckManager( true );
+    private HashMap<String, RemoteRepositoryFilterSource> remoteRepositoryFilterSources;
+
+    private RemoteRepositoryFilterManager remoteRepositoryFilterManager;
+
+    @BeforeEach
+    void setup() {
+        remoteRepositoryFilterSources = new HashMap<>();
+        remoteRepositoryFilterManager = new DefaultRemoteRepositoryFilterManager(remoteRepositoryFilterSources);
+
+        UpdateCheckManager updateCheckManager = new StaticUpdateCheckManager(true);
         repositoryConnectorProvider = new StubRepositoryConnectorProvider();
         VersionResolver versionResolver = new StubVersionResolver();
         session = TestUtils.newSession();
         lrm = (TestLocalRepositoryManager) session.getLocalRepositoryManager();
-        resolver = new DefaultArtifactResolver();
-        resolver.setFileProcessor( new TestFileProcessor() );
-        resolver.setRepositoryEventDispatcher( new StubRepositoryEventDispatcher() );
-        resolver.setVersionResolver( versionResolver );
-        resolver.setUpdateCheckManager( updateCheckManager );
-        resolver.setRepositoryConnectorProvider( repositoryConnectorProvider );
-        resolver.setRemoteRepositoryManager( new StubRemoteRepositoryManager() );
-        resolver.setSyncContextFactory( new StubSyncContextFactory() );
-        resolver.setOfflineController( new DefaultOfflineController() );
+        resolver = setupArtifactResolver(versionResolver, updateCheckManager);
 
-        artifact = new DefaultArtifact( "gid", "aid", "", "ext", "ver" );
+        artifact = new DefaultArtifact("gid", "aid", "", "ext", "ver");
 
         connector = new RecordingRepositoryConnector();
-        repositoryConnectorProvider.setConnector( connector );
+        repositoryConnectorProvider.setConnector(connector);
     }
 
-    @After
-    public void teardown()
-        throws Exception
-    {
-        if ( session.getLocalRepository() != null )
-        {
-            TestFileUtils.deleteFile( session.getLocalRepository().getBasedir() );
+    private DefaultArtifactResolver setupArtifactResolver(
+            VersionResolver versionResolver, UpdateCheckManager updateCheckManager) {
+        return new DefaultArtifactResolver(
+                new PathProcessorSupport(),
+                new StubRepositoryEventDispatcher(),
+                versionResolver,
+                updateCheckManager,
+                repositoryConnectorProvider,
+                new StubRemoteRepositoryManager(),
+                new StubSyncContextFactory(),
+                new DefaultOfflineController(),
+                Collections.emptyMap(),
+                remoteRepositoryFilterManager);
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        if (session.getLocalRepository() != null) {
+            TestFileUtils.deleteFile(session.getLocalRepository().getBasedir());
         }
     }
 
     @Test
-    public void testResolveLocalArtifactSuccessful()
-        throws IOException, ArtifactResolutionException
-    {
-        File tmpFile = TestFileUtils.createTempFile( "tmp" );
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put( ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath() );
-        artifact = artifact.setProperties( properties );
+    void testResolveLocalArtifactSuccessful() throws IOException, ArtifactResolutionException {
+        File tmpFile = TestFileUtils.createTempFile("tmp");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath());
+        artifact = artifact.setProperties(properties);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        ArtifactResult result = resolver.resolveArtifact( session, request );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
-        resolved = resolved.setFile( null );
+        assertNotNull(resolved.getFile());
+        resolved = resolved.setFile(null);
 
-        assertEquals( artifact, resolved );
+        assertEquals(artifact, resolved);
     }
 
     @Test
-    public void testResolveLocalArtifactUnsuccessful()
-        throws IOException, ArtifactResolutionException
-    {
-        File tmpFile = TestFileUtils.createTempFile( "tmp" );
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put( ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath() );
-        artifact = artifact.setProperties( properties );
+    void testResolveLocalArtifactUnsuccessful() throws IOException {
+        File tmpFile = TestFileUtils.createTempFile("tmp");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath());
+        artifact = artifact.setProperties(properties);
 
         tmpFile.delete();
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
 
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
-            assertNotNull( e.getResults() );
-            assertEquals( 1, e.getResults().size() );
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
+            assertNotNull(e.getResults());
+            assertEquals(1, e.getResults().size());
 
-            ArtifactResult result = e.getResults().get( 0 );
+            ArtifactResult result = e.getResults().get(0);
 
-            assertSame( request, result.getRequest() );
+            assertSame(request, result.getRequest());
 
-            assertFalse( result.getExceptions().isEmpty() );
-            assertTrue( result.getExceptions().get( 0 ) instanceof ArtifactNotFoundException );
+            assertFalse(result.getExceptions().isEmpty());
+            assertInstanceOf(
+                    ArtifactNotFoundException.class, result.getExceptions().get(0));
 
             Artifact resolved = result.getArtifact();
-            assertNull( resolved );
+            assertNull(resolved);
         }
-
     }
 
     @Test
-    public void testResolveRemoteArtifact()
-        throws IOException, ArtifactResolutionException
-    {
-        connector.setExpectGet( artifact );
+    void testResolveRemoteArtifact() throws ArtifactResolutionException {
+        connector.setExpectGet(artifact);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        ArtifactResult result = resolver.resolveArtifact( session, request );
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
 
         connector.assertSeenExpected();
     }
 
     @Test
-    public void testResolveRemoteArtifactUnsuccessful()
-        throws IOException, ArtifactResolutionException
-    {
-        RecordingRepositoryConnector connector = new RecordingRepositoryConnector()
-        {
+    void testResolveRemoteArtifactUnsuccessful() {
+        RecordingRepositoryConnector connector = new RecordingRepositoryConnector() {
 
             @Override
-            public void get( Collection<? extends ArtifactDownload> artifactDownloads,
-                             Collection<? extends MetadataDownload> metadataDownloads )
-            {
-                super.get( artifactDownloads, metadataDownloads );
+            public void get(
+                    Collection<? extends ArtifactDownload> artifactDownloads,
+                    Collection<? extends MetadataDownload> metadataDownloads) {
+                super.get(artifactDownloads, metadataDownloads);
                 ArtifactDownload download = artifactDownloads.iterator().next();
                 ArtifactTransferException exception =
-                    new ArtifactNotFoundException( download.getArtifact(), null, "not found" );
-                download.setException( exception );
+                        new ArtifactNotFoundException(download.getArtifact(), null, "not found");
+                download.setException(exception);
             }
-
         };
 
-        connector.setExpectGet( artifact );
-        repositoryConnectorProvider.setConnector( connector );
+        connector.setExpectGet(artifact);
+        repositoryConnectorProvider.setConnector(connector);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
             connector.assertSeenExpected();
-            assertNotNull( e.getResults() );
-            assertEquals( 1, e.getResults().size() );
+            assertNotNull(e.getResults());
+            assertEquals(1, e.getResults().size());
 
-            ArtifactResult result = e.getResults().get( 0 );
+            ArtifactResult result = e.getResults().get(0);
 
-            assertSame( request, result.getRequest() );
+            assertSame(request, result.getRequest());
 
-            assertFalse( result.getExceptions().isEmpty() );
-            assertTrue( result.getExceptions().get( 0 ) instanceof ArtifactNotFoundException );
+            assertFalse(result.getExceptions().isEmpty());
+            assertInstanceOf(
+                    ArtifactNotFoundException.class, result.getExceptions().get(0));
 
             Artifact resolved = result.getArtifact();
-            assertNull( resolved );
+            assertNull(resolved);
         }
-
     }
 
     @Test
-    public void testArtifactNotFoundCache()
-        throws Exception
-    {
-        RecordingRepositoryConnector connector = new RecordingRepositoryConnector()
-        {
+    void testResolveRemoteArtifactAlwaysAcceptFilter() throws ArtifactResolutionException {
+        remoteRepositoryFilterSources.put("filter1", Filters.neverAcceptFrom("invalid repo id"));
+        remoteRepositoryFilterSources.put("filter2", Filters.alwaysAccept());
+        connector.setExpectGet(artifact);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        ArtifactResult result = resolver.resolveArtifact(session, request);
+
+        assertTrue(result.getExceptions().isEmpty());
+
+        Artifact resolved = result.getArtifact();
+        assertNotNull(resolved.getFile());
+
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
+
+        connector.assertSeenExpected();
+    }
+
+    @Test
+    void testResolveRemoteArtifactNeverAcceptFilter() {
+        remoteRepositoryFilterSources.put("filter1", Filters.neverAcceptFrom("invalid repo id"));
+        remoteRepositoryFilterSources.put("filter2", Filters.neverAccept());
+        // connector.setExpectGet( artifact ); // should not see it
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "project");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
+            connector.assertSeenExpected();
+            assertNotNull(e.getResults());
+            assertEquals(1, e.getResults().size());
+
+            ArtifactResult result = e.getResults().get(0);
+
+            assertSame(request, result.getRequest());
+
+            assertFalse(result.getExceptions().isEmpty());
+            assertInstanceOf(
+                    ArtifactNotFoundException.class, result.getExceptions().get(0));
+            assertEquals(
+                    "never-accept: never accept", result.getExceptions().get(0).getMessage());
+
+            Artifact resolved = result.getArtifact();
+            assertNull(resolved);
+        }
+    }
+
+    @Test
+    void testResolveRemoteArtifactAlwaysAcceptFromRepoFilter() throws ArtifactResolutionException {
+        remoteRepositoryFilterSources.put("filter1", Filters.alwaysAcceptFrom("id"));
+        connector.setExpectGet(artifact);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        ArtifactResult result = resolver.resolveArtifact(session, request);
+
+        assertTrue(result.getExceptions().isEmpty());
+
+        Artifact resolved = result.getArtifact();
+        assertNotNull(resolved.getFile());
+
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
+
+        connector.assertSeenExpected();
+    }
+
+    @Test
+    void testResolveRemoteArtifactNeverAcceptFilterFromRepo() {
+        remoteRepositoryFilterSources.put("filter1", Filters.neverAcceptFrom("id"));
+        // connector.setExpectGet( artifact ); // should not see it
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "project");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
+            connector.assertSeenExpected();
+            assertNotNull(e.getResults());
+            assertEquals(1, e.getResults().size());
+
+            ArtifactResult result = e.getResults().get(0);
+
+            assertSame(request, result.getRequest());
+
+            assertFalse(result.getExceptions().isEmpty());
+            assertInstanceOf(
+                    ArtifactNotFoundException.class, result.getExceptions().get(0));
+            assertEquals(
+                    "never-accept-id: matched", result.getExceptions().get(0).getMessage());
+
+            Artifact resolved = result.getArtifact();
+            assertNull(resolved);
+        }
+    }
+
+    @Test
+    void testArtifactNotFoundCache() throws Exception {
+        RecordingRepositoryConnector connector = new RecordingRepositoryConnector() {
             @Override
-            public void get( Collection<? extends ArtifactDownload> artifactDownloads,
-                             Collection<? extends MetadataDownload> metadataDownloads )
-            {
-                super.get( artifactDownloads, metadataDownloads );
-                for ( ArtifactDownload download : artifactDownloads )
-                {
+            public void get(
+                    Collection<? extends ArtifactDownload> artifactDownloads,
+                    Collection<? extends MetadataDownload> metadataDownloads) {
+                super.get(artifactDownloads, metadataDownloads);
+                for (ArtifactDownload download : artifactDownloads) {
                     download.getFile().delete();
                     ArtifactTransferException exception =
-                        new ArtifactNotFoundException( download.getArtifact(), null, "not found" );
-                    download.setException( exception );
+                            new ArtifactNotFoundException(download.getArtifact(), null, "not found");
+                    download.setException(exception);
                 }
             }
         };
 
-        repositoryConnectorProvider.setConnector( connector );
-        resolver.setUpdateCheckManager( new DefaultUpdateCheckManager().setUpdatePolicyAnalyzer( new DefaultUpdatePolicyAnalyzer() ) );
+        repositoryConnectorProvider.setConnector(connector);
+        resolver = setupArtifactResolver(
+                new StubVersionResolver(),
+                new DefaultUpdateCheckManager(
+                        new TrackingFileManagerSupplier().get(),
+                        new DefaultUpdatePolicyAnalyzer(),
+                        new DefaultPathProcessor()));
 
-        session.setResolutionErrorPolicy( new SimpleResolutionErrorPolicy( true, false ) );
-        session.setUpdatePolicy( RepositoryPolicy.UPDATE_POLICY_NEVER );
+        session.setResolutionErrorPolicy(new SimpleResolutionErrorPolicy(true, false));
+        session.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_NEVER);
 
-        RemoteRepository remoteRepo = new RemoteRepository.Builder( "id", "default", "file:///" ).build();
+        RemoteRepository remoteRepo = new RemoteRepository.Builder("id", "default", "file:///").build();
 
         Artifact artifact1 = artifact;
-        Artifact artifact2 = artifact.setVersion( "ver2" );
+        Artifact artifact2 = artifact.setVersion("ver2");
 
-        ArtifactRequest request1 = new ArtifactRequest( artifact1, Arrays.asList( remoteRepo ), "" );
-        ArtifactRequest request2 = new ArtifactRequest( artifact2, Arrays.asList( remoteRepo ), "" );
+        ArtifactRequest request1 = new ArtifactRequest(artifact1, Arrays.asList(remoteRepo), "");
+        ArtifactRequest request2 = new ArtifactRequest(artifact2, Arrays.asList(remoteRepo), "");
 
-        connector.setExpectGet( new Artifact[] { artifact1, artifact2 } );
-        try
-        {
-            resolver.resolveArtifacts( session, Arrays.asList( request1, request2 ) );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        connector.setExpectGet(artifact1, artifact2);
+        try {
+            resolver.resolveArtifacts(session, Arrays.asList(request1, request2));
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
             connector.assertSeenExpected();
         }
 
-        TestFileUtils.writeString( new File( lrm.getRepository().getBasedir(), lrm.getPathForLocalArtifact( artifact2 ) ),
-                             "artifact" );
-        lrm.setArtifactAvailability( artifact2, false );
+        TestFileUtils.writeString(
+                new File(lrm.getRepository().getBasedir(), lrm.getPathForLocalArtifact(artifact2)), "artifact");
+        lrm.setArtifactAvailability(artifact2, false);
 
-        DefaultUpdateCheckManagerTest.resetSessionData( session );
+        DefaultUpdateCheckManagerTest.resetSessionData(session);
         connector.resetActual();
-        connector.setExpectGet( new Artifact[0] );
-        try
-        {
-            resolver.resolveArtifacts( session, Arrays.asList( request1, request2 ) );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        connector.setExpectGet(new Artifact[0]);
+        try {
+            resolver.resolveArtifacts(session, Arrays.asList(request1, request2));
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
             connector.assertSeenExpected();
-            for ( ArtifactResult result : e.getResults() )
-            {
-                Throwable t = result.getExceptions().get( 0 );
-                assertEquals( t.toString(), true, t instanceof ArtifactNotFoundException );
-                assertEquals( t.toString(), true, t.getMessage().contains( "cached" ) );
+            for (ArtifactResult result : e.getResults()) {
+                Exception ex = result.getExceptions().get(0);
+                assertInstanceOf(ArtifactNotFoundException.class, ex, ex.toString());
+                assertTrue(ex.getMessage().contains("cached"), ex.toString());
             }
         }
     }
 
     @Test
-    public void testResolveFromWorkspace()
-        throws IOException, ArtifactResolutionException
-    {
-        WorkspaceReader workspace = new WorkspaceReader()
-        {
+    void testResolveFromWorkspace() throws IOException, ArtifactResolutionException {
+        WorkspaceReader workspace = new WorkspaceReader() {
 
-            public WorkspaceRepository getRepository()
-            {
-                return new WorkspaceRepository( "default" );
+            public WorkspaceRepository getRepository() {
+                return new WorkspaceRepository("default");
             }
 
-            public List<String> findVersions( Artifact artifact )
-            {
-                return Arrays.asList( artifact.getVersion() );
+            public List<String> findVersions(Artifact artifact) {
+                return Arrays.asList(artifact.getVersion());
             }
 
-            public File findArtifact( Artifact artifact )
-            {
-                try
-                {
-                    return TestFileUtils.createTempFile( artifact.toString() );
-                }
-                catch ( IOException e )
-                {
-                    throw new RuntimeException( e.getMessage(), e );
+            public File findArtifact(Artifact artifact) {
+                try {
+                    return TestFileUtils.createTempFile(artifact.toString());
+                } catch (IOException e) {
+                    throw new RuntimeException(e.getMessage(), e);
                 }
             }
         };
-        session.setWorkspaceReader( workspace );
+        session.setWorkspaceReader(workspace);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        ArtifactResult result = resolver.resolveArtifact( session, request );
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        assertEquals( resolved.toString(), TestFileUtils.readString( resolved.getFile() ) );
+        assertEquals(resolved.toString(), TestFileUtils.readString(resolved.getFile()));
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
 
         connector.assertSeenExpected();
     }
 
     @Test
-    public void testResolveFromWorkspaceFallbackToRepository()
-        throws IOException, ArtifactResolutionException
-    {
-        WorkspaceReader workspace = new WorkspaceReader()
-        {
+    void testResolveFromWorkspaceFallbackToRepository() throws ArtifactResolutionException {
+        WorkspaceReader workspace = new WorkspaceReader() {
 
-            public WorkspaceRepository getRepository()
-            {
-                return new WorkspaceRepository( "default" );
+            public WorkspaceRepository getRepository() {
+                return new WorkspaceRepository("default");
             }
 
-            public List<String> findVersions( Artifact artifact )
-            {
-                return Arrays.asList( artifact.getVersion() );
+            public List<String> findVersions(Artifact artifact) {
+                return Arrays.asList(artifact.getVersion());
             }
 
-            public File findArtifact( Artifact artifact )
-            {
+            public File findArtifact(Artifact artifact) {
                 return null;
             }
         };
-        session.setWorkspaceReader( workspace );
+        session.setWorkspaceReader(workspace);
 
-        connector.setExpectGet( artifact );
-        repositoryConnectorProvider.setConnector( connector );
+        connector.setExpectGet(artifact);
+        repositoryConnectorProvider.setConnector(connector);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        ArtifactResult result = resolver.resolveArtifact( session, request );
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        assertTrue( "exception on resolveArtifact", result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty(), "exception on resolveArtifact");
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
 
         connector.assertSeenExpected();
     }
 
     @Test
-    public void testRepositoryEventsSuccessfulLocal()
-        throws ArtifactResolutionException, IOException
-    {
+    void testRepositoryEventsSuccessfulLocal() throws ArtifactResolutionException, IOException {
         RecordingRepositoryListener listener = new RecordingRepositoryListener();
-        session.setRepositoryListener( listener );
+        session.setRepositoryListener(listener);
 
-        File tmpFile = TestFileUtils.createTempFile( "tmp" );
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put( ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath() );
-        artifact = artifact.setProperties( properties );
+        File tmpFile = TestFileUtils.createTempFile("tmp");
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ArtifactProperties.LOCAL_PATH, tmpFile.getAbsolutePath());
+        artifact = artifact.setProperties(properties);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        resolver.resolveArtifact( session, request );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        resolver.resolveArtifact(session, request);
 
         List<RepositoryEvent> events = listener.getEvents();
-        assertEquals( 2, events.size() );
-        RepositoryEvent event = events.get( 0 );
-        assertEquals( EventType.ARTIFACT_RESOLVING, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact() );
+        assertEquals(2, events.size());
+        RepositoryEvent event = events.get(0);
+        assertEquals(EventType.ARTIFACT_RESOLVING, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact());
 
-        event = events.get( 1 );
-        assertEquals( EventType.ARTIFACT_RESOLVED, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact().setFile( null ) );
+        event = events.get(1);
+        assertEquals(EventType.ARTIFACT_RESOLVED, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact().setFile(null));
     }
 
     @Test
-    public void testRepositoryEventsUnsuccessfulLocal()
-        throws IOException
-    {
+    void testRepositoryEventsUnsuccessfulLocal() {
         RecordingRepositoryListener listener = new RecordingRepositoryListener();
-        session.setRepositoryListener( listener );
+        session.setRepositoryListener(listener);
 
-        Map<String, String> properties = new HashMap<String, String>();
-        properties.put( ArtifactProperties.LOCAL_PATH, "doesnotexist" );
-        artifact = artifact.setProperties( properties );
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ArtifactProperties.LOCAL_PATH, "doesnotexist");
+        artifact = artifact.setProperties(properties);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException ignored) {
         }
 
         List<RepositoryEvent> events = listener.getEvents();
-        assertEquals( 2, events.size() );
+        assertEquals(2, events.size());
 
-        RepositoryEvent event = events.get( 0 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVING, event.getType() );
+        RepositoryEvent event = events.get(0);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVING, event.getType());
 
-        event = events.get( 1 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVED, event.getType() );
-        assertNotNull( event.getException() );
-        assertEquals( 1, event.getExceptions().size() );
-
+        event = events.get(1);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVED, event.getType());
+        assertNotNull(event.getException());
+        assertEquals(1, event.getExceptions().size());
     }
 
     @Test
-    public void testRepositoryEventsSuccessfulRemote()
-        throws ArtifactResolutionException
-    {
+    void testRepositoryEventsSuccessfulRemote() throws ArtifactResolutionException {
         RecordingRepositoryListener listener = new RecordingRepositoryListener();
-        session.setRepositoryListener( listener );
+        session.setRepositoryListener(listener);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        resolver.resolveArtifact( session, request );
+        resolver.resolveArtifact(session, request);
 
         List<RepositoryEvent> events = listener.getEvents();
-        assertEquals( events.toString(), 4, events.size() );
-        RepositoryEvent event = events.get( 0 );
-        assertEquals( EventType.ARTIFACT_RESOLVING, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact() );
+        assertEquals(4, events.size(), events.toString());
+        RepositoryEvent event = events.get(0);
+        assertEquals(EventType.ARTIFACT_RESOLVING, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact());
 
-        event = events.get( 1 );
-        assertEquals( EventType.ARTIFACT_DOWNLOADING, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact().setFile( null ) );
+        event = events.get(1);
+        assertEquals(EventType.ARTIFACT_DOWNLOADING, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact().setFile(null));
 
-        event = events.get( 2 );
-        assertEquals( EventType.ARTIFACT_DOWNLOADED, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact().setFile( null ) );
+        event = events.get(2);
+        assertEquals(EventType.ARTIFACT_DOWNLOADED, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact().setFile(null));
 
-        event = events.get( 3 );
-        assertEquals( EventType.ARTIFACT_RESOLVED, event.getType() );
-        assertNull( event.getException() );
-        assertEquals( artifact, event.getArtifact().setFile( null ) );
+        event = events.get(3);
+        assertEquals(EventType.ARTIFACT_RESOLVED, event.getType());
+        assertNull(event.getException());
+        assertEquals(artifact, event.getArtifact().setFile(null));
     }
 
     @Test
-    public void testRepositoryEventsUnsuccessfulRemote()
-        throws IOException, ArtifactResolutionException
-    {
-        RecordingRepositoryConnector connector = new RecordingRepositoryConnector()
-        {
+    void testRepositoryEventsUnsuccessfulRemote() {
+        RecordingRepositoryConnector connector = new RecordingRepositoryConnector() {
 
             @Override
-            public void get( Collection<? extends ArtifactDownload> artifactDownloads,
-                             Collection<? extends MetadataDownload> metadataDownloads )
-            {
-                super.get( artifactDownloads, metadataDownloads );
+            public void get(
+                    Collection<? extends ArtifactDownload> artifactDownloads,
+                    Collection<? extends MetadataDownload> metadataDownloads) {
+                super.get(artifactDownloads, metadataDownloads);
                 ArtifactDownload download = artifactDownloads.iterator().next();
                 ArtifactTransferException exception =
-                    new ArtifactNotFoundException( download.getArtifact(), null, "not found" );
-                download.setException( exception );
+                        new ArtifactNotFoundException(download.getArtifact(), null, "not found");
+                download.setException(exception);
             }
-
         };
-        repositoryConnectorProvider.setConnector( connector );
+        repositoryConnectorProvider.setConnector(connector);
 
         RecordingRepositoryListener listener = new RecordingRepositoryListener();
-        session.setRepositoryListener( listener );
+        session.setRepositoryListener(listener);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException ignored) {
         }
 
         List<RepositoryEvent> events = listener.getEvents();
-        assertEquals( events.toString(), 4, events.size() );
+        assertEquals(4, events.size(), events.toString());
 
-        RepositoryEvent event = events.get( 0 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVING, event.getType() );
+        RepositoryEvent event = events.get(0);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVING, event.getType());
 
-        event = events.get( 1 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_DOWNLOADING, event.getType() );
+        event = events.get(1);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_DOWNLOADING, event.getType());
 
-        event = events.get( 2 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_DOWNLOADED, event.getType() );
-        assertNotNull( event.getException() );
-        assertEquals( 1, event.getExceptions().size() );
+        event = events.get(2);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_DOWNLOADED, event.getType());
+        assertNotNull(event.getException());
+        assertEquals(1, event.getExceptions().size());
 
-        event = events.get( 3 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVED, event.getType() );
-        assertNotNull( event.getException() );
-        assertEquals( 1, event.getExceptions().size() );
+        event = events.get(3);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVED, event.getType());
+        assertNotNull(event.getException());
+        assertEquals(1, event.getExceptions().size());
     }
 
     @Test
-    public void testVersionResolverFails()
-    {
-        resolver.setVersionResolver( new VersionResolver()
-        {
+    void testVersionResolverFails() {
+        resolver = setupArtifactResolver(
+                new VersionResolver() {
+                    @Override
+                    public VersionResult resolveVersion(RepositorySystemSession session, VersionRequest request)
+                            throws VersionResolutionException {
+                        throw new VersionResolutionException(new VersionResult(request));
+                    }
+                },
+                new StaticUpdateCheckManager(true));
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
-                throws VersionResolutionException
-            {
-                throw new VersionResolutionException( new VersionResult( request ) );
-            }
-        } );
-
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException e) {
             connector.assertSeenExpected();
-            assertNotNull( e.getResults() );
-            assertEquals( 1, e.getResults().size() );
+            assertNotNull(e.getResults());
+            assertEquals(1, e.getResults().size());
 
-            ArtifactResult result = e.getResults().get( 0 );
+            ArtifactResult result = e.getResults().get(0);
 
-            assertSame( request, result.getRequest() );
+            assertSame(request, result.getRequest());
 
-            assertFalse( result.getExceptions().isEmpty() );
-            assertTrue( result.getExceptions().get( 0 ) instanceof VersionResolutionException );
+            assertFalse(result.getExceptions().isEmpty());
+            assertInstanceOf(
+                    VersionResolutionException.class, result.getExceptions().get(0));
 
             Artifact resolved = result.getArtifact();
-            assertNull( resolved );
+            assertNull(resolved);
         }
     }
 
     @Test
-    public void testRepositoryEventsOnVersionResolverFail()
-    {
-        resolver.setVersionResolver( new VersionResolver()
-        {
-
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
-                throws VersionResolutionException
-            {
-                throw new VersionResolutionException( new VersionResult( request ) );
-            }
-        } );
+    void testRepositoryEventsOnVersionResolverFail() {
+        resolver = setupArtifactResolver(
+                new VersionResolver() {
+                    @Override
+                    public VersionResult resolveVersion(RepositorySystemSession session, VersionRequest request)
+                            throws VersionResolutionException {
+                        throw new VersionResolutionException(new VersionResult(request));
+                    }
+                },
+                new StaticUpdateCheckManager(true));
 
         RecordingRepositoryListener listener = new RecordingRepositoryListener();
-        session.setRepositoryListener( listener );
+        session.setRepositoryListener(listener);
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        try
-        {
-            resolver.resolveArtifact( session, request );
-            fail( "expected exception" );
-        }
-        catch ( ArtifactResolutionException e )
-        {
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("expected exception");
+        } catch (ArtifactResolutionException ignored) {
         }
 
         List<RepositoryEvent> events = listener.getEvents();
-        assertEquals( 2, events.size() );
+        assertEquals(2, events.size());
 
-        RepositoryEvent event = events.get( 0 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVING, event.getType() );
+        RepositoryEvent event = events.get(0);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVING, event.getType());
 
-        event = events.get( 1 );
-        assertEquals( artifact, event.getArtifact() );
-        assertEquals( EventType.ARTIFACT_RESOLVED, event.getType() );
-        assertNotNull( event.getException() );
-        assertEquals( 1, event.getExceptions().size() );
+        event = events.get(1);
+        assertEquals(artifact, event.getArtifact());
+        assertEquals(EventType.ARTIFACT_RESOLVED, event.getType());
+        assertNotNull(event.getException());
+        assertEquals(1, event.getExceptions().size());
     }
 
     @Test
-    public void testLocalArtifactAvailable()
-        throws ArtifactResolutionException
-    {
-        session.setLocalRepositoryManager( new LocalRepositoryManager()
-        {
+    void testLocalArtifactAvailable() throws ArtifactResolutionException {
+        session.setLocalRepositoryManager(new LocalRepositoryManager() {
 
-            public LocalRepository getRepository()
-            {
+            public LocalRepository getRepository() {
                 return null;
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
-            {
+            public String getPathForRemoteMetadata(Metadata metadata, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
-            {
+            public String getPathForRemoteArtifact(Artifact artifact, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
-            {
+            public String getPathForLocalMetadata(Metadata metadata) {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
-            {
+            public String getPathForLocalArtifact(Artifact artifact) {
                 return null;
             }
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
-            {
+            public LocalArtifactResult find(RepositorySystemSession session, LocalArtifactRequest request) {
 
-                LocalArtifactResult result = new LocalArtifactResult( request );
-                result.setAvailable( true );
-                try
-                {
-                    result.setFile( TestFileUtils.createTempFile( "" ) );
-                }
-                catch ( IOException e )
-                {
-                    e.printStackTrace();
+                LocalArtifactResult result = new LocalArtifactResult(request);
+                result.setAvailable(true);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
-            {
-            }
+            public void add(RepositorySystemSession session, LocalArtifactRegistration request) {}
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
-            {
-                LocalMetadataResult result = new LocalMetadataResult( request );
-                try
-                {
-                    result.setFile( TestFileUtils.createTempFile( "" ) );
-                }
-                catch ( IOException e )
-                {
-                    e.printStackTrace();
+            public LocalMetadataResult find(RepositorySystemSession session, LocalMetadataRequest request) {
+                LocalMetadataResult result = new LocalMetadataResult(request);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
-            {
-            }
-        } );
+            public void add(RepositorySystemSession session, LocalMetadataRegistration request) {}
+        });
 
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-        ArtifactResult result = resolver.resolveArtifact( session, request );
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
-
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
     }
 
     @Test
-    public void testFindInLocalRepositoryWhenVersionWasFoundInLocalRepository()
-        throws ArtifactResolutionException
-    {
-        session.setLocalRepositoryManager( new LocalRepositoryManager()
-        {
+    void testFindInLocalRepositoryWhenVersionWasFoundInLocalRepository() throws ArtifactResolutionException {
+        session.setLocalRepositoryManager(new LocalRepositoryManager() {
 
-            public LocalRepository getRepository()
-            {
+            public LocalRepository getRepository() {
+                return new LocalRepository(lrm.getRepository().getBasePath());
+            }
+
+            public String getPathForRemoteMetadata(Metadata metadata, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
-            {
+            public String getPathForRemoteArtifact(Artifact artifact, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
-            {
+            public String getPathForLocalMetadata(Metadata metadata) {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
-            {
+            public String getPathForLocalArtifact(Artifact artifact) {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
-            {
-                return null;
-            }
+            public LocalArtifactResult find(RepositorySystemSession session, LocalArtifactRequest request) {
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
-            {
-
-                LocalArtifactResult result = new LocalArtifactResult( request );
-                result.setAvailable( false );
-                try
-                {
-                    result.setFile( TestFileUtils.createTempFile( "" ) );
-                }
-                catch ( IOException e )
-                {
-                    e.printStackTrace();
+                LocalArtifactResult result = new LocalArtifactResult(request);
+                result.setAvailable(false);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
-            {
+            public void add(RepositorySystemSession session, LocalArtifactRegistration request) {}
+
+            public LocalMetadataResult find(RepositorySystemSession session, LocalMetadataRequest request) {
+                return new LocalMetadataResult(request);
             }
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
-            {
-                LocalMetadataResult result = new LocalMetadataResult( request );
-                return result;
-            }
+            public void add(RepositorySystemSession session, LocalMetadataRegistration request) {}
+        });
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
-            {
-            }
-        } );
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
-        request.addRepository( new RemoteRepository.Builder( "id", "default", "file:///" ).build() );
+        resolver = setupArtifactResolver(
+                new VersionResolver() {
+                    @Override
+                    public VersionResult resolveVersion(RepositorySystemSession session, VersionRequest request) {
+                        return new VersionResult(request)
+                                .setRepository(new LocalRepository("id"))
+                                .setVersion(request.getArtifact().getVersion());
+                    }
+                },
+                new StaticUpdateCheckManager(true));
 
-        resolver.setVersionResolver( new VersionResolver()
-        {
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
-                throws VersionResolutionException
-            {
-                return new VersionResult( request ).setRepository( new LocalRepository( "id" ) ).setVersion( request.getArtifact().getVersion() );
-            }
-        } );
-        ArtifactResult result = resolver.resolveArtifact( session, request );
-
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
     }
 
     @Test
-    public void testFindInLocalRepositoryWhenVersionRangeWasResolvedFromLocalRepository()
-        throws ArtifactResolutionException
-    {
-        session.setLocalRepositoryManager( new LocalRepositoryManager()
-        {
+    void testFindInLocalRepositoryWhenVersionRangeWasResolvedFromLocalRepository() throws ArtifactResolutionException {
+        session.setLocalRepositoryManager(new LocalRepositoryManager() {
 
-            public LocalRepository getRepository()
-            {
+            public LocalRepository getRepository() {
+                return new LocalRepository(lrm.getRepository().getBasePath());
+            }
+
+            public String getPathForRemoteMetadata(Metadata metadata, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForRemoteMetadata( Metadata metadata, RemoteRepository repository, String context )
-            {
+            public String getPathForRemoteArtifact(Artifact artifact, RemoteRepository repository, String context) {
                 return null;
             }
 
-            public String getPathForRemoteArtifact( Artifact artifact, RemoteRepository repository, String context )
-            {
+            public String getPathForLocalMetadata(Metadata metadata) {
                 return null;
             }
 
-            public String getPathForLocalMetadata( Metadata metadata )
-            {
+            public String getPathForLocalArtifact(Artifact artifact) {
                 return null;
             }
 
-            public String getPathForLocalArtifact( Artifact artifact )
-            {
-                return null;
-            }
+            public LocalArtifactResult find(RepositorySystemSession session, LocalArtifactRequest request) {
 
-            public LocalArtifactResult find( RepositorySystemSession session, LocalArtifactRequest request )
-            {
-
-                LocalArtifactResult result = new LocalArtifactResult( request );
-                result.setAvailable( false );
-                try
-                {
-                    result.setFile( TestFileUtils.createTempFile( "" ) );
-                }
-                catch ( IOException e )
-                {
-                    e.printStackTrace();
+                LocalArtifactResult result = new LocalArtifactResult(request);
+                result.setAvailable(false);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
 
-            public void add( RepositorySystemSession session, LocalArtifactRegistration request )
-            {
+            public void add(RepositorySystemSession session, LocalArtifactRegistration request) {}
+
+            public LocalMetadataResult find(RepositorySystemSession session, LocalMetadataRequest request) {
+                return new LocalMetadataResult(request);
             }
 
-            public LocalMetadataResult find( RepositorySystemSession session, LocalMetadataRequest request )
-            {
-                LocalMetadataResult result = new LocalMetadataResult( request );
-                return result;
-            }
+            public void add(RepositorySystemSession session, LocalMetadataRegistration request) {}
+        });
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
 
-            public void add( RepositorySystemSession session, LocalMetadataRegistration request )
-            {
-            }
+        resolver = setupArtifactResolver(
+                new VersionResolver() {
+                    @Override
+                    public VersionResult resolveVersion(RepositorySystemSession session, VersionRequest request) {
+                        return new VersionResult(request)
+                                .setVersion(request.getArtifact().getVersion());
+                    }
+                },
+                new StaticUpdateCheckManager(true));
 
-        } );
-        ArtifactRequest request = new ArtifactRequest( artifact, null, "" );
+        ArtifactResult result = resolver.resolveArtifact(session, request);
 
-        resolver.setVersionResolver( new VersionResolver()
-        {
-
-            public VersionResult resolveVersion( RepositorySystemSession session, VersionRequest request )
-                throws VersionResolutionException
-            {
-                return new VersionResult( request ).setVersion( request.getArtifact().getVersion() );
-            }
-        } );
-        ArtifactResult result = resolver.resolveArtifact( session, request );
-
-        assertTrue( result.getExceptions().isEmpty() );
+        assertTrue(result.getExceptions().isEmpty());
 
         Artifact resolved = result.getArtifact();
-        assertNotNull( resolved.getFile() );
+        assertNotNull(resolved.getFile());
 
-        resolved = resolved.setFile( null );
-        assertEquals( artifact, resolved );
+        resolved = resolved.setFile(null);
+        assertEquals(artifact, resolved);
     }
 
+    @Test
+    void testCachedButFilteredOut() throws ArtifactResolutionException {
+        remoteRepositoryFilterManager = new RemoteRepositoryFilterManager() {
+            @Override
+            public RemoteRepositoryFilter getRemoteRepositoryFilter(RepositorySystemSession session) {
+                return new RemoteRepositoryFilter() {
+                    @Override
+                    public Result acceptArtifact(RemoteRepository remoteRepository, Artifact artifact) {
+                        return new Result() {
+                            @Override
+                            public boolean isAccepted() {
+                                return false;
+                            }
+
+                            @Override
+                            public String reasoning() {
+                                return "REFUSED";
+                            }
+                        };
+                    }
+
+                    @Override
+                    public Result acceptMetadata(RemoteRepository remoteRepository, Metadata metadata) {
+                        return new Result() {
+                            @Override
+                            public boolean isAccepted() {
+                                return true;
+                            }
+
+                            @Override
+                            public String reasoning() {
+                                return "OK";
+                            }
+                        };
+                    }
+                };
+            }
+        };
+        session.setLocalRepositoryManager(new LocalRepositoryManager() {
+            public LocalRepository getRepository() {
+                return null;
+            }
+
+            public String getPathForRemoteMetadata(Metadata metadata, RemoteRepository repository, String context) {
+                return null;
+            }
+
+            public String getPathForRemoteArtifact(Artifact artifact, RemoteRepository repository, String context) {
+                return null;
+            }
+
+            public String getPathForLocalMetadata(Metadata metadata) {
+                return null;
+            }
+
+            public String getPathForLocalArtifact(Artifact artifact) {
+                return null;
+            }
+
+            public LocalArtifactResult find(RepositorySystemSession session, LocalArtifactRequest request) {
+                LocalArtifactResult result = new LocalArtifactResult(request);
+                result.setAvailable(false);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                return result;
+            }
+
+            public void add(RepositorySystemSession session, LocalArtifactRegistration request) {}
+
+            public LocalMetadataResult find(RepositorySystemSession session, LocalMetadataRequest request) {
+                LocalMetadataResult result = new LocalMetadataResult(request);
+                try {
+                    result.setFile(TestFileUtils.createTempFile(""));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                return result;
+            }
+
+            public void add(RepositorySystemSession session, LocalMetadataRegistration request) {}
+        });
+
+        // rebuild resolver with our filter
+        resolver = setupArtifactResolver(new StubVersionResolver(), new StaticUpdateCheckManager(false));
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        // resolver should throw
+        ArtifactResolutionException ex =
+                assertThrows(ArtifactResolutionException.class, () -> resolver.resolveArtifact(session, request));
+        // message should contain present=true, available=false, filter message
+        assertTrue(ex.getMessage().contains("gid:aid:ext:ver (present, but unavailable): REFUSED"));
+    }
 }

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
@@ -1,0 +1,1 @@
+fatal: path 'maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultRepositoryCacheTest.java' does not exist in '85c561c2'

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultSessionDataTest.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultSessionDataTest.java
@@ -1,0 +1,1 @@
+fatal: path 'maven-resolver-test-util/src/main/java/org/eclipse/aether/DefaultSessionDataTest.java' does not exist in '85c561c2'


### PR DESCRIPTION
Fixes #1999

Changes:
- **DefaultArtifactResolverTest**: Replace `e.printStackTrace()` with `throw new RuntimeException(e)` so tests properly fail on IO errors instead of silently printing
- **DefaultSessionDataTest**: Remove redundant `t.printStackTrace()` — error already captured in AtomicReference and asserted
- **DefaultRepositoryCacheTest**: Same as DefaultSessionDataTest
- **Booter**: Use `System.err.println` for a user-friendly error message instead of raw stack trace