### PR TITLE
Fix compilation error in DefaultRepositorySystemReentrancyTest

### DIFF
--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRepositorySystemReentrancyTest.java
@@ -359,7 +359,7 @@ public class DefaultRepositorySystemReentrancyTest {
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
                 new DefaultRepositorySystemValidator(
-                        Collections.singletonList(EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
+                        Collections.singletonMap("expressionRejecting", EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
         systemRef.set(strictSystem);
 
         // The outermost collectDependencies call should succeed, and the inner
@@ -396,7 +396,7 @@ public class DefaultRepositorySystemReentrancyTest {
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
                 new DefaultRepositorySystemValidator(
-                        Collections.singletonList(EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
+                        Collections.singletonMap("expressionRejecting", EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
 
         // Direct dependency with uninterpolated expression should still be rejected
         CollectRequest collectRequest = new CollectRequest();
@@ -455,7 +455,7 @@ public class DefaultRepositorySystemReentrancyTest {
                 new DefaultRepositorySystemLifecycle(),
                 Collections.emptyMap(),
                 new DefaultRepositorySystemValidator(
-                        Collections.singletonList(EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
+                        Collections.singletonMap("expressionRejecting", EXPRESSION_REJECTING_VALIDATOR_FACTORY)));
 
         // First call: collectDependencies should throw because the collector throws
         CollectRequest collectRequest = new CollectRequest();


### PR DESCRIPTION
## Summary

- Commit 89f2bc1b ("Extend re-entrancy detection for broken trace chains") added three new test methods in `DefaultRepositorySystemReentrancyTest` that construct `DefaultRepositorySystemValidator` using `Collections.singletonList(EXPRESSION_REJECTING_VALIDATOR_FACTORY)`
- However, commit f164aa90 ("Allow validator factory to abstain", #2008) changed the constructor from `List<ValidatorFactory>` to `Map<String, ValidatorFactory>`
- This causes a compilation failure on **all 18 CI jobs** (every OS × JDK × Maven combination): `incompatible types: no instance(s) of type variable(s) T exist so that java.util.List<T> conforms to java.util.Map<java.lang.String,org.eclipse.aether.spi.validator.ValidatorFactory>`

The fix replaces `Collections.singletonList(...)` with `Collections.singletonMap("expressionRejecting", ...)` at all three call sites (lines 361, 398, 457), consistent with the existing correct usage at line 174.

## Test plan

- [x] `mvn -pl maven-resolver-impl test-compile` compiles successfully
- [x] `mvn -pl maven-resolver-impl test -Dtest=DefaultRepositorySystemReentrancyTest` — all 11 tests pass
- [ ] CI should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)