### PR TITLE
Extract included checksums from x-amz-meta-* headers

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/transport/http/XChecksumExtractor.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/transport/http/XChecksumExtractor.java
@@ -21,7 +21,9 @@ package org.eclipse.aether.internal.impl.transport.http;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -37,33 +39,39 @@ import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractorStrategy
 public final class XChecksumExtractor extends ChecksumExtractorStrategy {
     public static final String NAME = "xChecksum";
 
+    /**
+     * Header name prefixes, to be suffixed by lower case algorithm name. Tried in order, first prefix that yields
+     * any checksum wins.
+     */
+    private static final List<String> HEADER_PREFIXES = Arrays.asList(
+            // Central style: x-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
+            "x-checksum-",
+            // Google style: x-goog-meta-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
+            "x-goog-meta-checksum-",
+            // AWS S3 style: x-amz-meta-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
+            "x-amz-meta-checksum-");
+
     @Override
     public Map<String, String> extractChecksums(Function<String, String> headerGetter) {
-        String value;
+        for (String headerPrefix : HEADER_PREFIXES) {
+            Map<String, String> result = extractChecksums(headerGetter, headerPrefix);
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private static Map<String, String> extractChecksums(Function<String, String> headerGetter, String headerPrefix) {
         HashMap<String, String> result = new HashMap<>();
-        // Central style: x-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
-        value = headerGetter.apply("x-checksum-sha1");
+        String value = headerGetter.apply(headerPrefix + "sha1");
         if (value != null) {
             result.put(Sha1ChecksumAlgorithmFactory.NAME, value);
         }
-        // Central style: x-checksum-md5: 9ad0d8e3482767c122e85f83567b8ce6
-        value = headerGetter.apply("x-checksum-md5");
+        value = headerGetter.apply(headerPrefix + "md5");
         if (value != null) {
             result.put(Md5ChecksumAlgorithmFactory.NAME, value);
         }
-        if (!result.isEmpty()) {
-            return result;
-        }
-        // Google style: x-goog-meta-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
-        value = headerGetter.apply("x-goog-meta-checksum-sha1");
-        if (value != null) {
-            result.put(Sha1ChecksumAlgorithmFactory.NAME, value);
-        }
-        // Central style: x-goog-meta-checksum-sha1: 9ad0d8e3482767c122e85f83567b8ce6
-        value = headerGetter.apply("x-goog-meta-checksum-md5");
-        if (value != null) {
-            result.put(Md5ChecksumAlgorithmFactory.NAME, value);
-        }
-        return result.isEmpty() ? null : result;
+        return result;
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/transport/http/XChecksumExtractorTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/transport/http/XChecksumExtractorTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.transport.http;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * UT for {@link XChecksumExtractor}.
+ */
+class XChecksumExtractorTest {
+    private static final String SHA1 = "c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b";
+
+    private static final String MD5 = "9ad0d8e3482767c122e85f83567b8ce6";
+
+    private final XChecksumExtractor extractor = new XChecksumExtractor();
+
+    // HTTP header names are case insensitive, and transports return null for absent headers
+    private final TreeMap<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    private Map<String, String> extract() {
+        return extractor.extractChecksums(headers::get);
+    }
+
+    @Test
+    void noHeaders() {
+        assertNull(extract());
+    }
+
+    @Test
+    void unrelatedHeaders() {
+        headers.put("ETag", "\"deadbeef\"");
+        headers.put("Content-Length", "42");
+        assertNull(extract());
+    }
+
+    @Test
+    void central() {
+        headers.put("x-checksum-sha1", SHA1);
+        headers.put("x-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(2, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void centralSha1Only() {
+        headers.put("x-checksum-sha1", SHA1);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void centralMd5Only() {
+        headers.put("x-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void google() {
+        headers.put("x-goog-meta-checksum-sha1", SHA1);
+        headers.put("x-goog-meta-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(2, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void googleSha1Only() {
+        headers.put("x-goog-meta-checksum-sha1", SHA1);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void googleMd5Only() {
+        headers.put("x-goog-meta-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void amazon() {
+        headers.put("x-amz-meta-checksum-sha1", SHA1);
+        headers.put("x-amz-meta-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(2, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void amazonSha1Only() {
+        headers.put("x-amz-meta-checksum-sha1", SHA1);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void amazonMd5Only() {
+        headers.put("x-amz-meta-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void amazonMixedCaseHeaderNames() {
+        headers.put("X-Amz-Meta-Checksum-Sha1", SHA1);
+        headers.put("X-AMZ-META-CHECKSUM-MD5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(2, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+        assertEquals(MD5, result.get(Md5ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void amazonAmongOtherAmzMetadata() {
+        headers.put("x-amz-request-id", "K2ZQ0RYZ6H2VJTVX");
+        headers.put("x-amz-meta-something", "irrelevant");
+        headers.put("x-amz-meta-checksum-sha1", SHA1);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void centralWinsOverGoogleAndAmazon() {
+        headers.put("x-checksum-sha1", SHA1);
+        headers.put("x-goog-meta-checksum-sha1", "0000000000000000000000000000000000000000");
+        headers.put("x-amz-meta-checksum-sha1", "1111111111111111111111111111111111111111");
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+
+    @Test
+    void googleWinsOverAmazon() {
+        // whole prefixes are tried in order, so the Amazon MD5 must not leak into the Google result
+        headers.put("x-goog-meta-checksum-sha1", SHA1);
+        headers.put("x-amz-meta-checksum-md5", MD5);
+        Map<String, String> result = extract();
+        assertEquals(1, result.size());
+        assertEquals(SHA1, result.get(Sha1ChecksumAlgorithmFactory.NAME));
+    }
+}

--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
@@ -153,7 +153,9 @@ public class HttpServer {
 
     public enum ChecksumHeader {
         NEXUS,
-        XCHECKSUM
+        XCHECKSUM,
+        XCHECKSUM_GOOGLE,
+        XCHECKSUM_AMAZON
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpServer.class);
@@ -664,6 +666,12 @@ public class HttpServer {
                         response.getHeaders().add(HttpHeader.ETAG.asString(), "{SHA1{" + checksums.get("SHA-1") + "}}");
                     } else if (checksumHeader == ChecksumHeader.XCHECKSUM) {
                         response.getHeaders().add("x-checksum-sha1", checksums.get(Sha1ChecksumAlgorithmFactory.NAME));
+                    } else if (checksumHeader == ChecksumHeader.XCHECKSUM_GOOGLE) {
+                        response.getHeaders()
+                                .add("x-goog-meta-checksum-sha1", checksums.get(Sha1ChecksumAlgorithmFactory.NAME));
+                    } else if (checksumHeader == ChecksumHeader.XCHECKSUM_AMAZON) {
+                        response.getHeaders()
+                                .add("x-amz-meta-checksum-sha1", checksums.get(Sha1ChecksumAlgorithmFactory.NAME));
                     }
                 }
                 if (HttpMethod.HEAD.is(req.getMethod())) {

--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
@@ -1061,6 +1061,26 @@ public abstract class HttpTransporterTest {
     }
 
     @Test
+    protected void testGet_Checksums_XChecksum_Google() throws Exception {
+        httpServer.setChecksumHeader(HttpServer.ChecksumHeader.XCHECKSUM_GOOGLE);
+        GetTask task = new GetTask(URI.create("repo/file.txt"));
+        transporter.get(task);
+        assertEquals("test", task.getDataString());
+        assertEquals(
+                "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", task.getChecksums().get("SHA-1"));
+    }
+
+    @Test
+    protected void testGet_Checksums_XChecksum_Amazon() throws Exception {
+        httpServer.setChecksumHeader(HttpServer.ChecksumHeader.XCHECKSUM_AMAZON);
+        GetTask task = new GetTask(URI.create("repo/file.txt"));
+        transporter.get(task);
+        assertEquals("test", task.getDataString());
+        assertEquals(
+                "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", task.getChecksums().get("SHA-1"));
+    }
+
+    @Test
     protected void testGet_FileHandleLeak() throws Exception {
         for (int i = 0; i < 100; i++) {
             File file = TestFileUtils.createTempFile("failure");

--- a/src/site/markdown/expected-checksums.md
+++ b/src/site/markdown/expected-checksums.md
@@ -125,9 +125,10 @@ Emitted by: Sonatype Nexus2 only.
 
 Maven Central emits headers `x-checksum-sha1` and `x-checksum-md5` along with artifact response. 
 Google GCS on the other hand uses `x-goog-meta-checksum-sha1` and `x-goog-meta-checksum-md5` 
-headers. Resolver will detect all these and use their value.
+headers. AWS S3 uses `x-amz-meta-checksum-sha1` and `x-amz-meta-checksum-md5` headers.
+Resolver will detect all these and use their value.
 
-Emitted by: Maven Central, GCS, some CDNs and probably more.
+Emitted by: Maven Central, GCS, AWS S3, some CDNs and probably more.
 
 
 ### Remote External checksums


### PR DESCRIPTION
AWS S3 exposes user defined object metadata under the x-amz-meta- prefix, so an object uploaded with the checksum-sha1 and checksum-md5 metadata keys is served back with the x-amz-meta-checksum-sha1 and x-amz-meta-checksum-md5 response headers. XChecksumExtractor did not know about them, so Resolver fell through to the Remote External strategy and issued a second request for the checksum sidecar file, even though the checksum was already in hand from the artifact response.

Teach the extractor that prefix. The three supported prefixes are now held in a list and tried in order, keeping the pre-existing precedence: the first prefix yielding any checksum wins, so a partial match on a later prefix cannot leak into an earlier one's result.

Stores that follow the same metadata convention, such as Cloudflare R2, MinIO and Backblaze B2, benefit from this as well.

Fixes #2019

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
