### PR TITLE
Fix resource leak pattern in DependencyGraphParser.parseLiteral()

### DIFF
--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
@@ -172,19 +172,9 @@ public class DependencyGraphParser {
      * Parse the graph definition read from the given URL.
      */
     public DependencyNode parse(URL resource) throws IOException {
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8));
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
             return parse(reader);
-        } finally {
-            try {
-                if (reader != null) {
-                    reader.close();
-                    reader = null;
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            }
         }
     }
 

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/DependencyGraphParser.java
@@ -131,10 +131,9 @@ public class DependencyGraphParser {
      * Parse the given graph definition.
      */
     public DependencyNode parseLiteral(String dependencyGraph) throws IOException {
-        BufferedReader reader = new BufferedReader(new StringReader(dependencyGraph));
-        DependencyNode node = parse(reader);
-        reader.close();
-        return node;
+        try (BufferedReader reader = new BufferedReader(new StringReader(dependencyGraph))) {
+            return parse(reader);
+        }
     }
 
     /**


### PR DESCRIPTION
Wrap the BufferedReader in try-with-resources so it is closed even if parse() throws. StringReader.close() is currently a no-op, but this is to keep the method consistent with the rest of the codebase.

Fixes #1996

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
