### PR TITLE
Reconcile the two download pages and modernise them

### DIFF
--- a/maven-resolver-demos/src/site/xdoc/download.xml.vm
+++ b/maven-resolver-demos/src/site/xdoc/download.xml.vm
@@ -23,104 +23,54 @@ under the License.
   <properties>
     <title>Download ${project.name} Source</title>
   </properties>
+
   <body>
     <section name="Download ${project.name} ${project.version} Source">
 
-      <p>${project.name} ${project.version} is distributed in source format. Use a source archive if you intend to build
-      ${project.name} yourself. Otherwise, simply use the ready-made binary artifacts from central repository.</p>
+      <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
 
-      <p>You will be prompted for a mirror - if the file is not found on yours, please be patient, as it may take 24
-      hours to reach all mirrors.<p/>
+      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
 
-      <p>In order to guard against corrupted downloads/installations, it is highly recommended to
-      <a href="https://www.apache.org/dev/release-signing#verifying-signature">verify the signature</a>
-      of the release bundles against the public <a href="https://www.apache.org/dist/maven/KEYS">KEYS</a> used by the Apache Maven
-      developers.</p>
+      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
 
-      <p>${project.name} is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
+      <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
-      <p></p>We <b>strongly</b> encourage our users to configure a Maven repository mirror closer to their location, please read <a href="/guides/mini/guide-mirror-settings.html">How to Use Mirrors for Repositories</a>.</p>
+      <p><strong>${project.name}</strong> is released as part of <strong>Maven Artifact Resolver</strong>; the source archive below is the Maven Artifact Resolver source release.</p>
 
-      <a name="mirror"/>
-      <subsection name="Mirror">
+      <subsection name="Files">
 
-        <p>
-          [if-any logo]
-          <a href="[link]">
-            <img align="right" src="[logo]" border="0"
-                 alt="logo"/>
-          </a>
-          [end]
-          The currently selected mirror is
-          <b>[preferred]</b>.
-          If you encounter a problem with this mirror,
-          please select another mirror.
-          If all mirrors are failing, there are
-          <i>backup</i>
-          mirrors
-          (at the end of the mirrors list) that should be available.
+        <p>This is the current stable version of <strong>${project.name}</strong>.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Link</th>
+              <th>Checksum</th>
+              <th>Signature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>${project.name} ${project.version} (Source zip)</td>
+              <td><a href="https://dlcdn.apache.org/maven/resolver/maven-resolver-${project.version}-source-release.zip">maven-resolver-${project.version}-source-release.zip</a></td>
+              <td><a href="https://downloads.apache.org/maven/resolver/maven-resolver-${project.version}-source-release.zip.sha512">maven-resolver-${project.version}-source-release.zip.sha512</a></td>
+              <td><a href="https://downloads.apache.org/maven/resolver/maven-resolver-${project.version}-source-release.zip.asc">maven-resolver-${project.version}-source-release.zip.asc</a></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+          using the checksum (.sha512 file)
+          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
         </p>
 
-        <form action="[location]" method="get" id="SelectMirror">
-          Other mirrors:
-          <select name="Preferred">
-            [if-any http]
-            [for http]
-            <option value="[http]">[http]</option>
-            [end]
-            [end]
-            [if-any ftp]
-            [for ftp]
-            <option value="[ftp]">[ftp]</option>
-            [end]
-            [end]
-            [if-any backup]
-            [for backup]
-            <option value="[backup]">[backup] (backup)</option>
-            [end]
-            [end]
-          </select>
-          <input type="submit" value="Change"/>
-        </form>
-
-        <p>
-          You may also consult the
-          <a href="https://www.apache.org/mirrors/">complete list of
-            mirrors.</a>
-        </p>
-
-      </subsection>
-      
-      <subsection name="${project.name} ${project.version}">
-        
-      <p>This is the current stable version of ${project.name}.</p>
-        
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>Link</th>
-            <th>Checksum</th>
-            <th>Signature</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>${project.name} ${project.version} (Source zip)</td>
-            <td><a href="[preferred]maven/resolver/${project.artifactId}-${project.version}-source-release.zip">maven/resolver/${project.artifactId}-${project.version}-source-release.zip</a></td>
-            <td><a href="https://www.apache.org/dist/maven/resolver/${project.artifactId}-${project.version}-source-release.zip.sha512">maven/resolver/${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
-            <td><a href="https://www.apache.org/dist/maven/resolver/${project.artifactId}-${project.version}-source-release.zip.asc">maven/resolver/${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
-          </tr>
-        </tbody>
-      </table>
       </subsection>
 
       <subsection name="Previous Versions">
-        
-      <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/resolver/">archive site</a>.</p>
-
+        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
+        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/resolver/">archive site</a>.</p>
       </subsection>
     </section>
   </body>
 </document>
-

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -36,7 +36,7 @@ under the License.
       <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
       <subsection name="Files">
-        
+
         <p>This is the current stable version of <strong>${project.name}</strong>.</p>
 
         <table>
@@ -72,4 +72,3 @@ under the License.
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
This repository carries **two** download pages from different generations: the root page in the current form, and `maven-resolver-demos/src/site/xdoc/download.xml.vm` still on the 2014 **mirror-selection form**, with its checksum and KEYS links pointing at `www.apache.org/dist` (a 301 to `downloads.apache.org` for years now).

### The module page advertised a file that does not exist

It offered `maven-resolver-demos-${project.version}-source-release.zip`. **That has never been released.** `maven-resolver-demos` ships inside the `maven-resolver` source release and has no source bundle of its own — `https://downloads.apache.org/maven/resolver/` confirms it.

Rather than making a wrong page prettier, the module page now points at the `maven-resolver` bundle that actually exists, and says so in a sentence, so a reader is not surprised by a page titled after the module offering an archive named after its parent. The URL stays live either way — it is reachable today and deleting it was not on the table.

### Also

- Both pages brought to the form the rest of the Maven estate uses (finishing the sweep started in 2023 that stopped part-way through).
- `www.apache.org/dist` → `downloads.apache.org` for checksums and KEYS.
- **The ASF licence headers are left byte-for-byte as they were.** My first pass spliced in a canonical header and silently downgraded an `https://` LICENSE-2.0 URL to `http://`; the generator now preserves each file's existing preamble and never rewrites it.
- The root page diff is whitespace only.

### Verification

XML well-formedness checked on both files, and the new module page rendered through a site build to confirm the headings, the added sentence and the download row come out right. Local checks only — not claiming CI is green; draft until it is.