### PR TITLE
Stop dependabot from offering guice 7 on the 1.9.x line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
   ignore:
     - dependency-name: "biz.aQute.bnd:bnd-maven-plugin"
       versions: [ "[7.0.0,)" ]
+    - dependency-name: "com.google.inject:guice"
+      versions: [ "[6.0.0,)" ]
     - dependency-name: "com.hazelcast:hazelcast"
       versions: [ "[5.4.0,)" ]
     - dependency-name: "javax.servlet:javax.servlet-api"


### PR DESCRIPTION
Guice 6 switched from `javax.inject` to `jakarta.inject`, so #2070 fails to compile on `maven-resolver-1.9.x`:

```
AetherModule.java:[282,17] no suitable method found for
  toProvider(java.lang.Class<...StaticNameMapperProvider>)
```

I checked whether the two could be supported at once. Changing the nine `*NameMapperProvider` classes from `javax.inject.Provider` to `com.google.inject.Provider` does make the module compile against guice 5.1.0 **and** 7.0.0, and all 358 `maven-resolver-impl` tests pass on 5.1.0. But on 7.0.0 `AetherModuleTest.testModuleCompleteness` then fails:

```
No implementation for DependencyCollectorDelegate was bound.
Did you mean?
  * DependencyCollectorDelegate annotated with @Named("bf") bound at AetherModule.configure(:162)
Requested by: AetherModule.dependencyCollectorDelegates(AetherModule.java:370)
```

Guice 7 dropped `javax.inject` annotation support outright, so the `@Named` qualifiers on the `@Provides` parameters are invisible to it. Fixing the `Provider` signature only moves the failure from compile time to injector creation. Taking guice 7 on this line means migrating the whole stack to `jakarta.inject`, which is not a maintenance-branch change.

Worth recording: both 5.1.0 and 7.0.0 are Java 8 bytecode, so the Java 8 baseline is not what blocks this. Master is unaffected — it has no `AetherModule`.

Supersedes #2070.

*This change was created with AI assistance.*