### PR TITLE
Fix #1994: log exceptions from IpcNamedLock.tryUnlock()

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcNamedLock.java
@@ -112,6 +112,7 @@ class IpcNamedLock extends NamedLockSupport {
             // Best-effort cleanup: if unlock fails during timeout handling,
             // we must not propagate the exception — doing so would crash the
             // calling thread and skip latch countdowns in tests, causing hangs.
+            logger.warn("Unable to unlock (contextId = {}) after timeout", contextId, e);
         }
     }
 

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockTest.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcNamedLockTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.named.ipc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.aether.named.NamedLockKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IpcNamedLockTest {
+
+    @Test
+    void unlockFailureDuringTimeoutCleanupIsLogged() throws Exception {
+        IpcClient client = mock(IpcClient.class);
+        IpcNamedLockFactory factory = mock(IpcNamedLockFactory.class);
+
+        NamedLockKey key = NamedLockKey.of("test");
+        Collection<String> keys = Collections.singleton("test");
+        IpcNamedLock lock = new IpcNamedLock(key, factory, client, keys);
+
+        when(client.newContext(true, 100L, TimeUnit.MILLISECONDS)).thenReturn("ctx-1");
+        doThrow(new TimeoutException("lock timed out")).when(client).lock("ctx-1", keys, 100L, TimeUnit.MILLISECONDS);
+        doThrow(new RuntimeException("simulated unlock failure")).when(client).unlock("ctx-1");
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errBuffer, true, StandardCharsets.UTF_8));
+        try {
+            assertFalse(lock.lockShared(100L, TimeUnit.MILLISECONDS));
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        String logOutput = errBuffer.toString(StandardCharsets.UTF_8);
+        assertTrue(
+                logOutput.contains("simulated unlock failure"),
+                "expected unlock failure to be logged, but was: " + logOutput);
+    }
+}


### PR DESCRIPTION
Fixes #1994

`IpcNamedLock.tryUnlock()` was silently discarding all exceptions from `client.unlock()` during timeout cleanup, masking real IO/connectivity issues.

**Fix:** log the failure at WARN level instead of swallowing it. The exception is still not propagated, preserving the best-effort cleanup semantics that must not crash the calling thread.

**Test:** added `IpcNamedLockTest.unlockFailureDuringTimeoutCleanupIsLogged`, which mocks `IpcClient` so that `lock()` times out and `unlock()` throws, then asserts the unlock failure is logged. The test fails against the old code (no log output) and passes with the fix.