### PR TITLE
Deflake JettyTransporterTest.testGet_HTTP3 (UDP port collision)

### DIFF
--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
@@ -20,6 +20,9 @@ package org.eclipse.aether.internal.test.util.http;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
@@ -225,22 +228,26 @@ public class HttpServer {
     }
 
     public HttpServer addHttp2ConnectorWithMutualTLS() {
-        return addHttp2Connector(true, true);
+        return addHttp2Connector(true, true, -1);
     }
 
     public HttpServer addHttp2Connector() {
-        return addHttp2Connector(false, true);
+        return addHttp2Connector(false, true, -1);
     }
 
     public HttpServer addHttp2OnlyConnector() {
-        return addHttp2Connector(false, false);
+        return addHttp2Connector(false, false, -1);
     }
 
     public HttpServer addHttp2OnlyConnectorWithMutualTLS() {
-        return addHttp2Connector(true, false);
+        return addHttp2Connector(true, false, -1);
     }
 
-    private HttpServer addHttp2Connector(boolean needClientAuth, boolean needHttp11) {
+    public HttpServer addHttp2OnlyConnectorWithMutualTLS(int port) {
+        return addHttp2Connector(true, false, port);
+    }
+
+    private HttpServer addHttp2Connector(boolean needClientAuth, boolean needHttp11, int port) {
         if (httpsConnector == null) {
             SslContextFactory.Server ssl = createServerSslContextFactory(needClientAuth);
 
@@ -264,6 +271,9 @@ public class HttpServer {
                 httpsConnector = new ServerConnector(server, tls, alpn, http2, http1);
             } else {
                 httpsConnector = new ServerConnector(server, tls, alpn, http2);
+            }
+            if (port != -1) {
+                httpsConnector.setPort(port);
             }
             server.addConnector(httpsConnector);
             try {
@@ -314,6 +324,36 @@ public class HttpServer {
             }
         }
         return this;
+    }
+
+    /**
+     * Finds a port that is free for both TCP and UDP, so that the HTTP/2 (TCP) and HTTP/3 (UDP) connectors can be
+     * bound to the same port number. TCP and UDP port spaces are independent, so an OS-assigned TCP port may have its
+     * same-numbered UDP port already taken by another process, which makes binding HTTP/3 to the HTTPS port flaky.
+     * @return a port number that is (at probe time) free for both TCP and UDP
+     */
+    public int findFreeTcpAndUdpPort() {
+        for (int i = 0; i < 20; i++) {
+            int port;
+            try (ServerSocket serverSocket = new ServerSocket(0)) {
+                port = serverSocket.getLocalPort();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to find a free TCP port", e);
+            }
+            if (isUdpPortFree(port)) {
+                return port;
+            }
+        }
+        throw new IllegalStateException("Failed to find a port free for both TCP and UDP");
+    }
+
+    private static boolean isUdpPortFree(int port) {
+        try (DatagramSocket socket = new DatagramSocket(null)) {
+            socket.bind(new InetSocketAddress(port));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     public List<LogEntry> getLogEntries() {

--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpServer.java
@@ -330,9 +330,10 @@ public class HttpServer {
      * Finds a port that is free for both TCP and UDP, so that the HTTP/2 (TCP) and HTTP/3 (UDP) connectors can be
      * bound to the same port number. TCP and UDP port spaces are independent, so an OS-assigned TCP port may have its
      * same-numbered UDP port already taken by another process, which makes binding HTTP/3 to the HTTPS port flaky.
+     *
      * @return a port number that is (at probe time) free for both TCP and UDP
      */
-    public int findFreeTcpAndUdpPort() {
+    int findFreeTcpAndUdpPort() {
         for (int i = 0; i < 20; i++) {
             int port;
             try (ServerSocket serverSocket = new ServerSocket(0)) {

--- a/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
+++ b/maven-resolver-test-http/src/main/java/org/eclipse/aether/internal/test/util/http/HttpTransporterTest.java
@@ -926,8 +926,11 @@ public abstract class HttpTransporterTest {
         assumeTrue(supportsHttp3(), "Transporter does not support HTTP/3");
         session.setConfigProperty(ConfigurationProperties.HTTP_VERSION, ConfigurationProperties.HttpVersion.HTTP_3);
         // both HTTP2 and HTTP3 endpoints are available at the same port
-        httpServer.addHttp2OnlyConnectorWithMutualTLS();
-        httpServer.addHttp3Connector(false, httpServer.getHttpsPort());
+        // reserve a port free for both TCP and UDP, as the same-numbered UDP port of an OS-assigned TCP port may be
+        // taken (https://github.com/apache/maven-resolver/issues/2036)
+        int port = httpServer.findFreeTcpAndUdpPort();
+        httpServer.addHttp2OnlyConnectorWithMutualTLS(port);
+        httpServer.addHttp3Connector(false, port);
         // alt-svc header should point to http/3
         httpServer.start();
         newTransporter(httpServer.getHttp3Url());


### PR DESCRIPTION
Fixes #2036

## Problem
`JettyTransporterTest.testGet_HTTP3` is flaky: binding the HTTP/3 (UDP) connector to the HTTPS TCP connector's port fails with `java.net.BindException: Address already in use`.

## Root cause
The test bound both connectors to the same numeric port by reusing `getHttpsPort()`, which is an OS-assigned *TCP* port. TCP and UDP port spaces are allocated independently, so the same-numbered *UDP* port may already be in use by another process. The collision is inherent to the "let the OS pick a TCP port, then force UDP onto the same number" pattern (verified by experiment: ~1% collision rate with a few hundred UDP sockets occupied).

## Fix
- Added `HttpServer.findFreeTcpAndUdpPort()`, which probes for a port that is free for **both** TCP and UDP.
- Added `HttpServer.addHttp2OnlyConnectorWithMutualTLS(int port)` so the HTTPS (HTTP/2) connector can be bound to that exact port.
- `testGet_HTTP3` now reserves such a port and binds both connectors to it, keeping the intended "HTTP/2 and HTTP/3 on the same port" semantics.

Verified: `JettyTransporterTest` (89 tests), `ApacheTransporterTest` (93), and `JdkTransporterTest` (92) all pass; the HTTP/3 requests in `testGet_HTTP3` are served over HTTP/3.0.