### PR TITLE
docs: rewrite how-resolver-works.md to STE rules

### DIFF
--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -47,7 +47,7 @@ The local repository is usually a directory on the local file system.
 Remote repositories are usually HTTP servers.
 
 *Resolving* is the process of finding
-an artifact from its coordinates and adding it to the Maven build.
+*Resolving* is the process of locating an artifact from its coordinates and obtaining its content.
 It involves the following steps:
 
 1. **Dependency graph collection** builds the dependency graph.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -73,21 +73,19 @@ Normally you don't need to think about this.
 ### Dependency Graph Collection
 
 Collection is the first step.
-Resolver adds a root artifact to the list.
-TODO: breadth first or depth first????
-Then it looks at the dependencies of that root artifact and adds them to the list.
-Then it looks at the dependencies of each of those dependencies and adds each of those 
-it has not already seen to the list.  
-The output of the collection step is a **dependency graph** known as the *dirty graph*.
+Resolver adds a root artifact to a graph.
+Then it adds the dependencies of the root artifact to the graph.
+Then it adds the dependencies of the dependencies, and so on.
+It stops when there are no more dependencies that haven't been added to the graph. 
+The output of the collection step is a *dependency graph* known as the *dirty graph*.
 It can contain conflicts and duplicates.
 
-Since Resolver 1.9.x, two collector implementations exist.
-The legacy collector uses depth-first (DF) traversal.
-The new collector uses breadth-first (BF) traversal.
-The BF collector is the default now.
-It offers better performance.
-
-WTF???? This is a huge incompatible change that will break projects. 
+The exact procedure for building the dirty graph isn't important as long as 
+it ends with the same graph.
+Starting in Resolver 1.9.x, there are two collector implementations.
+The legacy collector traverses in depth-first order.
+The new collector traverses in breadth-first (BF) order.
+The BF collector is faster and is now the default.
 
 During collection, only certain parts of the effective model are used, not the whole POM.
 

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -46,8 +46,7 @@ repositories.
 The local repository is usually a directory on the local file system.
 Remote repositories are usually HTTP servers.
 
-*Resolving* is the process of finding
-*Resolving* is the process of locating an artifact from its coordinates and obtaining its content.
+*Resolving* is the process of finding an artifact from its coordinates and storing it locally.
 It involves the following steps:
 
 1. **Dependency graph collection** builds the dependency graph.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -116,15 +116,11 @@ The resolver does not download anything.
 Resolver 2.x has two conflict resolution implementations.
 The legacy implementation does multiple graph passes.
 The faster path-based implementation does a single graph pass.
-TODO: do they give the same result?
+
 The strategy for selecting winners is pluggable in Resolver 2.x.
-
 Nearest and highest strategies are available out of the box.
-
 Experimental version convergence and major version convergence strategies are also
 available, but these are not enabled by default.
-
-
 
 ### Flattening
 

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -64,19 +64,22 @@ The repository can be local or remote.
 To make an artifact resolvable from the local repository, you install it.
 To make an artifact resolvable from a remote repository, you deploy it.
 
-Extension points such as `WorkspaceReader` can make artifacts resolvable when
-you do not install or deploy them.
-This is an integration detail.
-Maven does this when it exposes reactor projects.
+<aside>
+Artifacts that are not in repositories also be resolved through extension points such as `WorkspaceReader`.
+Maven does this when it exposes reactor projects, for example.
+Normally you don't need to think about this.
+</aside>
 
 ### Dependency Graph Collection
 
 Collection is the first step.
-The caller usually provides the root artifact and the set of remote
-repositories to use.
-The output of the collection step is a **dependency graph**.
-The graph is also known as the dirty graph.
-It can contain cycles, conflicts, and duplicates.
+Resolver adds a root artifact to the list.
+TODO: breadth first or depth first????
+Then it looks at the dependencies of that root artifact and adds them to the list.
+Then it looks at the dependencies of each of those dependencies and adds each of those 
+it has not already seen to the list.  
+The output of the collection step is a **dependency graph** known as the *dirty graph*.
+It can contain conflicts and duplicates.
 
 Since Resolver 1.9.x, two collector implementations exist.
 The legacy collector uses depth-first (DF) traversal.
@@ -84,9 +87,9 @@ The new collector uses breadth-first (BF) traversal.
 The BF collector is the default now.
 It offers better performance.
 
-People constantly misunderstand the information used during graph collection.
-Only certain parts of the effective model are used, not the whole POM.
-Only the following aspects of the effective model are used:
+WTF???? This is a huge incompatible change that will break projects. 
+
+During collection, only certain parts of the effective model are used, not the whole POM.
 
 * `project/dependencies` defines the direct dependencies on a given node.
 * `project/dependencyManagement/dependencies` defines the dependency management
@@ -94,70 +97,61 @@ Only the following aspects of the effective model are used:
 * `project/repositories` defines the repositories to be used on subsequent
   nodes.
 
+
+TODO: what is an artifact descriptor?
+
+TODO: likely don't need this
 Read the API documentation for
 `org.eclipse.aether.resolution.ArtifactDescriptorResult`.
 This class is the peephole for Resolver to see the effective model.
 
+TODO: what is transitive dependency management and do we want to talk about it here?
 Resolver 1.x ignored transitive dependency management by default.
 Resolver 2.x changed this.
 Transitive dependency management is enabled by default in Resolver 2.x.
 
-These steps operate only on models.
-Only POMs are resolved.
-Their effective models are built during graph collection.
+During the collection step, Resolver downloads pom.xml file from remote repositories.
+It does not yet download binary JAR files or other artifacts.
 
 See also [common misconceptions](common-misconceptions.html).
 
 ### Conflict Resolution
 
-Conflict resolution is the process that removes conflicts, duplicates, and
-cycles from the dependency graph.
+Conflict resolution removes conflicts, duplicates, and cycles from the dependency graph.
 The result is the **dependency tree**.
-Cycles are removed.
 
-Resolver 2.x has two conflict resolver implementations.
+Resolver 2.x has two conflict resolution implementations.
 The legacy implementation does multiple graph passes.
-The path-based implementation does a single graph pass.
-It is faster.
+The faster path-based implementation does a single graph pass.
+TODO: do they give the same result?
 The winner selection strategy is pluggable since Resolver 2.x.
 
 The nearest and highest strategies are available out of the box.
 The version convergence and major version convergence strategies are also
 available.
-They are not enabled by default.
-They are experimental.
+They are experimental and not enabled by default.
 
-This step operates only on the graph stored in memory.
-There is no resolution of any kind.
+This step operates entirely in memory.
+The resolver does not download anything.
 
 ### Flattening
 
-Flattening is the process that transforms the tree into a flat list of
-artifacts.
+Flattening transforms the tree into a list of artifacts.
 The list order becomes the classpath order.
 Filtering is applied here as well.
 
 Resolver historically used pre-order to flatten the tree into a list.
-Resolver 2 offers three strategies.
-They are pre-order, post-order, and level order.
+Resolver 2 offers three strategies: pre-order, post-order, and level order.
 Level order is the default.
 
-This step operates only on the tree stored in memory.
-There is no resolution of any kind.
+This step operates entirely in memory.
+The resolver does not download anything.
 
 ### Artifact Resolution
 
-Artifact resolution is the process that resolves the actual artifact content
-from the local repository.
-When needed, Resolver downloads and caches the content.
-
-Dependency graph collection uses this step implicitly.
-The collector asks for the artifact descriptor of each artifact during graph
-collection.
-The artifact descriptor is the effective model.
-The artifact descriptor call enters the model builder.
-During the build, the model builder resolves POMs as needed.
-Examples are parent POMs, import POMs, and mixins.
+Artifact resolution checks to see if the binary artifact resource, most commonly a JAR file, is
+in the local repository. If it isn't, then Resolver downloads the file
+from a remote repository and caches it in the local repository.
 
 ----
 

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -118,7 +118,8 @@ See also [common misconceptions](common-misconceptions.html).
 ### Conflict Resolution
 
 Conflict resolution removes conflicts, duplicates, and cycles from the dependency graph.
-The result is the **dependency tree**.
+The result is the **dependency tree**. This step operates entirely in memory.
+The resolver does not download anything.
 
 Resolver 2.x has two conflict resolution implementations.
 The legacy implementation does multiple graph passes.
@@ -127,12 +128,11 @@ TODO: do they give the same result?
 The strategy for selecting winners is pluggable in Resolver 2.x.
 
 Nearest and highest strategies are available out of the box.
-Version convergence and major version convergence strategies are also
-available.
-They are experimental and not enabled by default.
 
-This step operates entirely in memory.
-The resolver does not download anything.
+Experimental version convergence and major version convergence strategies are also
+available, but these are not enabled by default.
+
+
 
 ### Flattening
 

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -87,29 +87,23 @@ The legacy collector traverses in depth-first order.
 The new collector traverses in breadth-first (BF) order.
 The BF collector is faster and is now the default.
 
+During the collection step, Resolver downloads pom.xml files from remote repositories.
+It does not yet download binary JAR files or other artifacts.
+
 During collection, only certain parts of the effective model are used, not the whole POM.
 
-* `project/dependencies` defines the direct dependencies on a given node.
+* `project/dependencies` defines the direct dependencies of a given node.
 * `project/dependencyManagement/dependencies` defines the dependency management
   for subsequent nodes.
 * `project/repositories` defines the repositories to be used on subsequent
   nodes.
 
+In Resolver 1.x, `project/dependencyManagement` only defines versions of dependencies
+for its own pom.xml. It does not affect the versions of the dependencies of the dependencies.
+(*transitive dependencies*).
 
-TODO: what is an artifact descriptor?
-
-TODO: likely don't need this
-Read the API documentation for
-`org.eclipse.aether.resolution.ArtifactDescriptorResult`.
-This class is the peephole for Resolver to see the effective model.
-
-TODO: what is transitive dependency management and do we want to talk about it here?
-Resolver 1.x ignored transitive dependency management by default.
-Resolver 2.x changed this.
-Transitive dependency management is enabled by default in Resolver 2.x.
-
-During the collection step, Resolver downloads pom.xml files from remote repositories.
-It does not yet download binary JAR files or other artifacts.
+In Resolver 2.x, `project/dependencyManagement` does define versions of dependencies
+for the transitive dependencies.
 
 See also [common misconceptions](common-misconceptions.html).
 

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -8,7 +8,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -55,7 +55,7 @@ It involves the following steps:
    graph. It produces the dependency tree.
 3. **Flattening** transforms the tree into a list of artifacts. The list
    order represents the classpath order.
-4. **Artifact resolution** finds the artifact in one of the available repositories. If necessary, it downloads
+4. **Artifact resolution** finds each artifact in the flattened list in one of the available repositories. If necessary, it downloads
    the artifact from a remote repository and adds it to the local repository.
 
 We call an artifact *resolvable* if it can be resolved from any available

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -22,49 +22,47 @@ Maven Artifact Resolver (formerly Aether) is a central piece of Maven.
 This document explains how Resolver works internally.
 It also explains the main concepts and components of Resolver.
 
-Resolver alone is incomplete.
-Applications such as Maven provide the glue.
-The glue includes the models and the logic to resolve versions and ranges and
-to build effective models.
-By itself, Resolver is unusable.
-You must complement it with models and implementations of missing components.
-The Maven module `org.apache.maven:maven-resolver-provider` completes Resolver.
+Resolver alone is incomplete. It needs an application such as 
+Maven to resolve versions and build effective models.
+The Maven module `org.apache.maven:maven-resolver-provider` complements it with
+models and implementations of missing components.
+
 
 ## Core Concepts
 
 **Artifacts** and **repositories** are at the core of Resolver.
-An artifact is a symbolic coordinate backed by some content.
-Usually it is a JAR, but it can be anything as long as Maven coordinates can
+An *artifact* is a binary resource with Maven coordinates.
+Usually it is a JAR file, but it can be anything as long as Maven coordinates can
 address it.
 The Maven coordinates are
 `<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>`.
 The default value of `extension` is `jar`.
 The default value of `classifier` is an empty string.
 
-Repositories are places where artifacts are stored and from where they can be
+A *repository* is a place where artifacts are stored and from where they can be
 retrieved.
 By default, Resolver operates with one local repository and zero or more remote
 repositories.
 The local repository is usually a directory on the local file system.
+Remote repositories are usually HTTP servers.
 
-The term resolving is overloaded.
-In general, it involves the following steps:
+*Resolving* is the process of finding
+an artifact from its coordinates and adding it to the Maven build.
+It involves the following steps:
 
 1. **Dependency graph collection** builds the dependency graph.
 2. **Conflict resolution** removes conflicts, duplicates, and cycles from the
    graph. It produces the dependency tree.
-3. **Flattening** transforms the tree into a flat list of artifacts. The list
+3. **Flattening** transforms the tree into a list of artifacts. The list
    order represents the classpath order.
-4. **Artifact resolution** resolves the actual artifact payload. It downloads
-   and caches the payload when needed.
+4. **Artifact resolution** finds the artifact in one of the available repositories. If necessary, it downloads
+   the artifact from a remote repository and adds it to the local repository.
 
-We call an artifact resolvable if it can be resolved from any available
+We call an artifact *resolvable* if it can be resolved from any available
 repository.
 The repository can be local or remote.
-To make an artifact resolvable from the local repository, you must install it.
-To make an artifact resolvable from a remote repository, you must deploy it.
-This is an over-simplification.
-Publishing is a new term, but it also involves the deploy step.
+To make an artifact resolvable from the local repository, you install it.
+To make an artifact resolvable from a remote repository, you deploy it.
 
 Extension points such as `WorkspaceReader` can make artifacts resolvable when
 you do not install or deploy them.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -18,111 +18,167 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Maven Artifact Resolver (former Aether) is a central piece of Maven.
-This document tries to  explain how resolver works under the hood, and explain the main concepts
-and building blocks of Resolver.
+Maven Artifact Resolver (formerly Aether) is a central piece of Maven.
+This document explains how Resolver works internally.
+It also explains the main concepts and components of Resolver.
 
-Resolver alone is "incomplete". Integrating applications like Maven provide the "glue" (models) and logic to 
-resolve versions and ranges and build effective models. By itself, Resolver is unusable. One needs to complement it 
-with models and implementations of missing components. Historically, the Maven module completing Resolver 
-is `org.apache.maven:maven-resolver-provider`.
-
-
+Resolver alone is incomplete.
+Applications such as Maven provide the glue.
+The glue includes the models and the logic to resolve versions and ranges and
+to build effective models.
+By itself, Resolver is unusable.
+You must complement it with models and implementations of missing components.
+The Maven module `org.apache.maven:maven-resolver-provider` completes Resolver.
 
 ## Core Concepts
 
-At the core of Resolver are **artifacts** and **repositories**. An artifact is basically a 
-"symbolic coordinate" backed by some content. Usually it is a JAR, but it can be really anything, as long as it is
-"addressable" using Maven coordinates: `<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>` (default value of
-`extension` is `jar`, and default value for `classifier` is `""`, empty string). Repositories
-are places where artifacts are stored and from where they can be retrieved. Resolver, by default operates
-with one local repository (usually a directory on local filesystem) and zero or more remote repositories.
+**Artifacts** and **repositories** are at the core of Resolver.
+An artifact is a symbolic coordinate backed by some content.
+Usually it is a JAR, but it can be anything as long as Maven coordinates can
+address it.
+The Maven coordinates are
+`<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>`.
+The default value of `extension` is `jar`.
+The default value of `classifier` is an empty string.
 
-The term "resolving" is a bit overloaded, but in general it involves following steps:
-1. **dependency graph collection** builds the "dependency graph"
-2. **conflict resolution** makes the graph free of cycles, conflicts and duplicates, resulting in "dependency tree"
-3. **flattening** transforms the tree into a flat list of artifacts, which also represents classpath ordering
-4. **artifact resolving** is the process of resolving (downloading and caching, if needed) the actual artifact payload
+Repositories are places where artifacts are stored and from where they can be
+retrieved.
+By default, Resolver operates with one local repository and zero or more remote
+repositories.
+The local repository is usually a directory on the local file system.
 
-We call an artifact "resolvable" if it can be resolved from any available (local or remote) repository. To make an artifact
-"resolvable" from the local repository, one needs to "install" it. To make an artifact "resolvable" from a remote repository, 
-one needs to "deploy" it (this is an over-simplification; publishing is a new term, but it also involves deploy step).
-Furthermore, there are extension points like `WorkspaceReader` that can make artifacts resolvable 
-without installing or deploying them, but that is an integration detail (like Maven does by exposing reactor projects).
+The term resolving is overloaded.
+In general, it involves the following steps:
+
+1. **Dependency graph collection** builds the dependency graph.
+2. **Conflict resolution** removes conflicts, duplicates, and cycles from the
+   graph. It produces the dependency tree.
+3. **Flattening** transforms the tree into a flat list of artifacts. The list
+   order represents the classpath order.
+4. **Artifact resolution** resolves the actual artifact payload. It downloads
+   and caches the payload when needed.
+
+We call an artifact resolvable if it can be resolved from any available
+repository.
+The repository can be local or remote.
+To make an artifact resolvable from the local repository, you must install it.
+To make an artifact resolvable from a remote repository, you must deploy it.
+This is an over-simplification.
+Publishing is a new term, but it also involves the deploy step.
+
+Extension points such as `WorkspaceReader` can make artifacts resolvable when
+you do not install or deploy them.
+This is an integration detail.
+Maven does this when it exposes reactor projects.
 
 ### Dependency Graph Collection
 
-Collection is the first step. The caller usually provides the root artifact along with the set of remote repositories to use.
-The output of the collection step is a **dependency graph**; a.k.a. a "dirty graph" that may contain cycles, conflicts, 
-duplicates and the like.
+Collection is the first step.
+The caller usually provides the root artifact and the set of remote
+repositories to use.
+The output of the collection step is a **dependency graph**.
+The graph is also known as the dirty graph.
+It can contain cycles, conflicts, and duplicates.
 
-Since Resolver 1.9.x there are two collector implementations: the legacy depth-first (DF) and the new breadth-first (BF) collector.
-The BF collector is now the default, as it offers better performance.
+Since Resolver 1.9.x, two collector implementations exist.
+The legacy collector uses depth-first (DF) traversal.
+The new collector uses breadth-first (BF) traversal.
+The BF collector is the default now.
+It offers better performance.
 
-One very important thing, that is constantly misunderstood, is what information is used during graph collection. 
+People constantly misunderstand the information used during graph collection.
 Only certain parts of the effective model are used, not the whole POM.
-If I may oversimplify, only the following aspects of the effective model are used during graph collection:
-* `project/dependencies` as direct dependencies on given node
-* `project/dependencyManagement/dependencies` for **subsequent** dependency management on given node
-* `project/repositories` for **subsequent** repositories to be used on given node
+Only the following aspects of the effective model are used:
 
-For more, check out `org.eclipse.aether.resolution.ArtifactDescriptorResult` class, as that is the "peephole" for Resolver
-to see the effective model.
+* `project/dependencies` defines the direct dependencies on a given node.
+* `project/dependencyManagement/dependencies` defines the dependency management
+  for subsequent nodes.
+* `project/repositories` defines the repositories to be used on subsequent
+  nodes.
 
-Another important detail is that Resolver 1.x by default ignored transitive dependency management. This changed in
-Resolver 2.x where transitive dependency management is enabled by default.
+Read the API documentation for
+`org.eclipse.aether.resolution.ArtifactDescriptorResult`.
+This class is the peephole for Resolver to see the effective model.
 
-These steps operate only on models. Only POMs are resolved, and their effective models are built during
-graph collection.
+Resolver 1.x ignored transitive dependency management by default.
+Resolver 2.x changed this.
+Transitive dependency management is enabled by default in Resolver 2.x.
+
+These steps operate only on models.
+Only POMs are resolved.
+Their effective models are built during graph collection.
 
 See also [common misconceptions](common-misconceptions.html).
 
 ### Conflict Resolution
 
-Conflict resolution is the process of removing conflicts, duplicates, and cycles from the dependency graph, resulting 
-in the **dependency tree** (as cycles are removed).
+Conflict resolution is the process that removes conflicts, duplicates, and
+cycles from the dependency graph.
+The result is the **dependency tree**.
+Cycles are removed.
 
-Resolver 2.x has two conflict resolver implementations: "legacy" (doing multiple graph passes) and new, 
-faster "path based" (doing single graph pass) conflict resolver. Winner selection strategy is also pluggable since 
-Resolver 2.x. Out of the box "nearest" and "highest" strategies are available (extras as "version convergence" and
-"major version convergence" are available as well, but not available by default; experimental).
+Resolver 2.x has two conflict resolver implementations.
+The legacy implementation does multiple graph passes.
+The path-based implementation does a single graph pass.
+It is faster.
+The winner selection strategy is pluggable since Resolver 2.x.
 
-This step operates only on the graph stored in memory. There is no resolution of any kind.
+The nearest and highest strategies are available out of the box.
+The version convergence and major version convergence strategies are also
+available.
+They are not enabled by default.
+They are experimental.
+
+This step operates only on the graph stored in memory.
+There is no resolution of any kind.
 
 ### Flattening
 
-Flattening is the process of transforming the tree into a flat list of artifacts. This list order becomes the classpath order.
-This is where filtering is applied as well.
+Flattening is the process that transforms the tree into a flat list of
+artifacts.
+The list order becomes the classpath order.
+Filtering is applied here as well.
 
-Resolver historically used "pre-order" to flatten the tree into a list, but Resolver 2 offers three strategies: "pre-order", 
-"post-order", and "level order" (the default).
+Resolver historically used pre-order to flatten the tree into a list.
+Resolver 2 offers three strategies.
+They are pre-order, post-order, and level order.
+Level order is the default.
 
-This step operates only on the tree stored in memory. There is no resolution of any kind.
+This step operates only on the tree stored in memory.
+There is no resolution of any kind.
 
 ### Artifact Resolution
 
-Artifact resolution is the process of resolving (downloading and caching, if needed) the actual artifact content from 
-local repository.
+Artifact resolution is the process that resolves the actual artifact content
+from the local repository.
+When needed, Resolver downloads and caches the content.
 
-This step is implicitly used by the Dependency Graph Resolution step as well, as collector
-will ask for artifact descriptors (effective model) of each artifact during graph collection, and artifact descriptor calls
-into model builder, that in turn, during building, resolve POMs as needed (parent POMs, import POMs, mixins, etc).
+Dependency graph collection uses this step implicitly.
+The collector asks for the artifact descriptor of each artifact during graph
+collection.
+The artifact descriptor is the effective model.
+The artifact descriptor call enters the model builder.
+During the build, the model builder resolves POMs as needed.
+Examples are parent POMs, import POMs, and mixins.
 
 ----
 
-In general, the steps "dependency graph collection" and "conflict resolution" are performed together. The name we give that operation is "dependency collection".
-The "flattening" and "artifact resolving" are also usually done together, and we use for those the term "artifact resolution".
-To make the story more confusing, when all the steps are performed together is also called "dependency resolution".
-The Resolver API reflects this terminology and offers methods doing collection, resolution or both.
+In general, Resolver performs dependency graph collection and conflict
+resolution together.
+The name for this operation is dependency collection.
+Resolver also usually performs flattening and artifact resolution together.
+The name for this pair is artifact resolution.
+When all the steps are performed together, the process is called dependency
+resolution.
+The Resolver API reflects this terminology and offers methods for collection,
+resolution, or both.
 
-* The method `CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)` performs only the collection step,
-as its name suggests. Hence, only the steps "collection" and "conflict resolution" are performed.
-* Method `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<? extends ArtifactRequest> requests)`
-performs only the artifact resolving step.
-* Method `DependencyResult resolveDependencies(RepositorySystemSession session, DependencyRequest request)` performs both 
-collection and resolution steps.
+* `CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)` performs only the collection step. Only the collection and conflict resolution steps are performed.
+* `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<? extends ArtifactRequest> requests)` performs only the artifact resolution step.
+* `DependencyResult resolveDependencies(RepositorySystemSession session, DependencyRequest request)` performs both the collection and resolution steps.
 
-Each subsequent step depends on the previous one. For example a "dirty graph" cannot be flattened (due to possible cycles).
-Many times, what you want depends on your use case. For example, to investigate the dependency graph, one may 
-want to collect the dirty graph, but not conflict resolve it.
-
+Each subsequent step depends on the previous one.
+For example, a dirty graph cannot be flattened because it can contain cycles.
+What you want depends on your use case.
+To investigate the dependency graph, you can collect the dirty graph.
+You can skip conflict resolution.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -65,7 +65,7 @@ To make an artifact resolvable from the local repository, you install it.
 To make an artifact resolvable from a remote repository, you deploy it.
 
 <aside>
-Artifacts that are not in repositories also be resolved through extension points such as `WorkspaceReader`.
+Artifacts that are not in repositories can also be resolved through extension points such as `WorkspaceReader`.
 Maven does this when it exposes reactor projects, for example.
 Normally you don't need to think about this.
 </aside>

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -157,7 +157,7 @@ The Resolver API reflects this terminology and offers methods for collection,
 resolution, or both.
 
 * `CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)` performs the dependency collection step. It builds the dependency graph and resolves conflicts in that graph before returning.
-* `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<? extends ArtifactRequest> requests)` performs the artifact resolution step. It builds a flattened list and downloads artifacts before returning.
+* `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<ArtifactRequest> requests)` performs the artifact resolution step. It builds a flattened list and downloads artifacts before returning.
 * `DependencyResult resolveDependencies(RepositorySystemSession session, DependencyRequest request)` performs both the collection and resolution steps.
 
 Each step depends on the previous one.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -155,22 +155,28 @@ from a remote repository and caches it in the local repository.
 
 ----
 
-In general, Resolver performs dependency graph collection and conflict
-resolution together.
-The name for this operation is dependency collection.
-Resolver also usually performs flattening and artifact resolution together.
-The name for this pair is artifact resolution.
-When all the steps are performed together, the process is called dependency
-resolution.
+In general, Resolver builds the dependency graph and resolves conflicts in that graph in the same pass.
+The name for this operation is *dependency collection*.
+
+Resolver also usually resolves artifacts as it builds the flattened list.
+The name for this combined step is *artifact resolution*.
+
+When all the steps are performed together, the process is called *dependency
+resolution*.
+
+Yes, this is an unfortunate overload of terminology. 
+
 The Resolver API reflects this terminology and offers methods for collection,
 resolution, or both.
 
-* `CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)` performs only the collection step. Only the collection and conflict resolution steps are performed.
-* `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<? extends ArtifactRequest> requests)` performs only the artifact resolution step.
+* `CollectResult collectDependencies(RepositorySystemSession session, CollectRequest request)` performs the dependency collection step. It builds the dependency graph and resolves conflicts in that graph before returning.
+* `List<ArtifactResult> resolveArtifacts(RepositorySystemSession session, Collection<? extends ArtifactRequest> requests)` performs the artifact resolution step. It builds a flattened list and downloads artifacts before returning.
 * `DependencyResult resolveDependencies(RepositorySystemSession session, DependencyRequest request)` performs both the collection and resolution steps.
 
-Each subsequent step depends on the previous one.
+Each step depends on the previous one.
 For example, a dirty graph cannot be flattened because it can contain cycles.
-What you want depends on your use case.
-To investigate the dependency graph, you can collect the dirty graph.
-You can skip conflict resolution.
+
+While a standard Maven build will perform all these steps, 
+you can use them independently if you're doing something else.
+For example, if you're looking for linkage errors, you can collect the dirty graph for inspection
+and skip conflict resolution.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -110,7 +110,7 @@ Resolver 1.x ignored transitive dependency management by default.
 Resolver 2.x changed this.
 Transitive dependency management is enabled by default in Resolver 2.x.
 
-During the collection step, Resolver downloads pom.xml file from remote repositories.
+During the collection step, Resolver downloads pom.xml files from remote repositories.
 It does not yet download binary JAR files or other artifacts.
 
 See also [common misconceptions](common-misconceptions.html).
@@ -150,7 +150,7 @@ The resolver does not download anything.
 ### Artifact Resolution
 
 Artifact resolution checks to see if the binary artifact resource, most commonly a JAR file, is
-in the local repository. If it isn't, then Resolver downloads the file
+in the local repository. If it isn't, Resolver downloads the file
 from a remote repository and caches it in the local repository.
 
 ----

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -78,7 +78,7 @@ Then it adds the dependencies of the root artifact to the graph.
 Then it adds the dependencies of the dependencies, and so on.
 It stops when there are no more dependencies that haven't been added to the graph. 
 The output of the collection step is a *dependency graph* known as the *dirty graph*.
-It can contain conflicts and duplicates.
+It can contain conflicts, duplicates, and cycles.
 
 The exact procedure for building the dirty graph isn't important as long as 
 it ends with the same graph.

--- a/src/site/markdown/how-resolver-works.md
+++ b/src/site/markdown/how-resolver-works.md
@@ -124,10 +124,10 @@ Resolver 2.x has two conflict resolution implementations.
 The legacy implementation does multiple graph passes.
 The faster path-based implementation does a single graph pass.
 TODO: do they give the same result?
-The winner selection strategy is pluggable since Resolver 2.x.
+The strategy for selecting winners is pluggable in Resolver 2.x.
 
-The nearest and highest strategies are available out of the box.
-The version convergence and major version convergence strategies are also
+Nearest and highest strategies are available out of the box.
+Version convergence and major version convergence strategies are also
 available.
 They are experimental and not enabled by default.
 


### PR DESCRIPTION
Along with the usual style improvements:

* Much more precise and careful definitions of  terms. The previous definition of artifact was simply wrong.