### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -29,5 +29,6 @@ jobs:
       ff-run: false
       ff-site-run: false
       maven4-enabled: true
+      maven4-version: '4.0.0-rc-6' # the same as used in project
       verify-fail-fast: false
       jdk-matrix: '[ "21", "25", "26" ]'

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <jettyVersion>12.1.11</jettyVersion>
     <!-- used by supplier and demo only -->
     <maven3Version>3.9.16</maven3Version>
-    <maven4Version>4.0.0-rc-5</maven4Version>
+    <maven4Version>4.0.0-rc-6</maven4Version>
     <plexusUtils3Version>3.6.1</plexusUtils3Version>
     <plexusUtils4Version>4.0.3</plexusUtils4Version>
     <plexusXml4Version>4.1.1</plexusXml4Version>


### PR DESCRIPTION
4.0.0-rc-6 is released. This moves `maven4Version` to it and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

Verified: green on the fork before opening.
