### PR TITLE
fix: earn trust labels through verification and bind tracking to URL

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -119,6 +119,23 @@ public class DefaultArtifactResolver implements ArtifactResolver {
 
     public static final boolean DEFAULT_SIMPLE_LRM_INTEROP = false;
 
+    /**
+     * Configuration to restore the legacy "existence check" behavior for artifacts that are present in the local
+     * repository but were cached from a remote repository unavailable in the current build context: when enabled, a
+     * bare remote existence check (no content transfer, hence no checksum validation) suffices to re-label the cached
+     * bytes as originating from the queried repository. When disabled (the default), the artifact is downloaded again
+     * through the regular transfer path, so the content is validated against the repository's checksum policy before
+     * it is registered with the local repository for that repository. Enabling this trades integrity for bandwidth
+     * and is warmly recommended to leave it disabled.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_EXISTENCE_CHECK_RELABEL}
+     */
+    public static final String CONFIG_PROP_EXISTENCE_CHECK_RELABEL = CONFIG_PROPS_PREFIX + "existenceCheckRelabel";
+
+    public static final boolean DEFAULT_EXISTENCE_CHECK_RELABEL = false;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArtifactResolver.class);
 
     private final PathProcessor pathProcessor;
@@ -325,8 +342,23 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                         }
 
                         try {
-                            artifact = artifact.setPath(getPath(session, artifact, local.getPath()));
+                            Path localArtifactPath = local.getPath();
+                            artifact = artifact.setPath(getPath(session, artifact, localArtifactPath));
                             result.setArtifact(artifact);
+                            if (local.getRepository() != null && !localArtifactPath.equals(artifact.getPath())) {
+                                /*
+                                 * NOTE: Snapshot normalization materialized a base-version copy next to the tracked
+                                 * timestamped file. The copy must carry the same provenance tracking as its source;
+                                 * otherwise the untracked copy is later treated as locally installed (accepted
+                                 * without any repository/offline checks) by the untracked-file interop logic.
+                                 */
+                                lrm.add(
+                                        session,
+                                        new LocalArtifactRegistration(
+                                                artifact.setVersion(artifact.getBaseVersion()),
+                                                local.getRepository(),
+                                                Collections.singleton(request.getRequestContext())));
+                            }
                             artifactResolved(session, trace, artifact, result.getRepository(), null);
                         } catch (ArtifactTransferException e) {
                             result.addException(lrm.getRepository(), e);
@@ -520,6 +552,8 @@ public class DefaultArtifactResolver implements ArtifactResolver {
 
     private List<ArtifactDownload> gatherDownloads(RepositorySystemSession session, ResolutionGroup group) {
         LocalRepositoryManager lrm = session.getLocalRepositoryManager();
+        final boolean existenceCheckRelabel =
+                ConfigUtils.getBoolean(session, DEFAULT_EXISTENCE_CHECK_RELABEL, CONFIG_PROP_EXISTENCE_CHECK_RELABEL);
         List<ArtifactDownload> downloads = new ArrayList<>();
 
         for (ResolutionItem item : group.items) {
@@ -535,10 +569,19 @@ public class DefaultArtifactResolver implements ArtifactResolver {
             download.setRequestContext(item.request.getRequestContext());
             download.setListener(SafeTransferListener.wrap(session));
             download.setTrace(item.trace);
-            if (item.local.getPath() != null) {
+            if (item.local.getPath() != null && existenceCheckRelabel) {
+                /*
+                 * NOTE: Legacy behavior, disabled by default: a bare existence check transfers no content, so the
+                 * cached bytes are re-labeled to this repository without ever passing checksum validation.
+                 */
                 download.setPath(item.local.getPath());
                 download.setExistenceCheck(true);
             } else {
+                /*
+                 * NOTE: Even if the artifact is present in the local repository (cached from a repository unavailable
+                 * in the current build context), download it again so the content passes the repository's checksum
+                 * policy before the artifact is registered with the local repository for this repository.
+                 */
                 download.setPath(lrm.getAbsolutePathForRemoteArtifact(
                         artifact, group.repository, item.request.getRequestContext()));
             }
@@ -592,6 +635,21 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                     lrm.add(
                             session,
                             new LocalArtifactRegistration(artifact, group.repository, download.getSupportedContexts()));
+                    if (!download.getPath().equals(artifact.getPath())) {
+                        /*
+                         * NOTE: Snapshot normalization materialized a base-version copy of the downloaded file. Every
+                         * file the resolver derives from remote content must carry the same provenance tracking as
+                         * the download it stems from: register the copy under the same repository, otherwise the
+                         * untracked copy is later treated as locally installed (accepted without any
+                         * repository/offline checks) by the untracked-file interop logic.
+                         */
+                        lrm.add(
+                                session,
+                                new LocalArtifactRegistration(
+                                        artifact.setVersion(artifact.getBaseVersion()),
+                                        group.repository,
+                                        download.getSupportedContexts()));
+                    }
                 } catch (ArtifactTransferException e) {
                     download.setException(e);
                     item.result.addException(group.repository, e);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -37,6 +38,9 @@ import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryKeyFunction;
+import org.eclipse.aether.util.ConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,9 +61,16 @@ import static java.util.Objects.requireNonNull;
  * artifact-1.0.pom>my_repo_id=
  * </pre>
  *
+ * The repository id component of a tracking key is produced by the tracking-scoped repository key function, which
+ * is URL-qualified by default: two repositories that merely share an id but point at different URLs are tracked as
+ * different origins (see
+ * {@link EnhancedLocalRepositoryManagerFactory#CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION}).
+ *
  * @see EnhancedLocalRepositoryManagerFactory
  */
 class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnhancedLocalRepositoryManager.class);
 
     private static final String LOCAL_REPO_ID = "";
 
@@ -91,6 +102,17 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
     private final LocalPathPrefixComposer localPathPrefixComposer;
 
     /**
+     * Repository key function used solely for the provenance tracking entries (the repository component of the
+     * keys in the tracking file); path composition keeps using the (system-wide) key function held by the
+     * superclass. URL-qualified by default, so two repositories merely sharing an id are not treated as the same
+     * origin - see {@link EnhancedLocalRepositoryManagerFactory#CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION}.
+     * Lookups of entries written under a different key function miss and fail safe: the artifact stays tracked
+     * (so the untracked inter-op fallback in {@link #checkFind} does not accept it) but unavailable, forcing a
+     * checksum-validated re-fetch.
+     */
+    private final RepositoryKeyFunction trackingRepositoryKeyFunction;
+
+    /**
      * Cache of tracking file contents, keyed by tracking file path. Eliminates redundant disk I/O
      * when multiple artifacts in the same directory are resolved — they all share the same
      * {@code _remote.repositories} tracking file. Invalidated on writes via {@link #addRepo}.
@@ -98,19 +120,31 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
      * Cached {@link Properties} instances are shared across threads and must be treated as
      * read-only by callers of {@link #readRepos}. The cache is scoped to this manager instance
      * (one per session), so concurrent builds in separate JVMs each maintain independent caches.
-     * If another process updates a tracking file after it has been cached here, the stale entry
-     * may cause a redundant (but harmless) download — no data corruption.
+     * If another process updates a tracking file after it has been cached here, a stale entry is
+     * NOT always harmless: for a tracked artifact it merely causes a redundant download, but in the
+     * untracked inter-op branch of {@link #checkFind} staleness would be trust-increasing (the file
+     * would be accepted as locally installed although its recorded origin says otherwise). That
+     * branch therefore re-reads the tracking file from disk before accepting, see
+     * {@link #readReposFresh}.
      */
     private final ConcurrentHashMap<Path, Properties> trackingFileCache = new ConcurrentHashMap<>();
+
+    /**
+     * Lazily computed real (symlink-resolved) path of the local repository base directory, used by
+     * {@link #hasFaithfulRealPath(Path)}. It cannot change during the lifetime of this manager.
+     */
+    private volatile Path realBasePath;
 
     EnhancedLocalRepositoryManager(
             Path basedir,
             LocalPathComposer localPathComposer,
             RepositoryKeyFunction repositoryKeyFunction,
+            RepositoryKeyFunction trackingRepositoryKeyFunction,
             String trackingFilename,
             TrackingFileManager trackingFileManager,
             LocalPathPrefixComposer localPathPrefixComposer) {
         super(basedir, "enhanced", localPathComposer, repositoryKeyFunction);
+        this.trackingRepositoryKeyFunction = requireNonNull(trackingRepositoryKeyFunction);
         this.trackingFilename = requireNonNull(trackingFilename);
         this.trackingFileManager = requireNonNull(trackingFileManager);
         this.localPathPrefixComposer = requireNonNull(localPathPrefixComposer);
@@ -156,19 +190,24 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         Artifact artifact = request.getArtifact();
         LocalArtifactResult result = new LocalArtifactResult(request);
 
+        boolean verifyRealPath = ConfigUtils.getBoolean(
+                session,
+                EnhancedLocalRepositoryManagerFactory.DEFAULT_VERIFY_REAL_PATH,
+                EnhancedLocalRepositoryManagerFactory.CONFIG_PROP_VERIFY_REAL_PATH);
+
         Path filePath;
 
         // Local repository CANNOT have timestamped installed, they are created only during deploy
         if (Objects.equals(artifact.getVersion(), artifact.getBaseVersion())) {
             filePath = getAbsolutePathForLocalArtifact(artifact);
-            checkFind(filePath, result);
+            checkFind(filePath, result, verifyRealPath);
         }
 
         if (!result.isAvailable()) {
             for (RemoteRepository repository : request.getRepositories()) {
                 filePath = getAbsolutePathForRemoteArtifact(artifact, repository, request.getContext());
 
-                checkFind(filePath, result);
+                checkFind(filePath, result, verifyRealPath);
 
                 if (result.isAvailable()) {
                     break;
@@ -179,27 +218,62 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         return result;
     }
 
-    private void checkFind(Path path, LocalArtifactResult result) {
-        if (Files.isRegularFile(path)) {
+    /**
+     * Verifies that the real (on-disk) spelling of the given artifact path matches the requested spelling,
+     * relative to the local repository base directory. On case-insensitive or normalization-preserving
+     * filesystems (the macOS and Windows defaults) a cached file whose stored name differs from the requested one
+     * - for example one cached for case-colliding coordinates - still passes the file-existence check, while the
+     * tracking data in the tracking file is compared exactly: the aliased file would then be treated as
+     * present-but-untracked and accepted with no download and no checksum verification. Such aliases are treated
+     * as "not present" instead (fail closed), forcing a proper download for the requested coordinates. The
+     * comparison is relative to the (symlink-resolved) base directory, so a symlinked base directory is
+     * supported; symbolic links below the base directory are not - see
+     * {@link EnhancedLocalRepositoryManagerFactory#CONFIG_PROP_VERIFY_REAL_PATH} to opt out.
+     */
+    private boolean hasFaithfulRealPath(Path path) {
+        try {
+            String requested = getRepository().getBasePath().relativize(path).toString();
+            String real = getRealBasePath().relativize(path.toRealPath()).toString();
+            if (!requested.equals(real)) {
+                LOGGER.warn(
+                        "Rejecting locally cached artifact {}: its on-disk path {} does not match the requested"
+                                + " coordinates (filesystem case/normalization alias); treating it as not present",
+                        path,
+                        real);
+                return false;
+            }
+            return true;
+        } catch (IOException | IllegalArgumentException e) {
+            // the real identity of the file cannot be established: fail closed, forcing a re-download
+            return false;
+        }
+    }
+
+    private Path getRealBasePath() throws IOException {
+        Path real = realBasePath;
+        if (real == null) {
+            real = getRepository().getBasePath().toRealPath();
+            realBasePath = real;
+        }
+        return real;
+    }
+
+    private void checkFind(Path path, LocalArtifactResult result, boolean verifyRealPath) {
+        if (Files.isRegularFile(path) && (!verifyRealPath || hasFaithfulRealPath(path))) {
             result.setPath(path);
 
             Properties props = readRepos(path);
 
-            if (props.get(getKey(path, LOCAL_REPO_ID)) != null) {
-                // artifact installed into the local repo is always accepted
-                result.setAvailable(true);
-            } else {
-                String context = result.getRequest().getContext();
-                for (RemoteRepository repository : result.getRequest().getRepositories()) {
-                    if (props.get(getKey(path, getRepositoryKey(repository, context))) != null) {
-                        // artifact downloaded from remote repository is accepted only downloaded from request
-                        // repositories
-                        result.setAvailable(true);
-                        result.setRepository(repository);
-                        break;
-                    }
-                }
-                if (!result.isAvailable() && !isTracked(props, path)) {
+            if (!applyTracking(path, result, props) && !isTracked(props, path)) {
+                /*
+                 * The (possibly cached) state claims the artifact is untracked, and the untracked inter-op
+                 * branch below is trust-increasing: it accepts the file as locally installed. That decision
+                 * must never rest on tracking state that may be older than the file it judges (another process
+                 * sharing this local repository may have recorded the true origin of the file after our cache
+                 * entry was populated), so re-read the tracking file from disk before concluding untracked.
+                 */
+                props = readReposFresh(path);
+                if (!applyTracking(path, result, props) && !isTracked(props, path)) {
                     /*
                      * NOTE: The artifact is present but not tracked at all, for inter-op with simple local repo, assume
                      * the artifact was locally installed.
@@ -208,6 +282,32 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
                 }
             }
         }
+    }
+
+    /**
+     * Applies the tracking-state based acceptance rules to given result: an artifact installed into the local
+     * repository is always accepted, an artifact downloaded from a remote repository is accepted only if
+     * downloaded from one of the request repositories.
+     *
+     * @return {@code true} if the result was made available, {@code false} otherwise.
+     */
+    private boolean applyTracking(Path path, LocalArtifactResult result, Properties props) {
+        if (props.get(getKey(path, LOCAL_REPO_ID)) != null) {
+            // artifact installed into the local repo is always accepted
+            result.setAvailable(true);
+            return true;
+        }
+        String context = result.getRequest().getContext();
+        for (RemoteRepository repository : result.getRequest().getRepositories()) {
+            if (props.get(getKey(path, getTrackingRepositoryKey(repository, context))) != null) {
+                // artifact downloaded from remote repository is accepted only downloaded from request
+                // repositories
+                result.setAvailable(true);
+                result.setRepository(repository);
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -232,7 +332,7 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
 
         if (contexts != null) {
             for (String context : contexts) {
-                keys.add(getRepositoryKey(repository, context));
+                keys.add(getTrackingRepositoryKey(repository, context));
             }
         }
 
@@ -256,6 +356,16 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         });
     }
 
+    /**
+     * Reads the tracking file for given artifact directly from disk, bypassing (and deliberately not populating)
+     * {@link #trackingFileCache}: callers use the result for a trust-increasing decision, which must not be taken
+     * on — nor allowed to re-cache — possibly stale state.
+     */
+    private Properties readReposFresh(Path artifactPath) {
+        Properties props = trackingFileManager.read(getTrackingFile(artifactPath));
+        return (props != null) ? props : EMPTY_PROPERTIES;
+    }
+
     private void addRepo(Path artifactPath, Collection<String> repositories) {
         Map<String, String> updates = new HashMap<>();
         for (String repository : repositories) {
@@ -264,11 +374,17 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
 
         Path trackingPath = getTrackingFile(artifactPath);
 
-        // Invalidate cache before write: using put() with the returned Properties would be
-        // racy — two concurrent addRepo() calls could reorder their puts, leaving stale data.
-        // Invalidating forces the next readRepos() to re-read from disk.
+        // Invalidate cache before AND after the write. Before: using put() with the returned Properties
+        // would be racy — two concurrent addRepo() calls could reorder their puts, leaving stale data.
+        // After: a reader may re-populate the cache with the pre-write contents between the first
+        // invalidation and the write completing; without a post-write invalidation that stale entry —
+        // which is trust-affecting, see checkFind — would survive for the whole session.
         trackingFileCache.remove(trackingPath);
-        trackingFileManager.update(trackingPath, updates);
+        try {
+            trackingFileManager.update(trackingPath, updates);
+        } finally {
+            trackingFileCache.remove(trackingPath);
+        }
     }
 
     private Path getTrackingFile(Path artifactPath) {
@@ -277,6 +393,16 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
 
     private String getKey(Path path, String repository) {
         return path.getFileName() + ">" + repository;
+    }
+
+    /**
+     * Returns the tracking key of given repository, derived with the tracking-scoped key function (URL-qualified
+     * by default). Deliberately distinct from {@link #getRepositoryKey(RemoteRepository, String)}, which follows
+     * the system-wide key function and is used for path composition: tracking must bind an artifact to the full
+     * identity of its origin, while on-disk layout and repository aggregation identity stay unchanged.
+     */
+    private String getTrackingRepositoryKey(RemoteRepository repository, String context) {
+        return trackingRepositoryKeyFunction.apply(repository, context);
     }
 
     private boolean isTracked(Properties props, Path path) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
@@ -66,7 +66,7 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
      * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
      * @configurationType {@link java.lang.String}
      * @configurationDefaultValue {@link #DEFAULT_TRACKING_REPOSITORY_KEY_FUNCTION}
-     * @since 2.0.22
+     * @since 2.0.23
      */
     public static final String CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION =
             CONFIG_PROPS_PREFIX + "trackingRepositoryKeyFunction";
@@ -98,7 +98,7 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
      * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
      * @configurationType {@link java.lang.Boolean}
      * @configurationDefaultValue {@link #DEFAULT_VERIFY_REAL_PATH}
-     * @since 2.0.22
+     * @since 2.0.23
      */
     public static final String CONFIG_PROP_VERIFY_REAL_PATH = CONFIG_PROPS_PREFIX + "verifyRealPath";
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory.java
@@ -48,6 +48,32 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
     static final String CONFIG_PROPS_PREFIX = ConfigurationProperties.PREFIX_LRM + NAME + ".";
 
     /**
+     * Repository key function used for the provenance tracking entries this local repository manager writes and
+     * consults (see {@link #CONFIG_PROP_TRACKING_FILENAME}), and for nothing else. With an ID-only key, "came from
+     * repository X" means X's possibly colliding label: a repository declared in an untrusted (for example,
+     * transitively resolved) POM under the same ID as a trusted repository would be tracked as the same origin and
+     * could poison a shared local repository. The default is therefore the URL-qualified {@code "nid_hurl"}
+     * function, scoped to tracking entries only: repository identity everywhere else (repository aggregation and
+     * mirror merging, artifact and metadata path composition, split local repository prefixes) keeps following the
+     * system-wide key function, whose default is unchanged - so no aggregation semantics change and no local
+     * repository re-layout occurs. If the system-wide function
+     * {@link ConfigurationProperties#REPOSITORY_SYSTEM_REPOSITORY_KEY_FUNCTION} is explicitly configured, tracking
+     * follows it (all consumers stay on one function, and setting it to {@code "nid"} restores the legacy ID-only
+     * tracking); this property, when set, overrides both. Tracking entries written under a different function than
+     * the active one never match a lookup and never enable the untracked-file fallback: affected artifacts are
+     * simply treated as locally unavailable and re-fetched (with checksum validation) once.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.String}
+     * @configurationDefaultValue {@link #DEFAULT_TRACKING_REPOSITORY_KEY_FUNCTION}
+     * @since 2.0.22
+     */
+    public static final String CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION =
+            CONFIG_PROPS_PREFIX + "trackingRepositoryKeyFunction";
+
+    public static final String DEFAULT_TRACKING_REPOSITORY_KEY_FUNCTION = "nid_hurl";
+
+    /**
      * Filename of the file in which to track the remote repositories.
      *
      * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
@@ -57,6 +83,26 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
     public static final String CONFIG_PROP_TRACKING_FILENAME = CONFIG_PROPS_PREFIX + "trackingFilename";
 
     public static final String DEFAULT_TRACKING_FILENAME = "_remote.repositories";
+
+    /**
+     * Whether to verify that the real (on-disk) path of a locally cached artifact matches the requested path
+     * spelling before the artifact is used. On case-insensitive or case/normalization-preserving filesystems (the
+     * macOS and Windows defaults) a file cached for one set of coordinates also answers lookups for coordinates
+     * that differ only in case or Unicode normalization, while the repository tracking data is compared exactly:
+     * such an aliased file is treated as present-but-untracked and accepted with no download and no checksum
+     * verification, letting case-colliding coordinates poison distinct GAVs. When enabled (the default), an
+     * artifact whose on-disk path spelling differs from the requested one is treated as not present, forcing a
+     * proper download. Disable only if the local repository intentionally contains symbolic links below its base
+     * directory (a symlinked base directory itself is supported either way).
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_VERIFY_REAL_PATH}
+     * @since 2.0.22
+     */
+    public static final String CONFIG_PROP_VERIFY_REAL_PATH = CONFIG_PROPS_PREFIX + "verifyRealPath";
+
+    public static final boolean DEFAULT_VERIFY_REAL_PATH = true;
 
     private float priority = 10.0f;
 
@@ -99,6 +145,14 @@ public class EnhancedLocalRepositoryManagerFactory implements LocalRepositoryMan
                     repository.getBasePath(),
                     localPathComposer,
                     repositoryKeyFunctionFactory.systemRepositoryKeyFunction(session),
+                    repositoryKeyFunctionFactory.repositoryKeyFunction(
+                            EnhancedLocalRepositoryManagerFactory.class,
+                            session,
+                            ConfigUtils.getString(
+                                    session,
+                                    DEFAULT_TRACKING_REPOSITORY_KEY_FUNCTION,
+                                    ConfigurationProperties.REPOSITORY_SYSTEM_REPOSITORY_KEY_FUNCTION),
+                            CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION),
                     trackingFilename,
                     trackingFileManager,
                     localPathPrefixComposerFactory.createComposer(session));

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -21,6 +21,7 @@ package org.eclipse.aether.internal.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -206,6 +207,33 @@ public class DefaultArtifactResolverTest {
     }
 
     @Test
+    void testResolveRemoteSnapshotRegistersNormalizedCopy() throws ArtifactResolutionException {
+        Artifact timestamped = new DefaultArtifact("gid", "aid", "", "ext", "1.0-20110329.221805-4");
+        connector.setExpectGet(timestamped);
+
+        ArtifactRequest request = new ArtifactRequest(timestamped, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        ArtifactResult result = resolver.resolveArtifact(session, request);
+
+        assertTrue(result.getExceptions().isEmpty());
+
+        // snapshot normalization (enabled by default) materialized a base-version copy of the download
+        Artifact resolved = result.getArtifact();
+        assertNotNull(resolved.getFile());
+        assertTrue(resolved.getFile().getName().contains("1.0-SNAPSHOT"));
+
+        // both the timestamped download and its base-version copy must carry the repository provenance,
+        // otherwise the untracked copy is later accepted as if it were locally installed
+        assertEquals(2, lrm.getArtifactRegistration().size());
+        assertTrue(
+                lrm.getArtifactRegistration().stream().anyMatch(a -> "1.0-20110329.221805-4".equals(a.getVersion())));
+        assertTrue(lrm.getArtifactRegistration().stream().anyMatch(a -> "1.0-SNAPSHOT".equals(a.getVersion())));
+
+        connector.assertSeenExpected();
+    }
+
+    @Test
     void testResolveRemoteArtifactUnsuccessful() {
         RecordingRepositoryConnector connector = new RecordingRepositoryConnector() {
 
@@ -246,6 +274,56 @@ public class DefaultArtifactResolverTest {
             Artifact resolved = result.getArtifact();
             assertNull(resolved);
         }
+    }
+
+    private List<Boolean> resolveCachedFromForeignRepository() throws IOException, ArtifactResolutionException {
+        TestFileUtils.writeString(
+                new File(lrm.getRepository().getBasedir(), lrm.getPathForLocalArtifact(artifact)), "cached");
+        lrm.setArtifactAvailability(artifact, false);
+
+        List<Boolean> existenceChecks = new ArrayList<>();
+        RecordingRepositoryConnector connector = new RecordingRepositoryConnector() {
+
+            @Override
+            public void get(
+                    Collection<? extends ArtifactDownload> artifactDownloads,
+                    Collection<? extends MetadataDownload> metadataDownloads) {
+                for (ArtifactDownload download : artifactDownloads) {
+                    existenceChecks.add(download.isExistenceCheck());
+                }
+                super.get(artifactDownloads, metadataDownloads);
+            }
+        };
+        connector.setExpectGet(artifact);
+        repositoryConnectorProvider.setConnector(connector);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        request.addRepository(new RemoteRepository.Builder("id", "default", "file:///").build());
+
+        ArtifactResult result = resolver.resolveArtifact(session, request);
+
+        assertTrue(result.getExceptions().isEmpty());
+        assertNotNull(result.getArtifact().getFile());
+        assertEquals(1, lrm.getArtifactRegistration().size());
+        connector.assertSeenExpected();
+
+        return existenceChecks;
+    }
+
+    @Test
+    void testResolveCachedFromForeignRepositoryDownloadsByDefault() throws IOException, ArtifactResolutionException {
+        List<Boolean> existenceChecks = resolveCachedFromForeignRepository();
+
+        assertEquals(Collections.singletonList(Boolean.FALSE), existenceChecks);
+    }
+
+    @Test
+    void testResolveCachedFromForeignRepositoryLegacyExistenceCheck() throws IOException, ArtifactResolutionException {
+        session.setConfigProperty(DefaultArtifactResolver.CONFIG_PROP_EXISTENCE_CHECK_RELABEL, true);
+
+        List<Boolean> existenceChecks = resolveCachedFromForeignRepository();
+
+        assertEquals(Collections.singletonList(Boolean.TRUE), existenceChecks);
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.test.util.TestFileUtils;
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.LocalArtifactRegistration;
+import org.eclipse.aether.repository.LocalArtifactRequest;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.StringDigestUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * UT for {@link EnhancedLocalRepositoryManagerFactory}, focused on the wiring of the tracking-scoped repository
+ * key function: provenance tracking entries must be URL-qualified by default, so a repository declared under a
+ * trusted ID but pointing at a different URL is a different origin, while path composition and everything else
+ * keeps following the (unchanged) system-wide key function.
+ */
+public class EnhancedLocalRepositoryManagerFactoryTest {
+
+    @TempDir
+    Path basedir;
+
+    private DefaultRepositorySystemSession session;
+
+    private EnhancedLocalRepositoryManagerFactory factory;
+
+    private final RemoteRepository repository =
+            new RemoteRepository.Builder("internal", "default", "https://repo.corp.example.com/maven2/").build();
+
+    private final RemoteRepository impostor =
+            new RemoteRepository.Builder("internal", "default", "https://impostor.invalid/maven2/").build();
+
+    private final String context = "project/compile";
+
+    @BeforeEach
+    void setup() {
+        session = TestUtils.newSession();
+        factory = new EnhancedLocalRepositoryManagerFactory(
+                new DefaultLocalPathComposer(),
+                new TrackingFileManagerSupplier().get(),
+                new DefaultLocalPathPrefixComposerFactory(new DefaultRepositoryKeyFunctionFactory()),
+                new DefaultRepositoryKeyFunctionFactory());
+    }
+
+    private LocalRepositoryManager newManager() throws Exception {
+        return factory.newInstance(session, new LocalRepository(basedir));
+    }
+
+    private Artifact addTrackedRemoteArtifact(LocalRepositoryManager manager) throws Exception {
+        Artifact artifact = new DefaultArtifact("gid:aid:1.0");
+        manager.add(session, new LocalArtifactRegistration(artifact, repository, Collections.singleton(context)));
+        Path file = basedir.resolve(manager.getPathForRemoteArtifact(artifact, repository, context));
+        TestFileUtils.writeString(file.toFile(), "artifact");
+        return artifact;
+    }
+
+    @Test
+    void defaultTrackingKeysAreUrlQualified() throws Exception {
+        LocalRepositoryManager manager = newManager();
+        Artifact artifact = addTrackedRemoteArtifact(manager);
+
+        // requested from the repository the artifact really came from: available
+        LocalArtifactRequest fromReal =
+                new LocalArtifactRequest(artifact, Collections.singletonList(repository), context);
+        assertTrue(manager.find(session, fromReal).isAvailable());
+
+        // requested from an impostor sharing the trusted ID but pointing at another URL: a different
+        // origin, so the cached bytes must not be accepted (they are re-fetched, checksum-validated)
+        LocalArtifactRequest fromImpostor =
+                new LocalArtifactRequest(artifact, Collections.singletonList(impostor), context);
+        assertFalse(manager.find(session, fromImpostor).isAvailable());
+    }
+
+    @Test
+    void trackingKeyFunctionDoesNotAffectPathComposition() throws Exception {
+        LocalRepositoryManager manager = newManager();
+        Artifact artifact = new DefaultArtifact("gid:aid:1.0");
+
+        // the URL-qualified default is scoped to tracking entries: artifact and metadata paths keep
+        // following the system-wide key function (default unchanged), so no local repository re-layout
+        String urlHash = StringDigestUtil.sha1(repository.getUrl());
+        assertFalse(
+                manager.getPathForRemoteArtifact(artifact, repository, context).contains(urlHash));
+        assertFalse(manager.getPathForRemoteMetadata(
+                        new DefaultMetadata("gid", "aid", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE),
+                        repository,
+                        context)
+                .contains(urlHash));
+    }
+
+    @Test
+    void explicitSystemWideKeyFunctionIsFollowedByTracking() throws Exception {
+        // an explicitly configured system-wide function keeps all consumers on one function; "nid" is
+        // the documented legacy (ID-only) opt-out
+        session.setConfigProperty(ConfigurationProperties.REPOSITORY_SYSTEM_REPOSITORY_KEY_FUNCTION, "nid");
+        LocalRepositoryManager manager = newManager();
+        Artifact artifact = addTrackedRemoteArtifact(manager);
+
+        LocalArtifactRequest fromImpostor =
+                new LocalArtifactRequest(artifact, Collections.singletonList(impostor), context);
+        assertTrue(manager.find(session, fromImpostor).isAvailable());
+    }
+
+    @Test
+    void trackingSpecificConfigurationOverridesSystemWideFunction() throws Exception {
+        session.setConfigProperty(ConfigurationProperties.REPOSITORY_SYSTEM_REPOSITORY_KEY_FUNCTION, "nid");
+        session.setConfigProperty(
+                EnhancedLocalRepositoryManagerFactory.CONFIG_PROP_TRACKING_REPOSITORY_KEY_FUNCTION, "nid_hurl");
+        LocalRepositoryManager manager = newManager();
+        Artifact artifact = addTrackedRemoteArtifact(manager);
+
+        LocalArtifactRequest fromImpostor =
+                new LocalArtifactRequest(artifact, Collections.singletonList(impostor), context);
+        assertFalse(manager.find(session, fromImpostor).isAvailable());
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -21,6 +21,8 @@ package org.eclipse.aether.internal.impl;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EnhancedLocalRepositoryManagerTest {
 
@@ -108,6 +111,7 @@ public class EnhancedLocalRepositoryManagerTest {
         return new EnhancedLocalRepositoryManager(
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
+                RepositoryIdHelper::simpleRepositoryKey,
                 RepositoryIdHelper::simpleRepositoryKey,
                 "_remote.repositories",
                 trackingFileManager,
@@ -247,6 +251,45 @@ public class EnhancedLocalRepositoryManagerTest {
         assertFalse(result.isAvailable());
     }
 
+    /**
+     * Simulates a case-aliasing filesystem (the macOS and Windows defaults) on any filesystem by creating a
+     * symbolic link whose name differs from the on-disk file only by case, and returns the aliased artifact.
+     */
+    private Artifact createCaseAliasedArtifact() throws Exception {
+        addLocalArtifact(artifact);
+
+        Artifact aliased = new DefaultArtifact("gid", "aid", "", "JAR", "1-test");
+        Path aliasPath = new File(basedir, manager.getPathForLocalArtifact(aliased)).toPath();
+        Path realPath = new File(basedir, manager.getPathForLocalArtifact(artifact)).toPath();
+        try {
+            Files.createSymbolicLink(aliasPath, realPath.getFileName());
+        } catch (IOException | UnsupportedOperationException e) {
+            assumeTrue(false, "filesystem does not support symbolic links");
+        }
+        return aliased;
+    }
+
+    @Test
+    void testFindDoesNotAcceptFileWhoseRealPathSpellingDiffers() throws Exception {
+        Artifact aliased = createCaseAliasedArtifact();
+
+        // the aliased file is present-but-untracked for the requested coordinates: it must not be accepted,
+        // otherwise case-colliding coordinates poison distinct GAVs on case-insensitive filesystems
+        LocalArtifactRequest request = new LocalArtifactRequest(aliased, null, null);
+        LocalArtifactResult result = manager.find(session, request);
+        assertFalse(result.isAvailable());
+    }
+
+    @Test
+    void testFindAcceptsAliasedFileWhenRealPathVerificationDisabled() throws Exception {
+        session.setConfigProperty(EnhancedLocalRepositoryManagerFactory.CONFIG_PROP_VERIFY_REAL_PATH, false);
+        Artifact aliased = createCaseAliasedArtifact();
+
+        LocalArtifactRequest request = new LocalArtifactRequest(aliased, null, null);
+        LocalArtifactResult result = manager.find(session, request);
+        assertTrue(result.isAvailable());
+    }
+
     @Test
     void testFindUntrackedFile() throws Exception {
         copy(artifact, manager.getPathForLocalArtifact(artifact));
@@ -315,5 +358,103 @@ public class EnhancedLocalRepositoryManagerTest {
         LocalArtifactResult result = manager.find(session, request);
         assertNull(result.getFile(), result.toString());
         assertFalse(result.isAvailable(), result.toString());
+    }
+
+    @Test
+    void testStaleUntrackedCacheDoesNotOverrideExternallyRecordedOrigin() throws Exception {
+        // Artifact file exists but is untracked: find() accepts it (simple local repo inter-op) and
+        // caches the "untracked" state of the shared tracking file.
+        copy(artifact, manager.getPathForLocalArtifact(artifact));
+        LocalArtifactRequest request = new LocalArtifactRequest(artifact, Arrays.asList(repository), testContext);
+        assertTrue(manager.find(session, request).isAvailable());
+
+        // Another process (bypassing this manager and hence its cache) records that the artifact
+        // actually originates from a repository that is NOT among the request repositories.
+        File artifactFile = new File(basedir, manager.getPathForLocalArtifact(artifact));
+        File trackingFile = new File(artifactFile.getParentFile(), "_remote.repositories");
+        trackingFileManager.update(
+                trackingFile.toPath(), Collections.singletonMap(artifactFile.getName() + ">not-a-request-repo", ""));
+
+        // The trust-increasing untracked branch must not rely on the stale cached state: the fresh
+        // on-disk state says "downloaded from a foreign repository", so the artifact is rejected.
+        LocalArtifactResult result = manager.find(session, request);
+        assertFalse(result.isAvailable());
+    }
+
+    @Test
+    void testFreshReadPicksUpExternallyRecordedRequestRepository() throws Exception {
+        copy(artifact, manager.getPathForLocalArtifact(artifact));
+        LocalArtifactRequest request = new LocalArtifactRequest(artifact, Arrays.asList(repository), testContext);
+        assertTrue(manager.find(session, request).isAvailable());
+
+        // Another process records the artifact as downloaded from the request repository: the fresh
+        // re-read must pick that up and report the origin repository.
+        File artifactFile = new File(basedir, manager.getPathForLocalArtifact(artifact));
+        File trackingFile = new File(artifactFile.getParentFile(), "_remote.repositories");
+        trackingFileManager.update(
+                trackingFile.toPath(),
+                Collections.singletonMap(
+                        artifactFile.getName() + ">" + RepositoryIdHelper.simpleRepositoryKey(repository, testContext),
+                        ""));
+
+        LocalArtifactResult result = manager.find(session, request);
+        assertTrue(result.isAvailable());
+        assertEquals(repository, result.getRepository());
+    }
+
+    /**
+     * Manager wired like production defaults: path composition on the (unchanged) system-wide key function,
+     * tracking entries on the URL-qualified {@code nid_hurl} function.
+     */
+    private EnhancedLocalRepositoryManager newUrlQualifiedTrackingManager() {
+        return new EnhancedLocalRepositoryManager(
+                basedir.toPath(),
+                new DefaultLocalPathComposer(),
+                RepositoryIdHelper::simpleRepositoryKey,
+                RepositoryIdHelper.getRepositoryKeyFunction("nid_hurl"),
+                "_remote.repositories",
+                trackingFileManager,
+                new DefaultLocalPathPrefixComposerFactory(new DefaultRepositoryKeyFunctionFactory())
+                        .createComposer(session));
+    }
+
+    @Test
+    void testUrlQualifiedTrackingDistinguishesSameIdDifferentUrl() throws Exception {
+        manager = newUrlQualifiedTrackingManager();
+        addRemoteArtifact(artifact);
+
+        // the repository the artifact really came from still satisfies the lookup
+        LocalArtifactRequest request = new LocalArtifactRequest(artifact, Arrays.asList(repository), testContext);
+        LocalArtifactResult result = manager.find(session, request);
+        assertTrue(result.isAvailable());
+        assertEquals(repository, result.getRepository());
+
+        // an impostor sharing the trusted id but pointing at a different URL is a different origin:
+        // the cached bytes must not be accepted as "came from" it (and vice versa, bytes cached from
+        // the impostor would not satisfy the trusted repository)
+        RemoteRepository impostor =
+                new RemoteRepository.Builder(repository.getId(), "default", "https://impostor.invalid/repo").build();
+        request = new LocalArtifactRequest(artifact, Arrays.asList(impostor), testContext);
+        result = manager.find(session, request);
+        assertFalse(result.isAvailable());
+    }
+
+    @Test
+    void testUrlQualifiedTrackingTreatsLegacyIdOnlyEntriesAsStale() throws Exception {
+        manager = newUrlQualifiedTrackingManager();
+
+        // artifact file present, tracked under a legacy ID-only key as written by an older resolver
+        copy(artifact, manager.getPathForLocalArtifact(artifact));
+        File file = new File(basedir, manager.getPathForLocalArtifact(artifact));
+        trackingFileManager.update(
+                new File(file.getParentFile(), "_remote.repositories").toPath(),
+                Collections.singletonMap(
+                        file.getName() + ">" + RepositoryIdHelper.simpleRepositoryKey(repository, testContext), ""));
+
+        // fail-safe stale-key semantics: the legacy key matches no request repository, and because the
+        // file IS tracked it must not fall through to the untracked inter-op acceptance either — the
+        // artifact is simply unavailable locally and gets re-fetched (with checksum validation)
+        LocalArtifactRequest request = new LocalArtifactRequest(artifact, Arrays.asList(repository), testContext);
+        assertFalse(manager.find(session, request).isAvailable());
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedSplitLocalRepositoryManagerTest.java
@@ -35,6 +35,7 @@ public class EnhancedSplitLocalRepositoryManagerTest extends EnhancedLocalReposi
                 basedir.toPath(),
                 new DefaultLocalPathComposer(),
                 RepositoryIdHelper::simpleRepositoryKey,
+                RepositoryIdHelper::simpleRepositoryKey,
                 "_remote.repositories",
                 trackingFileManager,
                 new DefaultLocalPathPrefixComposerFactory(new DefaultRepositoryKeyFunctionFactory())

--- a/src/site/markdown/repository-key-function.md
+++ b/src/site/markdown/repository-key-function.md
@@ -70,6 +70,17 @@ In these cases, the repository key function's only role is to provide "file syst
 **Important implication:** When Resolver/Maven is reconfigured to use alternative repository key function, it is
 worthwhile to start with new, empty local repository (as keys are used in LRM maintained metadata).
 
+**Local repository provenance tracking:** the enhanced LRM records from which repository each cached artifact was
+resolved (the `_remote.repositories` files). For these tracking entries only, it defaults to the URL-qualified
+`nid_hurl` function, so that two repositories merely sharing an id — for example a repository declared by a
+transitively resolved, untrusted POM under the same id as a trusted repository — are not treated as the same
+origin in a shared local repository. This is scoped to the tracking entries: repository aggregation and (split)
+path composition keep following the system-wide function above, whose default is unchanged. If the system-wide
+function is explicitly configured, tracking follows it; the `aether.lrm.enhanced.trackingRepositoryKeyFunction`
+configuration property, when set, overrides both. Tracking entries written under a different function than the
+active one are fail-safe: affected artifacts simply appear locally unavailable and are re-fetched (with checksum
+validation) once.
+
 ## Implemented Repository Key Functions
 
 The function is configurable, while the default function remains Maven 3.x compatible. The existing functions are:


### PR DESCRIPTION
## Summary

Fixes 5 findings from the maven-resolver security audit (scan-maven-resolver-20260811):

| Finding | Severity | Description |
|---------|----------|-------------|
| f005 | MEDIUM | Existence-check peek re-labels cached foreign-repo bytes without checksum verification |
| f006 | MEDIUM | Snapshot-normalized copy is untracked and later treated as locally installed |
| f013 | MEDIUM | Repo-id-only keying lets wire-injected repository poison shared local repo |
| f019 | MEDIUM | Case-colliding coordinates poison distinct GAVs on case-insensitive filesystems |
| f021 | LOW | Stale tracking-file cache flips repo-id rejection into local-install acceptance |

**Root cause:** The enhanced local repository manager's availability decision rests on tracking state that can be weaker than the file it judges: fail-open interop branch, id-only tracking keys, case-insensitive filesystem aliasing, and re-labeling without verification.

**Fix:** Make trust labels earned and identity-bound: require verification before re-labeling, bind tracking keys to URLs, use filesystem-faithful comparison, invalidate cache after writes.

## Test plan
- [ ] Existing tests pass
- [ ] Trust re-labeling requires checksum verification
- [ ] Snapshot normalization tracking validated
- [ ] Case-collision handling tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)