### PR TITLE
Fix InterruptedException silently dropping task in SmartExecutor.Limited.submit(Runnable)

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
@@ -176,6 +176,7 @@ public interface SmartExecutor extends AutoCloseable {
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
             }
         }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/concurrency/SmartExecutor.java
@@ -35,8 +35,10 @@ import java.util.concurrent.Semaphore;
 public interface SmartExecutor extends AutoCloseable {
     /**
      * Submits a {@link Runnable} to execution.
+     *
+     * @throws RejectedExecutionException If this executor cannot accept the task.
      */
-    void submit(Runnable runnable);
+    void submit(Runnable runnable) throws RejectedExecutionException;
 
     /**
      * Submits a {@link Callable} to execution, returns a {@link CompletableFuture}.
@@ -176,7 +178,7 @@ public interface SmartExecutor extends AutoCloseable {
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
+                throw new RejectedExecutionException(e);
             }
         }
 


### PR DESCRIPTION
Fixes #1993

In `Limited.submit(Runnable)` (line 155), if `semaphore.acquire()` throws `InterruptedException`, the interrupt flag was restored but the caller's task was never executed — it was silently dropped. The `submit(Callable)` variant correctly handles this by returning a failed `CompletableFuture`.

This fix throws a `RuntimeException` wrapping the `InterruptedException` after restoring the interrupt flag, so the caller is notified that the task could not be submitted.