### PR TITLE
Fix deadlock in IPC named lock access tests (#2030)

### DIFF
--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryTestSupport.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/NamedLockFactoryTestSupport.java
@@ -131,10 +131,10 @@ public abstract class NamedLockFactoryTestSupport {
         Thread t2 = new Thread(new Access(namedLockFactory, keys, true, winners, losers));
         t1.start();
         t2.start();
-        t1.join();
-        t2.join();
-        winners.await();
-        losers.await();
+        t1.join(5000);
+        t2.join(5000);
+        assertTrue(winners.await(5, TimeUnit.SECONDS), "expected both threads to win");
+        assertTrue(losers.await(5, TimeUnit.SECONDS), "expected no loser");
     }
 
     @Test
@@ -147,10 +147,10 @@ public abstract class NamedLockFactoryTestSupport {
         Thread t2 = new Thread(new Access(namedLockFactory, keys, false, winners, losers));
         t1.start();
         t2.start();
-        t1.join();
-        t2.join();
-        winners.await();
-        losers.await();
+        t1.join(5000);
+        t2.join(5000);
+        assertTrue(winners.await(5, TimeUnit.SECONDS), "expected a winner");
+        assertTrue(losers.await(5, TimeUnit.SECONDS), "expected a loser");
     }
 
     @Test
@@ -163,10 +163,10 @@ public abstract class NamedLockFactoryTestSupport {
         Thread t2 = new Thread(new Access(namedLockFactory, keys, false, winners, losers));
         t1.start();
         t2.start();
-        t1.join();
-        t2.join();
-        winners.await();
-        losers.await();
+        t1.join(5000);
+        t2.join(5000);
+        assertTrue(winners.await(5, TimeUnit.SECONDS), "expected a winner");
+        assertTrue(losers.await(5, TimeUnit.SECONDS), "expected a loser");
     }
 
     private static class Access implements Runnable {
@@ -193,17 +193,17 @@ public abstract class NamedLockFactoryTestSupport {
         public void run() {
             try (NamedLock lock = namedLockFactory.getLock(keys)) {
                 if (shared
-                        ? lock.lockShared(100L, TimeUnit.MILLISECONDS)
-                        : lock.lockExclusively(100L, TimeUnit.MILLISECONDS)) {
+                        ? lock.lockShared(1000L, TimeUnit.MILLISECONDS)
+                        : lock.lockExclusively(1000L, TimeUnit.MILLISECONDS)) {
                     try {
                         winner.countDown();
-                        loser.await();
+                        loser.await(5, TimeUnit.SECONDS);
                     } finally {
                         lock.unlock();
                     }
                 } else {
                     loser.countDown();
-                    winner.await();
+                    winner.await(5, TimeUnit.SECONDS);
                 }
             } catch (InterruptedException e) {
                 fail(e.getMessage());


### PR DESCRIPTION
Closes #2030

## Problem

org.eclipse.aether.named.ipc.IpcNamedLockFactoryIT.exclusiveAccess is flaky on Jenkins, timing out after 25 s with the main thread stuck in t1.join().

The root cause is a deadlock in the Access handshake shared by sharedAccess, exclusiveAccess and mixedAccess. When both competing threads fail to acquire the lock within the 100 ms acquisition timeout, both threads count down the loser latch and then block forever on winner.await(), because the winners latch is never counted down. The test then hangs until the JUnit @Timeout fires.

This happens under load when the in-process IPC server thread is starved for more than 100 ms, so neither acquisition completes in time. Earlier fixes only raised the overall test timeout (5 s to 15 s to 25 s), which converts the deadlock into a longer hang without fixing it.

## Fix

- Raise the lock acquisition timeout in Access from 100 ms to 1 s so at least one thread reliably wins even on a loaded machine. Mutual exclusion is still verified: the loser is queued behind the winner on the server and cannot be granted while the winner holds, so its failure is still caused by the winner holding the lock.
- Bound the winner/loser handshake awaits and the test-side joins and latch awaits, and assert the expected outcome. In the (now unlikely) case both threads lose, the test fails fast with a clear message instead of hanging for the full @Timeout.

Verified by running IpcNamedLockFactoryIT 21 consecutive times (15 normal + 6 under simulated CPU load), all passing.