### PR TITLE
fix: harden opt-in transport and lock backends against unauthenticated infrastructure

### DIFF
--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactory.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastCPSemaphoreNamedLockFactory.java
@@ -37,11 +37,25 @@ public class HazelcastCPSemaphoreNamedLockFactory extends HazelcastSemaphoreName
     public static final String NAME = "semaphore-hazelcast";
 
     /**
-     * The default constructor: creates own instance of Hazelcast using standard Hazelcast configuration discovery.
+     * The default constructor: creates own instance of Hazelcast using standard Hazelcast configuration discovery,
+     * but refuses to run on Hazelcast built-in defaults: an explicit operator-provided configuration (the
+     * {@code hazelcast.config} system property, or a {@code hazelcast.xml}/{@code hazelcast.yaml}/{@code
+     * hazelcast.yml} file on the classpath or in the working directory) is required, as the built-in defaults form
+     * an unauthenticated cluster any network peer may join and manipulate lock state through.
      */
     @Inject
     public HazelcastCPSemaphoreNamedLockFactory() {
-        this(Hazelcast.newHazelcastInstance(), true);
+        this(createConfiguredHazelcastInstance(), true);
+    }
+
+    private static HazelcastInstance createConfiguredHazelcastInstance() {
+        requireExplicitHazelcastConfig(
+                "hazelcast.config",
+                HazelcastCPSemaphoreNamedLockFactory.class.getClassLoader(),
+                "hazelcast.xml",
+                "hazelcast.yaml",
+                "hazelcast.yml");
+        return Hazelcast.newHazelcastInstance();
     }
 
     /**

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactory.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastClientCPSemaphoreNamedLockFactory.java
@@ -38,11 +38,25 @@ public class HazelcastClientCPSemaphoreNamedLockFactory extends HazelcastSemapho
     public static final String NAME = "semaphore-hazelcast-client";
 
     /**
-     * The default constructor: creates own instance of Hazelcast using standard Hazelcast configuration discovery.
+     * The default constructor: creates own instance of Hazelcast client using standard Hazelcast configuration
+     * discovery, but refuses to run on Hazelcast built-in defaults: an explicit operator-provided configuration
+     * (the {@code hazelcast.client.config} system property, or a {@code hazelcast-client.xml}/{@code
+     * hazelcast-client.yaml}/{@code hazelcast-client.yml} file on the classpath or in the working directory) is
+     * required, as the built-in defaults connect to an unauthenticated default-named cluster.
      */
     @Inject
     public HazelcastClientCPSemaphoreNamedLockFactory() {
-        this(HazelcastClient.newHazelcastClient(), true);
+        this(createConfiguredHazelcastClient(), true);
+    }
+
+    private static HazelcastInstance createConfiguredHazelcastClient() {
+        requireExplicitHazelcastConfig(
+                "hazelcast.client.config",
+                HazelcastClientCPSemaphoreNamedLockFactory.class.getClassLoader(),
+                "hazelcast-client.xml",
+                "hazelcast-client.yaml",
+                "hazelcast-client.yml");
+        return HazelcastClient.newHazelcastClient();
     }
 
     /**

--- a/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreNamedLockFactory.java
+++ b/maven-resolver-named-locks-hazelcast/src/main/java/org/eclipse/aether/named/hazelcast/HazelcastSemaphoreNamedLockFactory.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.aether.named.hazelcast;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +59,40 @@ public class HazelcastSemaphoreNamedLockFactory extends NamedLockFactorySupport 
         this.manageHazelcast = manageHazelcast;
         this.hazelcastSemaphoreProvider = requireNonNull(hazelcastSemaphoreProvider);
         this.semaphores = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Guard used by the default constructors of subclasses before they create a Hazelcast member or client via
+     * standard Hazelcast configuration discovery: refuses to proceed when no explicit operator-provided
+     * configuration is discoverable. Without one, Hazelcast falls back to its built-in defaults (default cluster
+     * name, auto-discovery join, no authentication or TLS in open-source Hazelcast), which lets any peer able to
+     * reach the network segment join the cluster and release the semaphore permits that guard local repository
+     * writes.
+     *
+     * @param configSystemProperty the Hazelcast system property naming an explicit configuration file
+     * @param classLoader the class loader to probe for configuration resources
+     * @param configResourceNames configuration file names probed on the classpath and in the working directory
+     * @throws IllegalStateException if no explicit configuration is discoverable
+     */
+    static void requireExplicitHazelcastConfig(
+            final String configSystemProperty, final ClassLoader classLoader, final String... configResourceNames) {
+        if (System.getProperty(configSystemProperty) != null) {
+            return;
+        }
+        for (String configResourceName : configResourceNames) {
+            if (classLoader.getResource(configResourceName) != null
+                    || Files.isRegularFile(Paths.get(configResourceName))) {
+                return;
+            }
+        }
+        throw new IllegalStateException(
+                "Refusing to create a Hazelcast instance from built-in defaults (default cluster name,"
+                        + " auto-discovery join, no authentication): distributed lock state guarding local"
+                        + " repository writes would be modifiable by unauthenticated network peers. Provide an"
+                        + " explicit Hazelcast configuration that secures or isolates the cluster, via the '"
+                        + configSystemProperty + "' system property or one of "
+                        + String.join(", ", configResourceNames)
+                        + " on the classpath or in the working directory.");
     }
 
     @Override

--- a/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/RequireExplicitHazelcastConfigTest.java
+++ b/maven-resolver-named-locks-hazelcast/src/test/java/org/eclipse/aether/named/hazelcast/RequireExplicitHazelcastConfigTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.named.hazelcast;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * UT for the explicit-configuration guard used by the default constructors: creating a Hazelcast member or client
+ * from built-in defaults would expose the lock state to unauthenticated network peers, so the guard must refuse
+ * when no explicit configuration is discoverable.
+ */
+class RequireExplicitHazelcastConfigTest {
+    @Test
+    void refusesWithoutExplicitConfiguration() {
+        ClassLoader emptyClassLoader = new URLClassLoader(new URL[0], null);
+        assertThrows(
+                IllegalStateException.class,
+                () -> HazelcastSemaphoreNamedLockFactory.requireExplicitHazelcastConfig(
+                        "no.such.system.property." + UUID.randomUUID(), emptyClassLoader, "no-such-config.xml"));
+    }
+
+    @Test
+    void acceptsSystemPropertyConfiguration() {
+        String property = "test.hazelcast.config." + UUID.randomUUID();
+        System.setProperty(property, "somewhere.xml");
+        try {
+            ClassLoader emptyClassLoader = new URLClassLoader(new URL[0], null);
+            HazelcastSemaphoreNamedLockFactory.requireExplicitHazelcastConfig(
+                    property, emptyClassLoader, "no-such-config.xml");
+        } finally {
+            System.clearProperty(property);
+        }
+    }
+
+    @Test
+    void acceptsClasspathConfiguration() {
+        // the test classpath ships hazelcast.xml (used by the ITs)
+        HazelcastSemaphoreNamedLockFactory.requireExplicitHazelcastConfig(
+                "no.such.system.property." + UUID.randomUUID(), getClass().getClassLoader(), "hazelcast.xml");
+    }
+}

--- a/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
+++ b/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
@@ -69,7 +69,7 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
      * {@code rediss://} (TLS) address, or a Redisson configuration file with authentication, for anything
      * cross-host.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      * @configurationSource {@link System#getProperty(String, String)}
      * @configurationType {@link java.lang.Boolean}
      * @configurationDefaultValue false

--- a/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
+++ b/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
@@ -20,9 +20,11 @@ package org.eclipse.aether.named.redisson;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import org.eclipse.aether.named.support.NamedLockFactorySupport;
 import org.redisson.Redisson;
@@ -59,6 +61,21 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
     public static final String SYSTEM_PROP_REDIS_ADDRESS = "aether.syncContext.named.redisson.address";
 
     public static final String DEFAULT_REDIS_ADDRESS = "redis://localhost:6379";
+
+    /**
+     * Whether a plaintext {@code redis://} address pointing at a non-loopback host is allowed. Such a connection is
+     * unencrypted and unauthenticated at the transport, so a tampered, spoofed, or on-path-modified Redis can grant
+     * conflicting locks and corrupt the shared local repository the locks protect. Disabled by default; prefer a
+     * {@code rediss://} (TLS) address, or a Redisson configuration file with authentication, for anything
+     * cross-host.
+     *
+     * @since 2.0.22
+     * @configurationSource {@link System#getProperty(String, String)}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue false
+     */
+    public static final String SYSTEM_PROP_ALLOW_INSECURE_ADDRESS =
+            "aether.syncContext.named.redisson.allowInsecureAddress";
 
     protected final RedissonClient redissonClient;
 
@@ -106,6 +123,22 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
         } else {
             config = new Config();
             String defaultRedisAddress = System.getProperty(SYSTEM_PROP_REDIS_ADDRESS, DEFAULT_REDIS_ADDRESS);
+            if (isInsecureRemoteAddress(defaultRedisAddress)) {
+                if (Boolean.getBoolean(SYSTEM_PROP_ALLOW_INSECURE_ADDRESS)) {
+                    logger.warn(
+                            "Using plaintext Redis address '{}' for lock state guarding local repository writes;"
+                                    + " the connection is unencrypted and unauthenticated at the transport, so the"
+                                    + " endpoint and the network path to it must be trusted and isolated",
+                            defaultRedisAddress);
+                } else {
+                    throw new IllegalStateException("Refusing plaintext non-loopback Redis address '"
+                            + defaultRedisAddress + "': lock answers from a tampered or spoofed Redis can void"
+                            + " mutual exclusion and corrupt the shared local repository. Use a 'rediss://' (TLS)"
+                            + " address, or a Redisson configuration file ('" + SYSTEM_PROP_CONFIG_FILE
+                            + "') with authentication, or explicitly opt in with -D"
+                            + SYSTEM_PROP_ALLOW_INSECURE_ADDRESS + "=true");
+                }
+            }
             config.useSingleServer().setAddress(defaultRedisAddress).setClientName(DEFAULT_CLIENT_NAME);
         }
 
@@ -113,5 +146,29 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
         logger.trace("Created Redisson client with id '{}'", redissonClient.getId());
 
         return redissonClient;
+    }
+
+    /**
+     * Returns {@code true} if the given address is a plaintext {@code redis://} address pointing at a non-loopback
+     * host. TLS ({@code rediss://}) addresses and loopback addresses are acceptable defaults; anything else is
+     * insecure. Unparseable addresses are treated as insecure (fail closed).
+     */
+    static boolean isInsecureRemoteAddress(String address) {
+        if (address.toLowerCase(Locale.ROOT).startsWith("rediss://")) {
+            return false; // TLS protects the channel
+        }
+        String host;
+        try {
+            host = URI.create(address).getHost();
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
+        if (host == null) {
+            return true;
+        }
+        return !("localhost".equalsIgnoreCase(host)
+                || host.startsWith("127.")
+                || "::1".equals(host)
+                || "[::1]".equals(host));
     }
 }

--- a/maven-resolver-named-locks-redisson/src/test/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupportTest.java
+++ b/maven-resolver-named-locks-redisson/src/test/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupportTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.named.redisson;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UT for the insecure-address guard: lock answers gate writes to the shared local repository, so a plaintext
+ * non-loopback Redis address must be refused unless explicitly opted into.
+ */
+class RedissonNamedLockFactorySupportTest {
+    @Test
+    void tlsAndLoopbackAddressesAreAcceptable() {
+        assertFalse(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("redis://localhost:6379"));
+        assertFalse(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("redis://127.0.0.1:6379"));
+        assertFalse(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("redis://[::1]:6379"));
+        assertFalse(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("rediss://redis.example.com:6379"));
+    }
+
+    @Test
+    void plaintextRemoteAddressesAreInsecure() {
+        assertTrue(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("redis://redis.ci.internal:6379"));
+        assertTrue(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("redis://10.0.0.5:6379"));
+        // unparseable addresses fail closed
+        assertTrue(RedissonNamedLockFactorySupport.isInsecureRemoteAddress("not a valid uri"));
+    }
+
+    @Test
+    void plaintextRemoteAddressRefusedAtFactoryCreation() {
+        System.setProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_REDIS_ADDRESS, "redis://redis.ci.internal:6379");
+        try {
+            // refused before any connection attempt is made
+            assertThrows(IllegalStateException.class, RedissonSemaphoreNamedLockFactory::new);
+        } finally {
+            System.clearProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_REDIS_ADDRESS);
+        }
+    }
+}

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterConfigurationKeys.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterConfigurationKeys.java
@@ -56,4 +56,21 @@ public final class MinioTransporterConfigurationKeys {
     public static final String CONFIG_PROP_FIXED_BUCKET_NAME = CONFIG_PROPS_PREFIX + "fixedBucketName";
 
     public static final String DEFAULT_FIXED_BUCKET_NAME = "maven";
+
+    /**
+     * Whether plaintext HTTP object storage endpoints (repository URLs in {@code minio+http} or {@code s3+http}
+     * form) are allowed. Plaintext endpoints offer no transport integrity (artifacts and their checksum objects
+     * travel over the same tamperable channel) and, because the repository protocol string is not {@code http},
+     * such URLs are not matched by {@code external:http:*} mirror blocking. They are therefore refused unless this
+     * property is explicitly set to {@code true}.
+     *
+     * @since 2.0.22
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_ALLOW_INSECURE_PROTOCOL}
+     * @configurationRepoIdSuffix Yes
+     */
+    public static final String CONFIG_PROP_ALLOW_INSECURE_PROTOCOL = CONFIG_PROPS_PREFIX + "allowInsecureProtocol";
+
+    public static final boolean DEFAULT_ALLOW_INSECURE_PROTOCOL = false;
 }

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterConfigurationKeys.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterConfigurationKeys.java
@@ -64,7 +64,7 @@ public final class MinioTransporterConfigurationKeys {
      * such URLs are not matched by {@code external:http:*} mirror blocking. They are therefore refused unless this
      * property is explicitly set to {@code true}.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
      * @configurationType {@link Boolean}
      * @configurationDefaultValue {@link #DEFAULT_ALLOW_INSECURE_PROTOCOL}

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterFactory.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/MinioTransporterFactory.java
@@ -76,20 +76,44 @@ public final class MinioTransporterFactory implements TransporterFactory {
         // this check is here only to support "minio+http" and "s3+http" protocols by default. But also when
         // raised priorities by user, allow to "overtake" plain HTTP repositories, if needed.
         RemoteRepository adjusted = repository;
+        boolean prefixStripped = false;
         if ("minio+http".equalsIgnoreCase(repository.getProtocol())
                 || "minio+https".equalsIgnoreCase(repository.getProtocol())) {
             adjusted = new RemoteRepository.Builder(repository)
                     .setUrl(repository.getUrl().substring("minio+".length()))
                     .build();
+            prefixStripped = true;
         } else if ("s3+http".equalsIgnoreCase(repository.getProtocol())
                 || "s3+https".equalsIgnoreCase(repository.getProtocol())) {
             adjusted = new RemoteRepository.Builder(repository)
                     .setUrl(repository.getUrl().substring("s3+".length()))
                     .build();
+            prefixStripped = true;
         } else if (priority == DEFAULT_PRIORITY) {
             throw new NoTransporterException(
                     repository,
                     "To use Minio transport with plain HTTP/HTTPS repositories, increase the Minio transport priority");
+        }
+        // Plaintext endpoints from "minio+http"/"s3+http" URLs are not matched by "external:http:*" mirror
+        // blocking (the repository protocol string is not "http") and offer no transport integrity: artifacts
+        // and their checksum objects travel over the same tamperable channel. Refuse them unless the operator
+        // explicitly opted in.
+        if (prefixStripped && "http".equalsIgnoreCase(adjusted.getProtocol())) {
+            boolean allowInsecureProtocol = ConfigUtils.getBoolean(
+                    session,
+                    MinioTransporterConfigurationKeys.DEFAULT_ALLOW_INSECURE_PROTOCOL,
+                    MinioTransporterConfigurationKeys.CONFIG_PROP_ALLOW_INSECURE_PROTOCOL + "." + repository.getId(),
+                    MinioTransporterConfigurationKeys.CONFIG_PROP_ALLOW_INSECURE_PROTOCOL);
+            if (!allowInsecureProtocol) {
+                throw new NoTransporterException(
+                        repository,
+                        "Plaintext HTTP object storage endpoints are insecure (no transport integrity; not subject"
+                                + " to 'external:http:*' mirror blocking) and are refused by default: use the"
+                                + " 'minio+https'/'s3+https' URL form, or explicitly opt in by setting the"
+                                + " configuration property '"
+                                + MinioTransporterConfigurationKeys.CONFIG_PROP_ALLOW_INSECURE_PROTOCOL
+                                + "' (optionally suffixed with '." + repository.getId() + "') to 'true'");
+            }
         }
         String objectNameMapperConf = ConfigUtils.getString(
                 session,

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/internal/FixedBucketObjectNameMapperFactory.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/internal/FixedBucketObjectNameMapperFactory.java
@@ -47,11 +47,13 @@ public class FixedBucketObjectNameMapperFactory implements ObjectNameMapperFacto
             RemoteRepository repository,
             MinioClient unused,
             Map<String, String> headers) {
+        // ConfigUtils.getString(session, defaultValue, keys...): the default value ("maven") comes first,
+        // then the repository-suffixed key, then the global key.
         String bucket = ConfigUtils.getString(
                 session,
-                MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME,
+                MinioTransporterConfigurationKeys.DEFAULT_FIXED_BUCKET_NAME,
                 MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME + "." + repository.getId(),
-                MinioTransporterConfigurationKeys.DEFAULT_FIXED_BUCKET_NAME);
+                MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME);
         return path -> new ObjectName(bucket, repository.getId() + "/" + ObjectName.normalize(path));
     }
 }

--- a/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/package-info.java
+++ b/maven-resolver-transport-minio/src/main/java/org/eclipse/aether/transport/minio/package-info.java
@@ -20,9 +20,11 @@
 /**
  * Support for downloads/uploads via the S3 protocol. The implementation is backed by
  * <a href="https://github.com/minio/minio-java">MinIO Java</a>.
- * The repository URL should be defined with protocol {@code minio+http} or {@code s3+http}. Note: use "https" if
- * you are going for HTTPS remote, factory will merely strip "minio+" or "s3+" prefix assuming resulting URL will
- * point to expected S3 endpoint.
+ * The repository URL should be defined with protocol {@code minio+https} or {@code s3+https}; the factory will
+ * merely strip the "minio+" or "s3+" prefix assuming the resulting URL will point to the expected S3 endpoint.
+ * The plaintext {@code minio+http}/{@code s3+http} forms are refused by default: they offer no transport integrity
+ * and are not matched by {@code external:http:*} mirror blocking. To use a plaintext endpoint anyway, explicitly
+ * set the configuration property {@code aether.transport.minio.allowInsecureProtocol} to {@code true}.
  *
  * @since 2.0.2
  */

--- a/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/MinioTransporterFactoryTest.java
+++ b/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/MinioTransporterFactoryTest.java
@@ -58,7 +58,7 @@ class MinioTransporterFactoryTest {
 
         factory = new MinioTransporterFactory(factories, new PathProcessorSupport());
         session = new DefaultRepositorySystemSession(h -> true);
-        repository = new RemoteRepository.Builder("repo", "default", "minio+http://localhost")
+        repository = new RemoteRepository.Builder("repo", "default", "minio+https://localhost")
                 .setAuthentication(new AuthenticationBuilder()
                         .addUsername("username")
                         .addPassword("password")
@@ -86,6 +86,35 @@ class MinioTransporterFactoryTest {
         assertThrows(NoTransporterException.class, () -> factory.newInstance(session, remoteRepository.get()));
         remoteRepository.set(new RemoteRepository.Builder("repo", "default", "https://localhost").build());
         assertThrows(NoTransporterException.class, () -> factory.newInstance(session, remoteRepository.get()));
+    }
+
+    @Test
+    void plaintextHttpRefusedByDefault() {
+        for (String url : new String[] {"minio+http://localhost", "s3+http://localhost"}) {
+            RemoteRepository plaintext = new RemoteRepository.Builder("repo", "default", url)
+                    .setAuthentication(new AuthenticationBuilder()
+                            .addUsername("username")
+                            .addPassword("password")
+                            .build())
+                    .build();
+            assertThrows(NoTransporterException.class, () -> factory.newInstance(session, plaintext));
+        }
+    }
+
+    @Test
+    void plaintextHttpAllowedWithExplicitOptIn() throws Exception {
+        DefaultRepositorySystemSession insecureSession = new DefaultRepositorySystemSession(h -> true);
+        insecureSession.setConfigProperty(
+                MinioTransporterConfigurationKeys.CONFIG_PROP_ALLOW_INSECURE_PROTOCOL, Boolean.TRUE);
+        RemoteRepository plaintext = new RemoteRepository.Builder("repo", "default", "minio+http://localhost")
+                .setAuthentication(new AuthenticationBuilder()
+                        .addUsername("username")
+                        .addPassword("password")
+                        .build())
+                .build();
+        try (Transporter transporter = factory.newInstance(insecureSession, plaintext)) {
+            // nope
+        }
     }
 
     @Test

--- a/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/internal/FixedBucketObjectNameMapperFactoryTest.java
+++ b/maven-resolver-transport-minio/src/test/java/org/eclipse/aether/transport/minio/internal/FixedBucketObjectNameMapperFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.minio.internal;
+
+import java.util.Collections;
+
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.transport.minio.MinioTransporterConfigurationKeys;
+import org.eclipse.aether.transport.minio.ObjectNameMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * UT asserting the effective bucket is exactly the one the operator configured, with the documented default:
+ * a swapped {@code ConfigUtils.getString} argument order previously made the effective bucket the literal
+ * configuration key string and ignored the documented global key.
+ */
+class FixedBucketObjectNameMapperFactoryTest {
+    private final FixedBucketObjectNameMapperFactory factory = new FixedBucketObjectNameMapperFactory();
+
+    private final RemoteRepository repository =
+            new RemoteRepository.Builder("repo", "default", "minio+https://localhost").build();
+
+    private String effectiveBucket(DefaultRepositorySystemSession session) {
+        ObjectNameMapper mapper = factory.create(session, repository, null, Collections.emptyMap());
+        return mapper.name("g/a/v/a.jar").getBucket();
+    }
+
+    @Test
+    void documentedDefaultBucketNameIsUsed() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> true);
+        assertEquals(MinioTransporterConfigurationKeys.DEFAULT_FIXED_BUCKET_NAME, effectiveBucket(session));
+    }
+
+    @Test
+    void globalConfigurationKeyIsHonored() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> true);
+        session.setConfigProperty(MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME, "custom-bucket");
+        assertEquals("custom-bucket", effectiveBucket(session));
+    }
+
+    @Test
+    void repositoryIdSuffixedKeyTakesPrecedence() {
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> true);
+        session.setConfigProperty(MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME, "custom-bucket");
+        session.setConfigProperty(
+                MinioTransporterConfigurationKeys.CONFIG_PROP_FIXED_BUCKET_NAME + "." + repository.getId(),
+                "repo-bucket");
+        assertEquals("repo-bucket", effectiveBucket(session));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 4 findings from the maven-resolver security audit (scan-maven-resolver-20260811):

| Finding | Severity | Description |
|---------|----------|-------------|
| f031 | MEDIUM | Plaintext `minio+http`/`s3+http` repositories evade `external:http:*` blocking |
| f032 | MEDIUM | Default-config Hazelcast member in build JVM accepts unauthenticated LAN peers |
| f033 | MEDIUM | Redis lock backend trusted unconditionally over unauthenticated plaintext |
| f034 | LOW | Swapped `ConfigUtils.getString` args ignore bucket config, misroute artifacts |

**Root cause:** Three opt-in modules place infrastructure that gates local-repository integrity outside every defense the platform otherwise applies: MinIO plaintext evades `external:http:*`, Hazelcast boots with no auth on defaults, Redis accepts any plaintext address.

**Fix:** Make enabling insecure backends a loud, deliberate act: refuse plaintext without opt-in, fail fast without explicit config, document trust boundary.

## Test plan
- [ ] Existing tests pass
- [ ] MinIO plaintext rejection tested
- [ ] Hazelcast fail-fast without config tested
- [ ] Redis plaintext refusal tested
- [ ] ConfigUtils.getString arg order fixed and unit tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)