### PR TITLE
Fix #1998: use try-with-resources in test file utilities

### DIFF
--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileProcessor.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileProcessor.java
@@ -63,23 +63,9 @@ public class TestFileProcessor implements FileProcessor {
     public void write(File file, String data) throws IOException {
         mkdirs(file.getParentFile());
 
-        FileOutputStream fos = null;
-        try {
-            fos = new FileOutputStream(file);
-
+        try (FileOutputStream fos = new FileOutputStream(file)) {
             if (data != null) {
                 fos.write(data.getBytes(StandardCharsets.UTF_8));
-            }
-
-            fos.close();
-            fos = null;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
             }
         }
     }
@@ -87,22 +73,8 @@ public class TestFileProcessor implements FileProcessor {
     public void write(File target, InputStream source) throws IOException {
         mkdirs(target.getAbsoluteFile().getParentFile());
 
-        OutputStream fos = null;
-        try {
-            fos = new BufferedOutputStream(new FileOutputStream(target));
-
+        try (OutputStream fos = new BufferedOutputStream(new FileOutputStream(target))) {
             copy(fos, source, null);
-
-            fos.close();
-            fos = null;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            }
         }
     }
 
@@ -113,38 +85,11 @@ public class TestFileProcessor implements FileProcessor {
     public long copy(File source, File target, ProgressListener listener) throws IOException {
         long total = 0;
 
-        InputStream fis = null;
-        OutputStream fos = null;
-        try {
-            fis = new FileInputStream(source);
+        mkdirs(target.getAbsoluteFile().getParentFile());
 
-            mkdirs(target.getAbsoluteFile().getParentFile());
-
-            fos = new BufferedOutputStream(new FileOutputStream(target));
-
+        try (InputStream fis = new FileInputStream(source);
+                OutputStream fos = new BufferedOutputStream(new FileOutputStream(target))) {
             total = copy(fos, fis, listener);
-
-            fos.close();
-            fos = null;
-
-            fis.close();
-            fis = null;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            } finally {
-                try {
-                    if (fis != null) {
-                        fis.close();
-                    }
-                } catch (final IOException e) {
-                    // Suppressed due to an exception already thrown in the try block.
-                }
-            }
         }
 
         return total;

--- a/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileUtils.java
+++ b/maven-resolver-test-util/src/main/java/org/eclipse/aether/internal/test/util/TestFileUtils.java
@@ -172,15 +172,10 @@ public class TestFileUtils {
     public static long copyFile(File source, File target) throws IOException {
         long total = 0;
 
-        FileInputStream fis = null;
-        OutputStream fos = null;
-        try {
-            fis = new FileInputStream(source);
+        mkdirs(target.getParentFile());
 
-            mkdirs(target.getParentFile());
-
-            fos = new BufferedOutputStream(new FileOutputStream(target));
-
+        try (FileInputStream fis = new FileInputStream(source);
+                OutputStream fos = new BufferedOutputStream(new FileOutputStream(target))) {
             for (byte[] buffer = new byte[1024 * 32]; ; ) {
                 int bytes = fis.read(buffer);
                 if (bytes < 0) {
@@ -190,28 +185,6 @@ public class TestFileUtils {
                 fos.write(buffer, 0, bytes);
 
                 total += bytes;
-            }
-
-            fos.close();
-            fos = null;
-
-            fis.close();
-            fis = null;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            } finally {
-                try {
-                    if (fis != null) {
-                        fis.close();
-                    }
-                } catch (final IOException e) {
-                    // Suppressed due to an exception already thrown in the try block.
-                }
             }
         }
 
@@ -228,22 +201,10 @@ public class TestFileUtils {
      */
     @Deprecated
     public static byte[] readBytes(File file) throws IOException {
-        RandomAccessFile in = null;
-        try {
-            in = new RandomAccessFile(file, "r");
+        try (RandomAccessFile in = new RandomAccessFile(file, "r")) {
             byte[] actual = new byte[(int) in.length()];
             in.readFully(actual);
-            in.close();
-            in = null;
             return actual;
-        } finally {
-            try {
-                if (in != null) {
-                    in.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            }
         }
     }
 
@@ -251,21 +212,9 @@ public class TestFileUtils {
     public static void writeBytes(File file, byte[] pattern, int repeat) throws IOException {
         file.deleteOnExit();
         file.getParentFile().mkdirs();
-        OutputStream out = null;
-        try {
-            out = new BufferedOutputStream(new FileOutputStream(file));
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
             for (int i = 0; i < repeat; i++) {
                 out.write(pattern);
-            }
-            out.close();
-            out = null;
-        } finally {
-            try {
-                if (out != null) {
-                    out.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
             }
         }
     }
@@ -287,40 +236,16 @@ public class TestFileUtils {
     }
 
     public static void readProps(File file, Properties props) throws IOException {
-        FileInputStream fis = null;
-        try {
-            fis = new FileInputStream(file);
+        try (FileInputStream fis = new FileInputStream(file)) {
             props.load(fis);
-            fis.close();
-            fis = null;
-        } finally {
-            try {
-                if (fis != null) {
-                    fis.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            }
         }
     }
 
     public static void writeProps(File file, Properties props) throws IOException {
         file.getParentFile().mkdirs();
 
-        FileOutputStream fos = null;
-        try {
-            fos = new FileOutputStream(file);
+        try (FileOutputStream fos = new FileOutputStream(file)) {
             props.store(fos, "aether-test");
-            fos.close();
-            fos = null;
-        } finally {
-            try {
-                if (fos != null) {
-                    fos.close();
-                }
-            } catch (final IOException e) {
-                // Suppressed due to an exception already thrown in the try block.
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1998

Convert manual `try-catch-finally` stream handling to try-with-resources in the test utilities:

- `TestFileUtils`: `copyFile`, `readBytes`, `writeBytes`, `readProps`, `writeProps`
- `TestFileProcessor`: `write(File, String)`, `write(File, InputStream)`, `copy(File, File, ProgressListener)`

Resources created inside each method are now closed reliably (with close exceptions properly suppressed), eliminating the leak when an explicit `close()` throws before the `finally` block. The caller-supplied `InputStream` in `TestFileProcessor.write/copy` remains intentionally unclosed, matching prior behavior.

No new tests required.