### PR TITLE
Drop the versions.junit5 property the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,9 +124,6 @@
     <minimalJavaBuildVersion>[21,)</minimalJavaBuildVersion>
     <project.build.outputTimestamp>2026-07-20T13:03:11Z</project.build.outputTimestamp>
     <bnd.instructions.additions />
-
-    <!-- Parent versions -->
-    <versions.junit5>5.14.4</versions.junit5>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
`org.apache.maven:maven-parent:49` already sets `versions.junit5` to **5.14.4** — the identical value — and it is the only pom that reads the property: nothing in this repository references `${versions.junit5}`. The local copy therefore changes nothing and simply has to be kept in step with the parent by hand.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything. `mvn help:effective-pom` is unchanged by this removal.

Generated-by: Claude Opus 5 (1M context)
