### PR TITLE
Replace printStackTrace with proper error handling

### DIFF
--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
@@ -79,7 +79,6 @@ public class DefaultRepositoryCacheTest {
                             assertEquals(Boolean.TRUE, get(key));
                         } catch (Throwable t) {
                             error.compareAndSet(null, t);
-
                         }
                     }
                 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
@@ -79,7 +79,7 @@ public class DefaultRepositoryCacheTest {
                             assertEquals(Boolean.TRUE, get(key));
                         } catch (Throwable t) {
                             error.compareAndSet(null, t);
-                            t.printStackTrace();
+
                         }
                     }
                 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultRepositoryCacheTest.java
@@ -90,6 +90,9 @@ public class DefaultRepositoryCacheTest {
         for (Thread thread : threads) {
             thread.join();
         }
-        assertNull(error.get(), String.valueOf(error.get()));
+        Throwable t = error.get();
+        if (t != null) {
+            throw new AssertionError(t);
+        }
     }
 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
@@ -115,7 +115,6 @@ public class DefaultSessionDataTest {
                             assertEquals(Boolean.TRUE, get(key));
                         } catch (Throwable t) {
                             error.compareAndSet(null, t);
-
                         }
                     }
                 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
@@ -115,7 +115,7 @@ public class DefaultSessionDataTest {
                             assertEquals(Boolean.TRUE, get(key));
                         } catch (Throwable t) {
                             error.compareAndSet(null, t);
-                            t.printStackTrace();
+
                         }
                     }
                 }

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/DefaultSessionDataTest.java
@@ -126,6 +126,9 @@ public class DefaultSessionDataTest {
         for (Thread thread : threads) {
             thread.join();
         }
-        assertNull(error.get(), String.valueOf(error.get()));
+        Throwable t = error.get();
+        if (t != null) {
+            throw new AssertionError(t);
+        }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -552,6 +552,10 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
 
         volatile String errorPath;
 
+        private int exceptionCount;
+
+        private int cycleCount;
+
         public Results(CollectResult result, RepositorySystemSession session) {
             this.result = result;
 
@@ -569,7 +573,8 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         }
 
         public synchronized void addException(Dependency dependency, Exception e, List<DependencyNode> nodes) {
-            if (maxExceptions < 0 || result.getExceptions().size() < maxExceptions) {
+            if (maxExceptions < 0 || exceptionCount < maxExceptions) {
+                exceptionCount++;
                 result.addException(e);
                 if (errorPath == null) {
                     StringBuilder buffer = new StringBuilder(256);
@@ -592,7 +597,8 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
         }
 
         public synchronized void addCycle(List<DependencyNode> nodes, int cycleEntry, Dependency dependency) {
-            if (maxCycles < 0 || result.getCycles().size() < maxCycles) {
+            if (maxCycles < 0 || cycleCount < maxCycles) {
+                cycleCount++;
                 result.addCycle(new DefaultDependencyCycle(nodes, cycleEntry, dependency));
             }
         }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -20,6 +20,7 @@ package org.eclipse.aether.internal.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -737,7 +738,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }
@@ -749,7 +750,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }
@@ -802,7 +803,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }
@@ -871,7 +872,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }
@@ -972,7 +973,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }
@@ -984,7 +985,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
                 return result;
             }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -737,7 +737,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
@@ -749,7 +749,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
@@ -802,7 +802,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
@@ -871,7 +871,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
@@ -972,7 +972,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }
@@ -984,7 +984,7 @@ public class DefaultArtifactResolverTest {
                 try {
                     result.setFile(TestFileUtils.createTempFile(""));
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
                 return result;
             }


### PR DESCRIPTION
Fixes #1999

Changes:
- **DefaultArtifactResolverTest**: Replace `e.printStackTrace()` with `throw new RuntimeException(e)` so tests properly fail on IO errors instead of silently printing
- **DefaultSessionDataTest**: Remove redundant `t.printStackTrace()` — error already captured in AtomicReference and asserted
- **DefaultRepositoryCacheTest**: Same as DefaultSessionDataTest
- **DependencyCollectorDelegate**: Use local counter fields instead of `result.getExceptions().size()` / `result.getCycles().size()` for thread safety during concurrent collection