### PR TITLE
Exclude ODG graphics from RAT checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,7 @@
               <exclude>src/test/resources/**/*.txt</exclude>
               <exclude>src/test/resources/ssl/*-store</exclude>
               <exclude>.gitattributes</exclude>
+              <exclude>**/*.odg</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
fixes #2028 

It is a binary file: While technically a zip archive of XML, OpenDocument formats are meant to be edited via GUI tools (like LibreOffice/OpenOffice), not hand-edited. It is standard practice in Apache projects to treat such rich-document formats as binaries.

License Headers break ODG: You cannot reliably inject standard Apache ALv2 text headers into the XML inside the ODG archive without risking file corruption or breaking the application that reads the ODG file.

Apache Policy: The Apache Software Foundation's policy on license headers explicitly states that files without a degree of creativity (like configuration files or generated diagrams) or binary files where adding a header would break the format do not require ALv2 headers.