### PR TITLE
fix: validate post-transformation path shapes and assert containment at resolve sinks

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -64,7 +64,7 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
             path.append('.').append(artifact.getExtension());
         }
 
-        return path.toString();
+        return requireContainedPath(path.toString());
     }
 
     @Override
@@ -89,7 +89,25 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
 
         path.append(insertRepositoryKey(metadata.getType(), repositoryKey));
 
-        return path.toString();
+        return requireContainedPath(path.toString());
+    }
+
+    /**
+     * Defense in depth: verifies that the composed path, once resolved against the local repository base
+     * directory, cannot escape it. The coordinate validation performed on entry should already guarantee this;
+     * this is a last-resort check on the composed result (absolute path, empty segment or ".." segment).
+     */
+    private static String requireContainedPath(String path) {
+        if (path.startsWith("/")
+                || path.contains("//")
+                || path.equals("..")
+                || path.startsWith("../")
+                || path.endsWith("/..")
+                || path.contains("/../")) {
+            throw new IllegalArgumentException(
+                    "Invalid coordinates: composed local repository path escapes the repository base: " + path);
+        }
+        return path;
     }
 
     private String insertRepositoryKey(String metadataType, String repositoryKey) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport.java
@@ -24,6 +24,7 @@ import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryKeyFunction;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.PathUtils;
 
 /**
  * Support class for {@link LocalPathPrefixComposerFactory} implementations: it predefines and makes re-usable
@@ -286,13 +287,13 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repositoryKeyFunction.apply(repository, null);
+                result += "/" + repositoryKeySegment(repository);
             }
             if (splitRemote) {
                 result += "/" + (artifact.isSnapshot() ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repositoryKeyFunction.apply(repository, null);
+                result += "/" + repositoryKeySegment(repository);
             }
             return result;
         }
@@ -316,19 +317,30 @@ public abstract class LocalPathPrefixComposerFactorySupport implements LocalPath
             }
             String result = remotePrefix;
             if (!splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repositoryKeyFunction.apply(repository, null);
+                result += "/" + repositoryKeySegment(repository);
             }
             if (splitRemote) {
                 result += "/" + (isSnapshot(metadata) ? snapshotsPrefix : releasesPrefix);
             }
             if (splitRemoteRepositoryLast && splitRemoteRepository) {
-                result += "/" + repositoryKeyFunction.apply(repository, null);
+                result += "/" + repositoryKeySegment(repository);
             }
             return result;
         }
 
         protected boolean isSnapshot(Metadata metadata) {
             return !metadata.getVersion().isEmpty() && metadata.getVersion().endsWith("-SNAPSHOT");
+        }
+
+        /**
+         * Defense in depth: the repository key is spliced into the local repository path prefix, so the key
+         * function in use must produce a safe path segment - a key like ".." would relocate the whole split
+         * prefix outside the local repository basedir.
+         */
+        private String repositoryKeySegment(RemoteRepository repository) {
+            String key = repositoryKeyFunction.apply(repository, null);
+            PathUtils.validatePathComponent(key, "repository key");
+            return key;
         }
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -44,6 +44,8 @@ import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.util.ConfigUtils;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validateArtifactComponents;
+import static org.eclipse.aether.util.PathUtils.validateMetadataComponents;
 
 /**
  * Provides a Maven-2 repository layout for repositories with content type {@code "default"}.
@@ -217,6 +219,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Artifact artifact, boolean upload) {
+            validateArtifactComponents(artifact);
+
             StringBuilder path = new StringBuilder(128);
 
             path.append(artifact.getGroupId().replace('.', '/')).append('/');
@@ -240,6 +244,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Metadata metadata, boolean upload) {
+            validateMetadataComponents(metadata);
+
             StringBuilder path = new StringBuilder(128);
 
             if (!metadata.getGroupId().isEmpty()) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource.java
@@ -39,6 +39,7 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.io.ChecksumProcessor;
 import org.eclipse.aether.spi.remoterepo.RepositoryKeyFunctionFactory;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,6 +179,10 @@ public final class SparseDirectoryTrustedChecksumsSource extends FileTrustedChec
         String path = localPathComposer.getPathForArtifact(artifact, false) + "."
                 + checksumAlgorithmFactory.getFileExtension();
         if (originAware) {
+            // defense in depth: the repository key function in use must produce a safe path segment; a key like
+            // ".." would resolve outside the checksums basedir, onto attacker-influenced files such as the
+            // connector-persisted checksums in the local repository root - defeating this trust control
+            PathUtils.validatePathComponent(safeRepositoryId, "repository key");
             path = safeRepositoryId + "/" + path;
         }
         return path;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
@@ -93,11 +93,26 @@ public class BasedirNameMapper implements NameMapper {
                     : DirectoryUtils.resolveDirectory(session, DEFAULT_LOCKS_DIR, CONFIG_PROP_LOCKS_DIR, false);
 
             return delegate.nameLocks(session, artifacts, metadatas).stream()
-                    .map(k -> NamedLockKey.of(
-                            basedir.resolve(k.name()).toAbsolutePath().toUri().toASCIIString(), k.resources()))
+                    .map(k -> NamedLockKey.of(resolveContained(basedir, k.name()), k.resources()))
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Resolves the delegate-provided lock name against the locks base directory, rejecting any name that would
+     * escape it. Lock names are derived from artifact coordinates that arrive from remote repositories; a name
+     * containing path traversal must never select a lock file outside the locks directory, as locks are created
+     * (and deleted on close) by the file lock factory at the resolved path.
+     *
+     * @since 2.0.22
+     */
+    private static String resolveContained(Path basedir, String name) {
+        Path resolved = basedir.resolve(name).toAbsolutePath();
+        if (!resolved.normalize().startsWith(basedir.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("Lock name '" + name + "' escapes the locks base directory " + basedir);
+        }
+        return resolved.toUri().toASCIIString();
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
@@ -74,7 +74,7 @@ public class BasedirNameMapper implements NameMapper {
             throw new IllegalArgumentException("delegate must be file-system friendly");
         }
         this.delegate = delegate;
-        this.basePath = path;
+        this.basePath = path != null ? path.toAbsolutePath().normalize() : null;
     }
 
     @Override
@@ -90,7 +90,9 @@ public class BasedirNameMapper implements NameMapper {
         try {
             final Path basedir = basePath != null
                     ? basePath
-                    : DirectoryUtils.resolveDirectory(session, DEFAULT_LOCKS_DIR, CONFIG_PROP_LOCKS_DIR, false);
+                    : DirectoryUtils.resolveDirectory(session, DEFAULT_LOCKS_DIR, CONFIG_PROP_LOCKS_DIR, false)
+                            .toAbsolutePath()
+                            .normalize();
 
             return delegate.nameLocks(session, artifacts, metadatas).stream()
                     .map(k -> NamedLockKey.of(resolveContained(basedir, k.name()), k.resources()))
@@ -106,11 +108,11 @@ public class BasedirNameMapper implements NameMapper {
      * containing path traversal must never select a lock file outside the locks directory, as locks are created
      * (and deleted on close) by the file lock factory at the resolved path.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     private static String resolveContained(Path basedir, String name) {
-        Path resolved = basedir.resolve(name).toAbsolutePath();
-        if (!resolved.normalize().startsWith(basedir.toAbsolutePath().normalize())) {
+        Path resolved = basedir.resolve(name).normalize();
+        if (!resolved.startsWith(basedir)) {
             throw new IllegalArgumentException("Lock name '" + name + "' escapes the locks base directory " + basedir);
         }
         return resolved.toUri().toASCIIString();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
@@ -41,25 +41,25 @@ public class GAECVNameMapper extends GAVNameMapper {
     protected String getArtifactName(Artifact artifact) {
         if (artifact.getClassifier().isEmpty()) {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         } else {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getClassifier()
+                    + fieldToSegment(artifact.getClassifier())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -113,7 +113,7 @@ public class GAVNameMapper implements NameMapper {
      * selects a lock path outside the locks directory, letting a malicious repository create or delete files
      * (including other builds' live locks) at attacker-chosen paths.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     protected String fieldToSegment(String field) {
         return fileSystemFriendly ? PathUtils.stringToPathSegment(field) : field;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -96,12 +96,27 @@ public class GAVNameMapper implements NameMapper {
 
     protected String getArtifactName(Artifact artifact) {
         return artifactPrefix
-                + artifact.getGroupId()
+                + fieldToSegment(artifact.getGroupId())
                 + fieldSeparator
-                + artifact.getArtifactId()
+                + fieldToSegment(artifact.getArtifactId())
                 + fieldSeparator
-                + artifact.getBaseVersion()
+                + fieldToSegment(artifact.getBaseVersion())
                 + artifactSuffix;
+    }
+
+    /**
+     * Returns the given coordinate field in a form that is safe to use as (part of) a file name: when this mapper
+     * is {@link #isFileSystemFriendly()}, characters that act as path separators or are otherwise illegal in file
+     * names are replaced via {@link PathUtils#stringToPathSegment(String)}. Coordinate fields arrive from remote
+     * repository metadata (i.e. from the wire), and file-system friendly names are resolved against the locks
+     * base directory by {@link BasedirNameMapper}: without this, a wire-supplied field like {@code "1/../../x"}
+     * selects a lock path outside the locks directory, letting a malicious repository create or delete files
+     * (including other builds' live locks) at attacker-chosen paths.
+     *
+     * @since 2.0.22
+     */
+    protected String fieldToSegment(String field) {
+        return fileSystemFriendly ? PathUtils.stringToPathSegment(field) : field;
     }
 
     protected static final String MAVEN_METADATA = "maven-metadata.xml";
@@ -109,20 +124,19 @@ public class GAVNameMapper implements NameMapper {
     protected String getMetadataName(Metadata metadata) {
         String name = metadataPrefix;
         if (!metadata.getGroupId().isEmpty()) {
-            name += metadata.getGroupId();
+            name += fieldToSegment(metadata.getGroupId());
             if (!metadata.getArtifactId().isEmpty()) {
-                name += fieldSeparator + metadata.getArtifactId();
+                name += fieldSeparator + fieldToSegment(metadata.getArtifactId());
                 if (!metadata.getVersion().isEmpty()) {
-                    name += fieldSeparator + metadata.getVersion();
+                    name += fieldSeparator + fieldToSegment(metadata.getVersion());
                 }
             }
             if (!MAVEN_METADATA.equals(metadata.getType())) {
-                name += fieldSeparator
-                        + (fileSystemFriendly ? PathUtils.stringToPathSegment(metadata.getType()) : metadata.getType());
+                name += fieldSeparator + fieldToSegment(metadata.getType());
             }
         } else {
             if (!MAVEN_METADATA.equals(metadata.getType())) {
-                name += (fileSystemFriendly ? PathUtils.stringToPathSegment(metadata.getType()) : metadata.getType());
+                name += fieldToSegment(metadata.getType());
             }
         }
         return name + metadataSuffix;

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
@@ -79,4 +79,59 @@ class DefaultLocalPathComposerTest {
         String path = composer.getPathForMetadata(metadata, "central");
         assertEquals("g/id/a-id/1.0.0-SNAPSHOT/maven-metadata-central.xml", path);
     }
+
+    @Test
+    void testGetPathForArtifactRejectsLeadingDotGroupId() {
+        // groupId ".home.ci" would expand to "/home/ci/..." - an absolute path escaping the local repository
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact(".home.ci", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsDoubleLeadingDotGroupId() {
+        // groupId "..evilhost" would expand to "//evilhost/..." - re-parsed as an authority URI by transports
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("..evilhost", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsConsecutiveDotsInGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g..id", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsTrailingDotInGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id.", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsColon() {
+        // colon enables drive-absolute escapes on Windows (e.g. "C:") and is never valid in coordinates
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("C:", "a-id", "jar", "1.0"), true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id", "a-id", "jar", "1.0:evil"), true));
+    }
+
+    @Test
+    void testGetPathForMetadataRejectsLeadingDotGroupId() {
+        Metadata metadata =
+                new DefaultMetadata(".home.ci", "a-id", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        assertThrows(IllegalArgumentException.class, () -> composer.getPathForMetadata(metadata, "central"));
+    }
+
+    @Test
+    void testGetPathForArtifactAcceptsNormalCoordinates() {
+        String path = composer.getPathForArtifact(
+                new DefaultArtifact("org.apache.maven", "commons-io", "jar", "1.0-SNAPSHOT"), true);
+        assertEquals("org/apache/maven/commons-io/1.0-SNAPSHOT/commons-io-1.0-SNAPSHOT.jar", path);
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactoryTest.java
@@ -232,4 +232,31 @@ public class DefaultLocalPathPrefixComposerFactoryTest {
         assertNotNull(prefix);
         assertEquals("cached/my-repo/releases", prefix);
     }
+
+    @Test
+    void dotDotRepositoryIdCannotEscapeSplitPrefix() {
+        DefaultRepositorySystemSession session = TestUtils.newSession();
+        session.setConfigProperty(DefaultLocalPathPrefixComposerFactory.CONFIG_PROP_SPLIT, Boolean.TRUE.toString());
+        session.setConfigProperty(
+                DefaultLocalPathPrefixComposerFactory.CONFIG_PROP_SPLIT_REMOTE_REPOSITORY, Boolean.TRUE.toString());
+
+        LocalPathPrefixComposerFactory factory =
+                new DefaultLocalPathPrefixComposerFactory(new DefaultRepositoryKeyFunctionFactory());
+        LocalPathPrefixComposer composer = factory.createComposer(session);
+        assertNotNull(composer);
+
+        // a malicious transitive POM may declare a repository with id ".." - the repository key derived from it
+        // must be neutralized into a harmless path segment instead of relocating the split prefix out of the
+        // local repository basedir
+        RemoteRepository dotDotRepository =
+                new RemoteRepository.Builder("..", "default", "https://evil.example.org/").build();
+
+        String prefix = composer.getPathPrefixForRemoteArtifact(releaseArtifact, dotDotRepository);
+        assertNotNull(prefix);
+        assertEquals("cached/-DOTDOT-", prefix);
+
+        prefix = composer.getPathPrefixForRemoteMetadata(releaseMetadata, dotDotRepository);
+        assertNotNull(prefix);
+        assertEquals("cached/-DOTDOT-", prefix);
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
@@ -139,6 +139,41 @@ public class Maven2RepositoryLayoutFactoryTest {
     }
 
     @Test
+    void testArtifactLocation_RejectsGroupIdWithEmptyDotSegments() {
+        // ".home.ci" would expand to "/home/ci/..." (absolute path), "..evilhost" to "//evilhost/..."
+        // (re-parsed as an authority URI, redirecting the fetch to another host)
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact(".home.ci", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("..evilhost", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g..i.d", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d.", "a-i.d", "cls", "ext", "1.0"), false));
+    }
+
+    @Test
+    void testArtifactLocation_RejectsTraversalAndColon() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d", "a-i.d", "cls", "ext", "1.0/../x"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d", "a-i.d", "cls", "ext", "1.0:evil"), false));
+    }
+
+    @Test
+    void testMetadataLocation_RejectsGroupIdWithEmptyDotSegments() {
+        DefaultMetadata metadata =
+                new DefaultMetadata("..evilhost", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        assertThrows(IllegalArgumentException.class, () -> layout.getLocation(metadata, false));
+    }
+
+    @Test
     void testMetadataLocation_RootLevel() {
         DefaultMetadata metadata = new DefaultMetadata("archetype-catalog.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
         URI uri = layout.getLocation(metadata, false);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
@@ -166,6 +168,41 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         assertEquals(
                 getPrefix() + "metadata~groupId~artifactId~something.xml.lock",
                 names.iterator().next().name());
+    }
+
+    @Test
+    void traversalCoordinatesStayWithinLocksDir() throws IOException {
+        configProperties.put("aether.syncContext.named.hashing.depth", "0");
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "jar", "1/../../../../home/user/x");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        assertEquals(
+                getPrefix()
+                        + "artifact~group~artifact~1-SLASH-..-SLASH-..-SLASH-..-SLASH-..-SLASH-home-SLASH-user-SLASH-x.lock",
+                names.iterator().next().name());
+    }
+
+    @Test
+    void escapingDelegateNameIsRejected() {
+        // even a (custom) delegate that emits traversal sequences must not select a path outside the locks dir
+        NameMapper escaping = new NameMapper() {
+            @Override
+            public boolean isFileSystemFriendly() {
+                return true;
+            }
+
+            @Override
+            public Collection<NamedLockKey> nameLocks(
+                    RepositorySystemSession session,
+                    Collection<? extends Artifact> artifacts,
+                    Collection<? extends Metadata> metadatas) {
+                return singletonList(NamedLockKey.of("../../../outside.lock"));
+            }
+        };
+        NameMapper basedirMapper = new BasedirNameMapper(escaping);
+        DefaultArtifact artifact = new DefaultArtifact("group:artifact:1.0");
+        assertThrows(
+                IllegalArgumentException.class, () -> basedirMapper.nameLocks(session, singletonList(artifact), null));
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GAVNameMapperTest extends NameMapperTestSupport {
@@ -97,6 +98,32 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         assertEquals(
                 "metadata~groupId~artifactId~something.xml.lock",
                 names.iterator().next().name());
+    }
+
+    @Test
+    void pathTraversalInArtifactCoordinatesIsNeutralized() {
+        // wire-supplied coordinate fields must not be able to select a lock path outside the locks directory
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "jar", "1/../../../../home/user/x");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals(
+                "artifact~group~artifact~1-SLASH-..-SLASH-..-SLASH-..-SLASH-..-SLASH-home-SLASH-user-SLASH-x.lock",
+                name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void pathTraversalInMetadataCoordinatesIsNeutralized() {
+        DefaultMetadata metadata = new DefaultMetadata(
+                "group", "artifact", "1\\..\\..\\x", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals("metadata~group~artifact~1-BACKSLASH-..-BACKSLASH-..-BACKSLASH-x.lock", name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
     }
 
     @Test

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -163,10 +163,22 @@ final class FileTransporter extends AbstractTransporter {
 
     private Path getPath(TransportTask task, boolean required) throws Exception {
         String path = task.getLocation().getPath();
-        if (path.contains("../")) {
+        if (path == null) {
+            throw new IllegalArgumentException("illegal resource path: null");
+        }
+        Path relative = fileSystem.getPath(path);
+        if (relative.isAbsolute()) {
             throw new IllegalArgumentException("illegal resource path: " + path);
         }
-        Path file = basePath.resolve(path);
+        for (Path segment : relative) {
+            if ("..".equals(segment.toString())) {
+                throw new IllegalArgumentException("illegal resource path: " + path);
+            }
+        }
+        Path file = basePath.resolve(relative).normalize();
+        if (!file.startsWith(basePath.normalize())) {
+            throw new IllegalArgumentException("illegal resource path: " + path);
+        }
         if (required && !Files.isRegularFile(file)) {
             throw new ResourceNotFoundException("Could not locate " + file);
         }

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -73,7 +73,7 @@ final class FileTransporter extends AbstractTransporter {
         this.fileSystem = requireNonNull(fileSystem);
         this.closeFileSystem = closeFileSystem;
         this.writableFileSystem = writableFileSystem;
-        this.basePath = requireNonNull(basePath);
+        this.basePath = requireNonNull(basePath).normalize();
         this.writeOp = requireNonNull(writeOp);
 
         // sanity check
@@ -176,7 +176,7 @@ final class FileTransporter extends AbstractTransporter {
             }
         }
         Path file = basePath.resolve(relative).normalize();
-        if (!file.startsWith(basePath.normalize())) {
+        if (!file.startsWith(basePath)) {
             throw new IllegalArgumentException("illegal resource path: " + path);
         }
         if (required && !Files.isRegularFile(file)) {

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -106,6 +106,20 @@ public class FileTransporterTest {
         transporter = factory.newInstance(session, newRepo(url));
     }
 
+    /**
+     * Builds a task location URI carrying the absolute path of the given resource within the repository base
+     * directory, in a platform and file system neutral way (e.g. {@code /C:/repo/file.txt} on Windows).
+     */
+    private URI absoluteLocation(String resource) throws Exception {
+        Path absolute =
+                ((FileTransporter) transporter).getBasePath().resolve(resource).toAbsolutePath();
+        String rawPath = absolute.toString().replace('\\', '/');
+        if (!rawPath.startsWith("/")) {
+            rawPath = "/" + rawPath;
+        }
+        return new URI(null, null, rawPath, null);
+    }
+
     void setUp(FS fs) {
         try {
             fileSystem = fs.name().startsWith("JIMFS") ? Jimfs.newFileSystem() : null;
@@ -302,6 +316,43 @@ public class FileTransporterTest {
 
     @ParameterizedTest
     @EnumSource(FS.class)
+    void testGet_AbsoluteResourcePathRejected(FS fs) throws Exception {
+        setUp(fs);
+        GetTask task = new GetTask(absoluteLocation("file.txt"));
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(task));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_ParentDirTraversalRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create("../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_BareParentDirRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create(".."))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_NestedParentDirEscapeRejected(FS fs) {
+        setUp(fs);
+        assertThrows(
+                IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create("a/../../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPeek_ParentDirTraversalRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.peek(new PeekTask(URI.create("../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
     void testGet_Closed(FS fs) throws Exception {
         setUp(fs);
         transporter.close();
@@ -447,6 +498,38 @@ public class FileTransporterTest {
             assertTrue(Files.deleteIfExists(src), i + ", " + src.toAbsolutePath());
             assertTrue(Files.deleteIfExists(dst), i + ", " + dst.toAbsolutePath());
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_AbsoluteResourcePathRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(absoluteLocation("absolute-upload.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        assertFalse(Files.exists(repoDir.resolve("absolute-upload.txt")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_ParentDirTraversalRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(URI.create("../escaped.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        Path base = ((FileTransporter) transporter).getBasePath();
+        assertFalse(Files.exists(base.getParent().resolve("escaped.txt")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_NestedParentDirEscapeRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(URI.create("a/../../escaped.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        Path base = ((FileTransporter) transporter).getBasePath();
+        assertFalse(Files.exists(base.getParent().resolve("escaped.txt")));
     }
 
     @ParameterizedTest

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -114,7 +114,7 @@ public final class PathUtils {
      * (".home.ci" becomes "/home/ci", escaping the local repository), protocol-relative authority URIs
      * ("..evilhost" becomes "//evilhost", redirecting remote fetches to another host) or empty path segments.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     public static void validateDotSeparatedPathComponent(String value, String label) {
         validatePathComponent(value, label);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -73,7 +73,17 @@ public final class PathUtils {
                 pos = result.indexOf(illegal);
             }
         }
-        return result.toString();
+        // Strings consisting solely of dots contain no illegal character, yet "." and ".." carry path meaning:
+        // used as a path segment, ".." escapes the intended base directory (for example a repository id of ".."
+        // redirects origin-aware trusted-checksums lookups and split local repository prefixes outside their
+        // basedir). Map them to explicit tokens, mirroring the character replacements above.
+        String segment = result.toString();
+        if (segment.equals(".")) {
+            return "-DOT-";
+        } else if (segment.equals("..")) {
+            return "-DOTDOT-";
+        }
+        return segment;
     }
 
     /**
@@ -87,9 +97,33 @@ public final class PathUtils {
         if (value != null && !value.isEmpty()) {
             // Important: "equals .." and not "contains ..", as if escape attempted, it will contain path separators
             // OTOH: version "1.." is valid version string!
-            if (value.equals("..") || value.contains("/") || value.contains("\\")) {
+            // Colon is never valid in a coordinate component: it enables drive-absolute paths on Windows and
+            // scheme/authority confusion when the component ends up in a URI.
+            if (value.equals("..") || value.contains("/") || value.contains("\\") || value.contains(":")) {
                 throw new IllegalArgumentException(
-                        "Invalid " + label + ": must not contain '..', '/' or '\\': " + value);
+                        "Invalid " + label + ": must not contain '..', '/', '\\' or ':': " + value);
+            }
+        }
+    }
+
+    /**
+     * Validates a coordinate component that is expanded into multiple path segments by replacing each dot with a
+     * path separator, like the group ID is. Beside the checks done by
+     * {@link #validatePathComponent(String, String)}, it rejects values containing empty dot-separated segments
+     * (leading, trailing or consecutive dots): after dot-to-slash expansion those would produce absolute paths
+     * (".home.ci" becomes "/home/ci", escaping the local repository), protocol-relative authority URIs
+     * ("..evilhost" becomes "//evilhost", redirecting remote fetches to another host) or empty path segments.
+     *
+     * @since 2.0.22
+     */
+    public static void validateDotSeparatedPathComponent(String value, String label) {
+        validatePathComponent(value, label);
+        if (value != null && !value.isEmpty()) {
+            for (String segment : value.split("\\.", -1)) {
+                if (segment.isEmpty()) {
+                    throw new IllegalArgumentException("Invalid " + label
+                            + ": must not contain empty segments (leading, trailing or consecutive dots): " + value);
+                }
             }
         }
     }
@@ -98,10 +132,11 @@ public final class PathUtils {
      * Validates all coordinate components of an {@link Artifact}.
      *
      * @see #validatePathComponent(String, String)
+     * @see #validateDotSeparatedPathComponent(String, String)
      * @since 2.0.21
      */
     public static void validateArtifactComponents(Artifact artifact) {
-        validatePathComponent(artifact.getGroupId(), "groupId");
+        validateDotSeparatedPathComponent(artifact.getGroupId(), "groupId");
         validatePathComponent(artifact.getArtifactId(), "artifactId");
         validatePathComponent(artifact.getVersion(), "version");
         validatePathComponent(artifact.getBaseVersion(), "baseVersion");
@@ -113,10 +148,11 @@ public final class PathUtils {
      * Validates all coordinate components of a {@link Metadata}.
      *
      * @see #validatePathComponent(String, String)
+     * @see #validateDotSeparatedPathComponent(String, String)
      * @since 2.0.21
      */
     public static void validateMetadataComponents(Metadata metadata) {
-        validatePathComponent(metadata.getGroupId(), "groupId");
+        validateDotSeparatedPathComponent(metadata.getGroupId(), "groupId");
         validatePathComponent(metadata.getArtifactId(), "artifactId");
         validatePathComponent(metadata.getVersion(), "version");
         // note: type may contain string like ".meta/prefixes.txt"!

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
@@ -22,8 +22,10 @@ import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PathUtilsTest {
     @Test
@@ -41,10 +43,78 @@ public class PathUtilsTest {
     }
 
     @Test
+    void stringToPathSegment_dotSegments() {
+        // "." and ".." contain no illegal character, but carry path meaning: a repository id of ".." used as a
+        // path segment escapes the intended base directory of every sink that splices it into a path
+        // (origin-aware trusted checksums, split local repository prefixes)
+        assertEquals("-DOTDOT-", PathUtils.stringToPathSegment(".."));
+        assertEquals("-DOT-", PathUtils.stringToPathSegment("."));
+        // dotted names and longer dot runs are inert as single path segments and stay untouched
+        assertEquals("...", PathUtils.stringToPathSegment("..."));
+        assertEquals("my.repo", PathUtils.stringToPathSegment("my.repo"));
+        assertEquals("repo..id", PathUtils.stringToPathSegment("repo..id"));
+        assertEquals("..id", PathUtils.stringToPathSegment("..id"));
+    }
+
+    @Test
     void stringToPathSegment_allCharsBad() {
         String veryBad = "\\/:\"<>|?*";
         String badFixedId = PathUtils.stringToPathSegment(veryBad);
         assertNotEquals(veryBad, badFixedId);
         assertEquals("-BACKSLASH--SLASH--COLON--QUOTE--LT--GT--PIPE--QMARK--ASTERISK-", badFixedId);
+    }
+
+    @Test
+    void validatePathComponent_rejectsTraversalSeparatorsAndColon() {
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("..", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0/../etc", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0\\..\\etc", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("C:", "groupId"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0:evil", "version"));
+    }
+
+    @Test
+    void validatePathComponent_acceptsNormalValues() {
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent(null, "version"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("", "version"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("commons-io", "artifactId"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("1.0-SNAPSHOT", "version"));
+        // version "1.." is a valid version string, and is not dot-expanded into path segments
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("1..", "version"));
+    }
+
+    @Test
+    void validateDotSeparatedPathComponent_rejectsEmptyDotSegments() {
+        // leading dot: ".home.ci" would expand to absolute path "/home/ci"
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent(".home.ci", "groupId"));
+        // leading double dot: "..evilhost" would expand to authority URI "//evilhost"
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent("..evilhost", "groupId"));
+        // consecutive dots
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent("com..example", "groupId"));
+        // trailing dot
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent("com.example.", "groupId"));
+        // dot(s) only
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent(".", "groupId"));
+        // checks of validatePathComponent still apply
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent("a:b", "groupId"));
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent("a/b", "groupId"));
+    }
+
+    @Test
+    void validateDotSeparatedPathComponent_acceptsNormalValues() {
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent(null, "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("", "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("org.apache.maven", "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("commons-io", "groupId"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes 4 findings from the maven-resolver security audit (scan-maven-resolver-20260811):

| Finding | Severity | Description |
|---------|----------|-------------|
| f001 | **HIGH** | Leading-dot and colon coordinates bypass `validatePathComponent`: absolute-path writes outside local repo and cross-host fetches |
| f003 | MEDIUM | `FileTransporter` traversal guard misses absolute paths and Windows separators |
| f010 | MEDIUM | Repository id `".."` escapes origin-aware trusted-checksums and split-LRM directories |
| f017 | MEDIUM | Default file-lock name mapper builds lock paths from raw wire-supplied coordinates |

**Root cause:** Strings from remote repositories (artifact coordinates, repository ids) are validated in their pre-transformation shape and then passed to `Path.resolve()`, which returns absolute arguments unchanged. No sink asserts containment.

**Fix:** Validate post-replacement path shape, reject `..`/`.`/`:` segments, and assert `normalize().startsWith(base)` containment at every resolve sink.

## Test plan
- [ ] Existing tests pass
- [ ] New test cases for leading-dot groupId, colon groupId, ".." repository id
- [ ] FileTransporter containment check tested
- [ ] Lock path containment tested

Generated with [Claude Code](https://claude.com/claude-code)