### PR TITLE
Enable Dependabot updates for GitHub Actions on maven-resolver-1.9.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,13 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "maven-resolver-1.9.x"
+  labels:
+    - "resolver1"
+    - "dependencies"
+    - "github_actions"


### PR DESCRIPTION
Also track GH action versions on 1.9.x