### PR TITLE
Enh: Allow validator factory to abstain

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
@@ -73,10 +73,10 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     private Validator newInstance(RepositorySystemSession session, String name, ValidatorFactory factory) {
         if (session.getCache() != null) {
             return ((ConcurrentHashMap<String, Validator>)
+                            session.getCache().computeIfAbsent(session, SESSION_VALIDATORS, ConcurrentHashMap::new))
+                    .computeIfAbsent(name, k -> requireNonNull(factory.newInstance(session)));
         } else {
             return requireNonNull(factory.newInstance(session));
-        }
-            return factory.newInstance(session);
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
@@ -229,7 +229,7 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
                 }
                 for (Dependency managedDependency : request.getManagedDependencies()) {
                     try {
-                        validator.validateDependency(managedDependency);
+                        validator.validateManagedDependency(managedDependency);
                     } catch (Exception e) {
                         exceptions.add(e);
                     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.Keys;
@@ -53,10 +54,10 @@ import static java.util.Objects.requireNonNull;
 @Named
 public class DefaultRepositorySystemValidator implements RepositorySystemValidator {
     private static final Object SESSION_VALIDATORS = Keys.of(DefaultRepositorySystemValidator.class, "validators");
-    private final List<ValidatorFactory> validatorFactories;
+    private final Map<String, ValidatorFactory> validatorFactories;
 
     @Inject
-    public DefaultRepositorySystemValidator(List<ValidatorFactory> validatorFactories) {
+    public DefaultRepositorySystemValidator(Map<String, ValidatorFactory> validatorFactories) {
         this.validatorFactories = requireNonNull(validatorFactories, "validatorFactories cannot be null");
     }
 
@@ -69,11 +70,11 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     }
 
     @SuppressWarnings("unchecked")
-    private Validator newInstance(RepositorySystemSession session, ValidatorFactory factory) {
+    private Validator newInstance(RepositorySystemSession session, String name, ValidatorFactory factory) {
         if (session.getCache() != null) {
-            return ((ConcurrentHashMap<Integer, Validator>)
+            return ((ConcurrentHashMap<String, Validator>)
                             session.getCache().computeIfAbsent(session, SESSION_VALIDATORS, ConcurrentHashMap::new))
-                    .computeIfAbsent(System.identityHashCode(factory), key -> factory.newInstance(session));
+                    .computeIfAbsent(name, key -> requireNonNull(factory.newInstance(session)));
         } else {
             return factory.newInstance(session);
         }
@@ -82,9 +83,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateVersionRequest(RepositorySystemSession session, VersionRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 try {
                     validator.validateArtifact(request.getArtifact());
                 } catch (Exception e) {
@@ -105,9 +106,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateVersionRangeRequest(RepositorySystemSession session, VersionRangeRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 try {
                     validator.validateArtifact(request.getArtifact());
                 } catch (Exception e) {
@@ -128,9 +129,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateArtifactDescriptorRequest(RepositorySystemSession session, ArtifactDescriptorRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 try {
                     validator.validateArtifact(request.getArtifact());
                 } catch (Exception e) {
@@ -152,9 +153,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateArtifactRequests(
             RepositorySystemSession session, Collection<? extends ArtifactRequest> requests) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (ArtifactRequest request : requests) {
                     try {
                         validator.validateArtifact(request.getArtifact());
@@ -178,9 +179,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateMetadataRequests(
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (MetadataRequest request : requests) {
                     try {
                         validator.validateMetadata(request.getMetadata());
@@ -203,9 +204,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateCollectRequest(RepositorySystemSession session, CollectRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 if (request.getRootArtifact() != null) {
                     try {
                         validator.validateArtifact(request.getRootArtifact());
@@ -260,9 +261,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateInstallRequest(RepositorySystemSession session, InstallRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (Artifact artifact : request.getArtifacts()) {
                     try {
                         validator.validateArtifact(artifact);
@@ -285,9 +286,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateDeployRequest(RepositorySystemSession session, DeployRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (Artifact artifact : request.getArtifacts()) {
                     try {
                         validator.validateArtifact(artifact);
@@ -317,9 +318,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateLocalRepositories(RepositorySystemSession session, Collection<LocalRepository> repositories) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (LocalRepository repository : repositories) {
                     try {
                         validator.validateLocalRepository(repository);
@@ -335,9 +336,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     @Override
     public void validateRemoteRepositories(RepositorySystemSession session, Collection<RemoteRepository> repositories) {
         ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = newInstance(session, factory);
-            if (validator != null) {
+        for (Map.Entry<String, ValidatorFactory> entry : validatorFactories.entrySet()) {
+            Validator validator = newInstance(session, entry.getKey(), entry.getValue());
+            if (validator != ValidatorFactory.NOOP) {
                 for (RemoteRepository repository : repositories) {
                     try {
                         validator.validateRemoteRepository(repository);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
@@ -73,9 +73,9 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     private Validator newInstance(RepositorySystemSession session, String name, ValidatorFactory factory) {
         if (session.getCache() != null) {
             return ((ConcurrentHashMap<String, Validator>)
-                            session.getCache().computeIfAbsent(session, SESSION_VALIDATORS, ConcurrentHashMap::new))
-                    .computeIfAbsent(name, key -> requireNonNull(factory.newInstance(session)));
         } else {
+            return requireNonNull(factory.newInstance(session));
+        }
             return factory.newInstance(session);
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidator.java
@@ -25,7 +25,9 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.CollectRequest;
@@ -50,6 +52,7 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 @Named
 public class DefaultRepositorySystemValidator implements RepositorySystemValidator {
+    private static final Object SESSION_VALIDATORS = Keys.of(DefaultRepositorySystemValidator.class, "validators");
     private final List<ValidatorFactory> validatorFactories;
 
     @Inject
@@ -65,76 +68,23 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Validator newInstance(RepositorySystemSession session, ValidatorFactory factory) {
+        if (session.getCache() != null) {
+            return ((ConcurrentHashMap<Integer, Validator>)
+                            session.getCache().computeIfAbsent(session, SESSION_VALIDATORS, ConcurrentHashMap::new))
+                    .computeIfAbsent(System.identityHashCode(factory), key -> factory.newInstance(session));
+        } else {
+            return factory.newInstance(session);
+        }
+    }
+
     @Override
     public void validateVersionRequest(RepositorySystemSession session, VersionRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            try {
-                validator.validateArtifact(request.getArtifact());
-            } catch (Exception e) {
-                exceptions.add(e);
-            }
-            for (RemoteRepository repository : request.getRepositories()) {
-                try {
-                    validator.validateRemoteRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-        }
-        mayThrow(exceptions, "Invalid Version Request: " + request);
-    }
-
-    @Override
-    public void validateVersionRangeRequest(RepositorySystemSession session, VersionRangeRequest request) {
-        ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            try {
-                validator.validateArtifact(request.getArtifact());
-            } catch (Exception e) {
-                exceptions.add(e);
-            }
-            for (RemoteRepository repository : request.getRepositories()) {
-                try {
-                    validator.validateRemoteRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-        }
-        mayThrow(exceptions, "Invalid Version Range Request: " + request);
-    }
-
-    @Override
-    public void validateArtifactDescriptorRequest(RepositorySystemSession session, ArtifactDescriptorRequest request) {
-        ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            try {
-                validator.validateArtifact(request.getArtifact());
-            } catch (Exception e) {
-                exceptions.add(e);
-            }
-            for (RemoteRepository repository : request.getRepositories()) {
-                try {
-                    validator.validateRemoteRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-        }
-        mayThrow(exceptions, "Invalid Artifact Descriptor Request: " + request);
-    }
-
-    @Override
-    public void validateArtifactRequests(
-            RepositorySystemSession session, Collection<? extends ArtifactRequest> requests) {
-        ArrayList<Exception> exceptions = new ArrayList<>();
-        for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (ArtifactRequest request : requests) {
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
                 try {
                     validator.validateArtifact(request.getArtifact());
                 } catch (Exception e) {
@@ -149,6 +99,78 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
                 }
             }
         }
+        mayThrow(exceptions, "Invalid Version Request: " + request);
+    }
+
+    @Override
+    public void validateVersionRangeRequest(RepositorySystemSession session, VersionRangeRequest request) {
+        ArrayList<Exception> exceptions = new ArrayList<>();
+        for (ValidatorFactory factory : validatorFactories) {
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                try {
+                    validator.validateArtifact(request.getArtifact());
+                } catch (Exception e) {
+                    exceptions.add(e);
+                }
+                for (RemoteRepository repository : request.getRepositories()) {
+                    try {
+                        validator.validateRemoteRepository(repository);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+            }
+        }
+        mayThrow(exceptions, "Invalid Version Range Request: " + request);
+    }
+
+    @Override
+    public void validateArtifactDescriptorRequest(RepositorySystemSession session, ArtifactDescriptorRequest request) {
+        ArrayList<Exception> exceptions = new ArrayList<>();
+        for (ValidatorFactory factory : validatorFactories) {
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                try {
+                    validator.validateArtifact(request.getArtifact());
+                } catch (Exception e) {
+                    exceptions.add(e);
+                }
+                for (RemoteRepository repository : request.getRepositories()) {
+                    try {
+                        validator.validateRemoteRepository(repository);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+            }
+        }
+        mayThrow(exceptions, "Invalid Artifact Descriptor Request: " + request);
+    }
+
+    @Override
+    public void validateArtifactRequests(
+            RepositorySystemSession session, Collection<? extends ArtifactRequest> requests) {
+        ArrayList<Exception> exceptions = new ArrayList<>();
+        for (ValidatorFactory factory : validatorFactories) {
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (ArtifactRequest request : requests) {
+                    try {
+                        validator.validateArtifact(request.getArtifact());
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                    for (RemoteRepository repository : request.getRepositories()) {
+                        try {
+                            validator.validateRemoteRepository(repository);
+                        } catch (Exception e) {
+                            exceptions.add(e);
+                        }
+                    }
+                }
+            }
+        }
         mayThrow(exceptions, "Invalid Artifact Requests: " + requests);
     }
 
@@ -157,19 +179,21 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (MetadataRequest request : requests) {
-                try {
-                    validator.validateMetadata(request.getMetadata());
-                } catch (Exception e) {
-                    exceptions.add(e);
-                }
-                try {
-                    if (request.getRepository() != null) {
-                        validator.validateRemoteRepository(request.getRepository());
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (MetadataRequest request : requests) {
+                    try {
+                        validator.validateMetadata(request.getMetadata());
+                    } catch (Exception e) {
+                        exceptions.add(e);
                     }
-                } catch (Exception e) {
-                    exceptions.add(e);
+                    try {
+                        if (request.getRepository() != null) {
+                            validator.validateRemoteRepository(request.getRepository());
+                        }
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
             }
         }
@@ -180,40 +204,42 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateCollectRequest(RepositorySystemSession session, CollectRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            if (request.getRootArtifact() != null) {
-                try {
-                    validator.validateArtifact(request.getRootArtifact());
-                } catch (Exception e) {
-                    exceptions.add(e);
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                if (request.getRootArtifact() != null) {
+                    try {
+                        validator.validateArtifact(request.getRootArtifact());
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
-            }
-            if (request.getRoot() != null) {
-                try {
-                    validator.validateDependency(request.getRoot());
-                } catch (Exception e) {
-                    exceptions.add(e);
+                if (request.getRoot() != null) {
+                    try {
+                        validator.validateDependency(request.getRoot());
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
-            }
-            for (Dependency dependency : request.getDependencies()) {
-                try {
-                    validator.validateDependency(dependency);
-                } catch (Exception e) {
-                    exceptions.add(e);
+                for (Dependency dependency : request.getDependencies()) {
+                    try {
+                        validator.validateDependency(dependency);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
-            }
-            for (Dependency managedDependency : request.getManagedDependencies()) {
-                try {
-                    validator.validateDependency(managedDependency);
-                } catch (Exception e) {
-                    exceptions.add(e);
+                for (Dependency managedDependency : request.getManagedDependencies()) {
+                    try {
+                        validator.validateDependency(managedDependency);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
-            }
-            for (RemoteRepository repository : request.getRepositories()) {
-                try {
-                    validator.validateRemoteRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
+                for (RemoteRepository repository : request.getRepositories()) {
+                    try {
+                        validator.validateRemoteRepository(repository);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
             }
         }
@@ -235,19 +261,21 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateInstallRequest(RepositorySystemSession session, InstallRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (Artifact artifact : request.getArtifacts()) {
-                try {
-                    validator.validateArtifact(artifact);
-                } catch (Exception e) {
-                    exceptions.add(e);
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (Artifact artifact : request.getArtifacts()) {
+                    try {
+                        validator.validateArtifact(artifact);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
-            }
-            for (Metadata metadata : request.getMetadata()) {
-                try {
-                    validator.validateMetadata(metadata);
-                } catch (Exception e) {
-                    exceptions.add(e);
+                for (Metadata metadata : request.getMetadata()) {
+                    try {
+                        validator.validateMetadata(metadata);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
             }
         }
@@ -258,27 +286,29 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateDeployRequest(RepositorySystemSession session, DeployRequest request) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (Artifact artifact : request.getArtifacts()) {
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (Artifact artifact : request.getArtifacts()) {
+                    try {
+                        validator.validateArtifact(artifact);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+                for (Metadata metadata : request.getMetadata()) {
+                    try {
+                        validator.validateMetadata(metadata);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
                 try {
-                    validator.validateArtifact(artifact);
+                    if (request.getRepository() != null) {
+                        validator.validateRemoteRepository(request.getRepository());
+                    }
                 } catch (Exception e) {
                     exceptions.add(e);
                 }
-            }
-            for (Metadata metadata : request.getMetadata()) {
-                try {
-                    validator.validateMetadata(metadata);
-                } catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-            try {
-                if (request.getRepository() != null) {
-                    validator.validateRemoteRepository(request.getRepository());
-                }
-            } catch (Exception e) {
-                exceptions.add(e);
             }
         }
         mayThrow(exceptions, "Invalid Deploy Request: " + request);
@@ -288,12 +318,14 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateLocalRepositories(RepositorySystemSession session, Collection<LocalRepository> repositories) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (LocalRepository repository : repositories) {
-                try {
-                    validator.validateLocalRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (LocalRepository repository : repositories) {
+                    try {
+                        validator.validateLocalRepository(repository);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
             }
         }
@@ -304,12 +336,14 @@ public class DefaultRepositorySystemValidator implements RepositorySystemValidat
     public void validateRemoteRepositories(RepositorySystemSession session, Collection<RemoteRepository> repositories) {
         ArrayList<Exception> exceptions = new ArrayList<>();
         for (ValidatorFactory factory : validatorFactories) {
-            Validator validator = factory.newInstance(session);
-            for (RemoteRepository repository : repositories) {
-                try {
-                    validator.validateRemoteRepository(repository);
-                } catch (Exception e) {
-                    exceptions.add(e);
+            Validator validator = newInstance(session, factory);
+            if (validator != null) {
+                for (RemoteRepository repository : repositories) {
+                    try {
+                        validator.validateRemoteRepository(repository);
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
                 }
             }
         }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
@@ -100,7 +100,7 @@ public class DefaultRepositorySystemReentrancyTest {
                         new DefaultRepositoryKeyFunctionFactory()),
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
-                new DefaultRepositorySystemValidator(Collections.singletonList(countingValidator)));
+                new DefaultRepositorySystemValidator(Collections.singletonMap("counting", countingValidator)));
         session = TestUtils.newSession();
     }
 
@@ -162,7 +162,7 @@ public class DefaultRepositorySystemReentrancyTest {
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
                 new DefaultRepositorySystemValidator(
-                        Collections.singletonList(EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
+                        Collections.singletonMap("expressionRejecting", EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
 
         // An outermost call with an uninterpolated expression MUST fail validation
         VersionRangeRequest outerBadRequest =
@@ -221,7 +221,7 @@ public class DefaultRepositorySystemReentrancyTest {
                         new DefaultRepositoryKeyFunctionFactory()),
                 new DefaultRepositorySystemLifecycle(),
                 Collections.singletonMap("test", decoratorFactory),
-                new DefaultRepositorySystemValidator(Collections.emptyList()));
+                new DefaultRepositorySystemValidator(Collections.emptyMap()));
 
         // Outermost call: decorator should run
         ArtifactDescriptorRequest outerRequest =

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemTest.java
@@ -69,7 +69,7 @@ public class DefaultRepositorySystemTest {
                         new DefaultRepositoryKeyFunctionFactory()),
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
-                new DefaultRepositorySystemValidator(Collections.emptyList()));
+                new DefaultRepositorySystemValidator(Collections.emptyMap()));
         session = TestUtils.newSession();
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidatorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidatorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.aether.DefaultRepositoryCache;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.spi.validator.Validator;
+import org.eclipse.aether.spi.validator.ValidatorFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DefaultRepositorySystemValidatorTest {
+    @Test
+    void abstain() {
+        DefaultRepositorySystemValidator validator = new DefaultRepositorySystemValidator(
+                Collections.singletonMap("abstain", session -> ValidatorFactory.NOOP));
+        ArtifactDescriptorRequest request =
+                new ArtifactDescriptorRequest(new DefaultArtifact("foo:bar:1.0"), Collections.emptyList(), "test");
+        assertDoesNotThrow(() -> validator.validateArtifactDescriptorRequest(TestUtils.newSession(), request));
+    }
+
+    @Test
+    void fail() {
+        DefaultRepositorySystemValidator validator =
+                new DefaultRepositorySystemValidator(Collections.singletonMap("abstain", session -> new Validator() {
+                    @Override
+                    public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
+                        throw new IllegalArgumentException("Artifact validation failed");
+                    }
+                }));
+        ArtifactDescriptorRequest request =
+                new ArtifactDescriptorRequest(new DefaultArtifact("foo:bar:1.0"), Collections.emptyList(), "test");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> validator.validateArtifactDescriptorRequest(TestUtils.newSession(), request));
+    }
+
+    @Test
+    void withCaching() {
+        final ConcurrentHashMap<Integer, AtomicInteger> instanceCounter = new ConcurrentHashMap<>();
+        DefaultRepositorySystemValidator validator =
+                new DefaultRepositorySystemValidator(Collections.singletonMap("counter", session -> new Validator() {
+                    @Override
+                    public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
+                        instanceCounter
+                                .computeIfAbsent(System.identityHashCode(this), k -> new AtomicInteger(0))
+                                .incrementAndGet();
+                    }
+                }));
+        DefaultRepositorySystemSession sameSession = TestUtils.newSession();
+        sameSession.setCache(new DefaultRepositoryCache()); // with cache
+        assertDoesNotThrow(() -> validator.validateArtifactDescriptorRequest(
+                sameSession,
+                new ArtifactDescriptorRequest(new DefaultArtifact("foo:bar:1.0"), Collections.emptyList(), "test")));
+        assertDoesNotThrow(() -> validator.validateArtifactDescriptorRequest(
+                sameSession,
+                new ArtifactDescriptorRequest(new DefaultArtifact("baz:foo:1.0"), Collections.emptyList(), "test")));
+        // one instance is
+        assertEquals(1, instanceCounter.size());
+        // used twice
+        assertEquals(
+                2,
+                instanceCounter
+                        .get(instanceCounter.keySet().stream().iterator().next())
+                        .get());
+    }
+
+    @Test
+    void withoutCaching() {
+        final ConcurrentHashMap<Integer, AtomicInteger> instanceCounter = new ConcurrentHashMap<>();
+        DefaultRepositorySystemValidator validator =
+                new DefaultRepositorySystemValidator(Collections.singletonMap("counter", session -> new Validator() {
+                    @Override
+                    public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
+                        instanceCounter
+                                .computeIfAbsent(System.identityHashCode(this), k -> new AtomicInteger(0))
+                                .incrementAndGet();
+                    }
+                }));
+        DefaultRepositorySystemSession sameSession = TestUtils.newSession();
+        sameSession.setCache(null); // without cache
+        assertDoesNotThrow(() -> validator.validateArtifactDescriptorRequest(
+                sameSession,
+                new ArtifactDescriptorRequest(new DefaultArtifact("foo:bar:1.0"), Collections.emptyList(), "test")));
+        assertDoesNotThrow(() -> validator.validateArtifactDescriptorRequest(
+                sameSession,
+                new ArtifactDescriptorRequest(new DefaultArtifact("baz:foo:1.0"), Collections.emptyList(), "test")));
+        // two instances
+        assertEquals(2, instanceCounter.size());
+        for (AtomicInteger counter : instanceCounter.values()) {
+            // each used once
+            assertEquals(1, counter.get());
+        }
+    }
+
+    @Test
+    void dependencies() {
+        final List<Dependency> dependencies =
+                Collections.singletonList(new Dependency(new DefaultArtifact("foo:bar:1.0"), "compile"));
+        final List<Dependency> managedDependencies =
+                Collections.singletonList(new Dependency(new DefaultArtifact("baz:foo:1.0"), "compile"));
+
+        final AtomicInteger validateDependencies = new AtomicInteger(0);
+        final AtomicInteger validateManagedDependencies = new AtomicInteger(0);
+        DefaultRepositorySystemValidator validator = new DefaultRepositorySystemValidator(Collections.singletonMap(
+                "dependencies", session -> new Validator() {
+                    @Override
+                    public void validateDependency(Dependency dependency) throws IllegalArgumentException {
+                        if (dependency.getArtifact().getArtifactId().equals("bar")) {
+                            validateDependencies.incrementAndGet();
+                        }
+                    }
+
+                    @Override
+                    public void validateManagedDependency(Dependency managedDependency)
+                            throws IllegalArgumentException {
+                        if (managedDependency.getArtifact().getArtifactId().equals("foo")) {
+                            validateManagedDependencies.incrementAndGet();
+                        }
+                    }
+                }));
+        assertDoesNotThrow(() -> validator.validateCollectRequest(
+                TestUtils.newSession(),
+                new CollectRequest(dependencies, managedDependencies, Collections.emptyList())));
+        assertEquals(1, validateDependencies.get());
+        assertEquals(1, validateManagedDependencies.get());
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidatorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemValidatorTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultRepositorySystemValidatorTest {
     @Test
@@ -52,7 +53,7 @@ public class DefaultRepositorySystemValidatorTest {
     @Test
     void fail() {
         DefaultRepositorySystemValidator validator =
-                new DefaultRepositorySystemValidator(Collections.singletonMap("abstain", session -> new Validator() {
+                new DefaultRepositorySystemValidator(Collections.singletonMap("fail", session -> new Validator() {
                     @Override
                     public void validateArtifact(Artifact artifact) throws IllegalArgumentException {
                         throw new IllegalArgumentException("Artifact validation failed");
@@ -136,17 +137,15 @@ public class DefaultRepositorySystemValidatorTest {
                 "dependencies", session -> new Validator() {
                     @Override
                     public void validateDependency(Dependency dependency) throws IllegalArgumentException {
-                        if (dependency.getArtifact().getArtifactId().equals("bar")) {
-                            validateDependencies.incrementAndGet();
-                        }
+                        assertTrue(dependencies.contains(dependency));
+                        validateDependencies.incrementAndGet();
                     }
 
                     @Override
                     public void validateManagedDependency(Dependency managedDependency)
                             throws IllegalArgumentException {
-                        if (managedDependency.getArtifact().getArtifactId().equals("foo")) {
-                            validateManagedDependencies.incrementAndGet();
-                        }
+                        assertTrue(managedDependencies.contains(managedDependency));
+                        validateManagedDependencies.incrementAndGet();
                     }
                 }));
         assertDoesNotThrow(() -> validator.validateCollectRequest(

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/Validator.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/Validator.java
@@ -33,7 +33,7 @@ public interface Validator {
     /**
      * Validates artifact.
      *
-     * @param artifact The artifact to validate, never {@code null}.
+     * @param artifact the artifact to validate, never {@code null}.
      * @throws IllegalArgumentException if artifact is invalid.
      */
     default void validateArtifact(Artifact artifact) throws IllegalArgumentException {}
@@ -41,15 +41,15 @@ public interface Validator {
     /**
      * Validates metadata.
      *
-     * @param metadata The metadata to validate, never {@code null}.
-     * @throws IllegalArgumentException if artifact is invalid.
+     * @param metadata the metadata to validate, never {@code null}.
+     * @throws IllegalArgumentException if metadata is invalid.
      */
     default void validateMetadata(Metadata metadata) throws IllegalArgumentException {}
 
     /**
      * Validates dependency.
      *
-     * @param dependency The dependency to validate, never {@code null}.
+     * @param dependency the dependency to validate, never {@code null}.
      * @throws IllegalArgumentException if dependency is invalid.
      */
     default void validateDependency(Dependency dependency) throws IllegalArgumentException {}
@@ -62,7 +62,7 @@ public interface Validator {
      * that are never actually used. If a managed dependency IS matched and its coordinates are invalid, the error
      * will surface naturally during version resolution or artifact resolution.
      *
-     * @param managedDependency The managed dependency to validate, never {@code null}.
+     * @param managedDependency the managed dependency to validate, never {@code null}.
      * @throws IllegalArgumentException if dependency is invalid.
      * @since 2.0.22
      */
@@ -71,7 +71,7 @@ public interface Validator {
     /**
      * Validates local repository.
      *
-     * @param localRepository The local repository to validate, never {@code null}.
+     * @param localRepository the local repository to validate, never {@code null}.
      * @throws IllegalArgumentException if local repository is invalid.
      */
     default void validateLocalRepository(LocalRepository localRepository) throws IllegalArgumentException {}
@@ -79,7 +79,7 @@ public interface Validator {
     /**
      * Validates remote repository.
      *
-     * @param remoteRepository The remote repository to validate, never {@code null}.
+     * @param remoteRepository the remote repository to validate, never {@code null}.
      * @throws IllegalArgumentException if remote repository is invalid.
      */
     default void validateRemoteRepository(RemoteRepository remoteRepository) throws IllegalArgumentException {}

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/Validator.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/Validator.java
@@ -55,6 +55,20 @@ public interface Validator {
     default void validateDependency(Dependency dependency) throws IllegalArgumentException {}
 
     /**
+     * Validates managed dependency.
+     * <em>Important:</em> They are declarative constraints (version/scope/exclusion overrides) that only take effect
+     * when a matching dependency is encountered during collection. Validating them eagerly may reject valid builds
+     * where a BOM imports managed dependencies with uninterpolated property expressions (e.g. {@code ${osgi.version}})
+     * that are never actually used. If a managed dependency IS matched and its coordinates are invalid, the error
+     * will surface naturally during version resolution or artifact resolution.
+     *
+     * @param managedDependency The managed dependency to validate, never {@code null}.
+     * @throws IllegalArgumentException if dependency is invalid.
+     * @since 2.0.22
+     */
+    default void validateManagedDependency(Dependency managedDependency) throws IllegalArgumentException {}
+
+    /**
      * Validates local repository.
      *
      * @param localRepository The local repository to validate, never {@code null}.

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
@@ -26,13 +26,21 @@ import org.eclipse.aether.RepositorySystemSession;
  * @since 2.0.8
  */
 public interface ValidatorFactory {
+
     /**
-     * Creates a new validator for the session, or {@code null} to abstain from validation. Factory is consulted
+     * The no-op (does not validate anything) instance of validator.
+     *
+     * @since 2.0.22
+     */
+    Validator NOOP = new Validator() {};
+
+    /**
+     * Creates a new validator for the session, or {@link #NOOP} to abstain from validation. Factory is consulted
      * once per session (if cache present in session) and returned instances (even {@code null}s) are cached and reused
      * across single session.
      *
      * @param session The repository system session from which to configure the validator, must not be {@code null}.
-     * @return The validator to be used for the session, or {@code null} to abstain from validation.
+     * @return The validator to be used for the session, or {@link #NOOP} to abstain from validation, never {@code null}.
      */
     Validator newInstance(RepositorySystemSession session);
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
@@ -27,10 +27,12 @@ import org.eclipse.aether.RepositorySystemSession;
  */
 public interface ValidatorFactory {
     /**
-     * Creates a new validator for the session.
+     * Creates a new validator for the session, or {@code null} to abstain from validation. Factory is consulted
+     * once per session (if cache present in session) and returned instances (even {@code null}s) are cached and reused
+     * across single session.
      *
      * @param session The repository system session from which to configure the validator, must not be {@code null}.
-     * @return The validator for the session, never {@code null}.
+     * @return The validator to be used for the session, or {@code null} to abstain from validation.
      */
     Validator newInstance(RepositorySystemSession session);
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
@@ -39,8 +39,8 @@ public interface ValidatorFactory {
      * once per session (if cache present in session) and returned instances are cached and reused
      * across single session.
      *
-     * @param session The repository system session from which to configure the validator, must not be {@code null}.
-     * @return The validator to be used for the session, or {@link #NOOP} to abstain from validation, never {@code null}.
+     * @param session the repository system session from which to configure the validator, must not be {@code null}.
+     * @return the validator to be used for the session, or {@link #NOOP} to abstain from validation, never {@code null}.
      */
     Validator newInstance(RepositorySystemSession session);
 }

--- a/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
+++ b/maven-resolver-spi/src/main/java/org/eclipse/aether/spi/validator/ValidatorFactory.java
@@ -36,7 +36,7 @@ public interface ValidatorFactory {
 
     /**
      * Creates a new validator for the session, or {@link #NOOP} to abstain from validation. Factory is consulted
-     * once per session (if cache present in session) and returned instances (even {@code null}s) are cached and reused
+     * once per session (if cache present in session) and returned instances are cached and reused
      * across single session.
      *
      * @param session The repository system session from which to configure the validator, must not be {@code null}.

--- a/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn3/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -18,9 +18,7 @@
  */
 package org.eclipse.aether.supplier;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -1131,9 +1129,9 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return new DefaultModelCacheFactory();
     }
 
-    private List<ValidatorFactory> validatorFactories;
+    private Map<String, ValidatorFactory> validatorFactories;
 
-    public final List<ValidatorFactory> getValidatorFactories() {
+    public final Map<String, ValidatorFactory> getValidatorFactories() {
         checkClosed();
         if (validatorFactories == null) {
             validatorFactories = createValidatorFactories();
@@ -1141,8 +1139,8 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return validatorFactories;
     }
 
-    protected List<ValidatorFactory> createValidatorFactories() {
-        return new ArrayList<>();
+    protected Map<String, ValidatorFactory> createValidatorFactories() {
+        return new HashMap<>();
     }
 
     private RepositorySystemValidator repositorySystemValidator;

--- a/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
+++ b/maven-resolver-supplier-mvn4/src/main/java/org/eclipse/aether/supplier/RepositorySystemSupplier.java
@@ -18,10 +18,8 @@
  */
 package org.eclipse.aether.supplier;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -1156,9 +1154,9 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return new DefaultModelCacheFactory();
     }
 
-    private List<ValidatorFactory> validatorFactories;
+    private Map<String, ValidatorFactory> validatorFactories;
 
-    public final List<ValidatorFactory> getValidatorFactories() {
+    public final Map<String, ValidatorFactory> getValidatorFactories() {
         checkClosed();
         if (validatorFactories == null) {
             validatorFactories = createValidatorFactories();
@@ -1166,8 +1164,8 @@ public class RepositorySystemSupplier implements Supplier<RepositorySystem> {
         return validatorFactories;
     }
 
-    protected List<ValidatorFactory> createValidatorFactories() {
-        return new ArrayList<>();
+    protected Map<String, ValidatorFactory> createValidatorFactories() {
+        return new HashMap<>();
     }
 
     private RepositorySystemValidator repositorySystemValidator;


### PR DESCRIPTION
Changes:
* allow `ValidatorFactory` to "abstain" and return `NOOP`
* introduce alt execution path for managed dependencies (use cases varies)
* cache validators per session

Fixes: #2007
