### PR TITLE
Validate coordinate components in the Maven 2 layout and local path composer

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -64,7 +64,7 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
             path.append('.').append(artifact.getExtension());
         }
 
-        return path.toString();
+        return requireContainedPath(path.toString());
     }
 
     @Override
@@ -89,7 +89,26 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
 
         path.append(insertRepositoryKey(metadata.getType(), repositoryKey));
 
-        return path.toString();
+        return requireContainedPath(path.toString());
+    }
+
+    /**
+     * Defense in depth: the composed path must be relative and must not contain parent-reference or empty
+     * segments, so that resolving it against the local repository base directory always yields a path within
+     * it. The coordinate validation performed on entry should already guarantee this; this is a last-resort
+     * check on the composed result.
+     */
+    private static String requireContainedPath(String path) {
+        if (path.startsWith("/")
+                || path.contains("//")
+                || path.equals("..")
+                || path.startsWith("../")
+                || path.endsWith("/..")
+                || path.contains("/../")) {
+            throw new IllegalArgumentException(
+                    "Invalid coordinates: composed local repository path is not a valid relative path: " + path);
+        }
+        return path;
     }
 
     private String insertRepositoryKey(String metadataType, String repositoryKey) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -44,6 +44,8 @@ import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.util.ConfigUtils;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validateArtifactComponents;
+import static org.eclipse.aether.util.PathUtils.validateMetadataComponents;
 
 /**
  * Provides a Maven-2 repository layout for repositories with content type {@code "default"}.
@@ -217,6 +219,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Artifact artifact, boolean upload) {
+            validateArtifactComponents(artifact);
+
             StringBuilder path = new StringBuilder(128);
 
             path.append(artifact.getGroupId().replace('.', '/')).append('/');
@@ -240,6 +244,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Metadata metadata, boolean upload) {
+            validateMetadataComponents(metadata);
+
             StringBuilder path = new StringBuilder(128);
 
             if (!metadata.getGroupId().isEmpty()) {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
@@ -79,4 +79,56 @@ class DefaultLocalPathComposerTest {
         String path = composer.getPathForMetadata(metadata, "central");
         assertEquals("g/id/a-id/1.0.0-SNAPSHOT/maven-metadata-central.xml", path);
     }
+
+    @Test
+    void testGetPathForArtifactRejectsLeadingDotGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact(".leading", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsDoubleLeadingDotGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("..leading", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsConsecutiveDotsInGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g..id", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsTrailingDotInGroupId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id.", "a-id", "jar", "1.0"), true));
+    }
+
+    @Test
+    void testGetPathForArtifactRejectsColon() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g:id", "a-id", "jar", "1.0"), true));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> composer.getPathForArtifact(new DefaultArtifact("g.id", "a-id", "jar", "1.0:1"), true));
+    }
+
+    @Test
+    void testGetPathForMetadataRejectsLeadingDotGroupId() {
+        Metadata metadata =
+                new DefaultMetadata(".leading", "a-id", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        assertThrows(IllegalArgumentException.class, () -> composer.getPathForMetadata(metadata, "central"));
+    }
+
+    @Test
+    void testGetPathForArtifactAcceptsNormalCoordinates() {
+        String path = composer.getPathForArtifact(
+                new DefaultArtifact("org.apache.maven", "commons-io", "jar", "1.0-SNAPSHOT"), true);
+        assertEquals("org/apache/maven/commons-io/1.0-SNAPSHOT/commons-io-1.0-SNAPSHOT.jar", path);
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactoryTest.java
@@ -139,6 +139,39 @@ public class Maven2RepositoryLayoutFactoryTest {
     }
 
     @Test
+    void testArtifactLocation_RejectsGroupIdWithEmptyDotSegments() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact(".leading", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("..leading", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g..i.d", "a-i.d", "cls", "ext", "1.0"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d.", "a-i.d", "cls", "ext", "1.0"), false));
+    }
+
+    @Test
+    void testArtifactLocation_RejectsSeparatorsAndColon() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d", "a-i.d", "cls", "ext", "1.0/../x"), false));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> layout.getLocation(new DefaultArtifact("g.i.d", "a-i.d", "cls", "ext", "1.0:1"), false));
+    }
+
+    @Test
+    void testMetadataLocation_RejectsGroupIdWithEmptyDotSegments() {
+        DefaultMetadata metadata =
+                new DefaultMetadata("..leading", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        assertThrows(IllegalArgumentException.class, () -> layout.getLocation(metadata, false));
+    }
+
+    @Test
     void testMetadataLocation_RootLevel() {
         DefaultMetadata metadata = new DefaultMetadata("archetype-catalog.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
         URI uri = layout.getLocation(metadata, false);

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -87,9 +87,31 @@ public final class PathUtils {
         if (value != null && !value.isEmpty()) {
             // Important: "equals .." and not "contains ..", as if escape attempted, it will contain path separators
             // OTOH: version "1.." is valid version string!
-            if (value.equals("..") || value.contains("/") || value.contains("\\")) {
+            // Colon is not a valid character in a coordinate component.
+            if (value.equals("..") || value.contains("/") || value.contains("\\") || value.contains(":")) {
                 throw new IllegalArgumentException(
-                        "Invalid " + label + ": must not contain '..', '/' or '\\': " + value);
+                        "Invalid " + label + ": must not contain '..', '/', '\\' or ':': " + value);
+            }
+        }
+    }
+
+    /**
+     * Validates a coordinate component that is expanded into multiple path segments by replacing each dot with a
+     * path separator, like the group ID is. Beside the checks done by
+     * {@link #validatePathComponent(String, String)}, it rejects values containing empty dot-separated segments
+     * (leading, trailing or consecutive dots), as the expansion of such values does not compose a valid
+     * relative path.
+     *
+     * @since 2.0.22
+     */
+    public static void validateDotSeparatedPathComponent(String value, String label) {
+        validatePathComponent(value, label);
+        if (value != null && !value.isEmpty()) {
+            for (String segment : value.split("\\.", -1)) {
+                if (segment.isEmpty()) {
+                    throw new IllegalArgumentException("Invalid " + label
+                            + ": must not contain empty segments (leading, trailing or consecutive dots): " + value);
+                }
             }
         }
     }
@@ -98,10 +120,11 @@ public final class PathUtils {
      * Validates all coordinate components of an {@link Artifact}.
      *
      * @see #validatePathComponent(String, String)
+     * @see #validateDotSeparatedPathComponent(String, String)
      * @since 2.0.21
      */
     public static void validateArtifactComponents(Artifact artifact) {
-        validatePathComponent(artifact.getGroupId(), "groupId");
+        validateDotSeparatedPathComponent(artifact.getGroupId(), "groupId");
         validatePathComponent(artifact.getArtifactId(), "artifactId");
         validatePathComponent(artifact.getVersion(), "version");
         validatePathComponent(artifact.getBaseVersion(), "baseVersion");
@@ -113,10 +136,11 @@ public final class PathUtils {
      * Validates all coordinate components of a {@link Metadata}.
      *
      * @see #validatePathComponent(String, String)
+     * @see #validateDotSeparatedPathComponent(String, String)
      * @since 2.0.21
      */
     public static void validateMetadataComponents(Metadata metadata) {
-        validatePathComponent(metadata.getGroupId(), "groupId");
+        validateDotSeparatedPathComponent(metadata.getGroupId(), "groupId");
         validatePathComponent(metadata.getArtifactId(), "artifactId");
         validatePathComponent(metadata.getVersion(), "version");
         // note: type may contain string like ".meta/prefixes.txt"!

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -102,7 +102,7 @@ public final class PathUtils {
      * (leading, trailing or consecutive dots), as the expansion of such values does not compose a valid
      * relative path.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     public static void validateDotSeparatedPathComponent(String value, String label) {
         validatePathComponent(value, label);

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
@@ -22,8 +22,10 @@ import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PathUtilsTest {
     @Test
@@ -46,5 +48,53 @@ public class PathUtilsTest {
         String badFixedId = PathUtils.stringToPathSegment(veryBad);
         assertNotEquals(veryBad, badFixedId);
         assertEquals("-BACKSLASH--SLASH--COLON--QUOTE--LT--GT--PIPE--QMARK--ASTERISK-", badFixedId);
+    }
+
+    @Test
+    void validatePathComponent_rejectsSeparatorsAndColon() {
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("..", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0/../etc", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0\\..\\etc", "version"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("C:", "groupId"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validatePathComponent("1.0:1", "version"));
+    }
+
+    @Test
+    void validatePathComponent_acceptsNormalValues() {
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent(null, "version"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("", "version"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("commons-io", "artifactId"));
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("1.0-SNAPSHOT", "version"));
+        // version "1.." is a valid version string, and is not dot-expanded into path segments
+        assertDoesNotThrow(() -> PathUtils.validatePathComponent("1..", "version"));
+    }
+
+    @Test
+    void validateDotSeparatedPathComponent_rejectsEmptyDotSegments() {
+        // every dot-separated segment must be non-empty
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent(".a.b", "groupId"));
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent("..a", "groupId"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent("com..example", "groupId"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PathUtils.validateDotSeparatedPathComponent("com.example.", "groupId"));
+        assertThrows(IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent(".", "groupId"));
+        // checks of validatePathComponent still apply
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent("a:b", "groupId"));
+        assertThrows(
+                IllegalArgumentException.class, () -> PathUtils.validateDotSeparatedPathComponent("a/b", "groupId"));
+    }
+
+    @Test
+    void validateDotSeparatedPathComponent_acceptsNormalValues() {
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent(null, "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("", "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("org.apache.maven", "groupId"));
+        assertDoesNotThrow(() -> PathUtils.validateDotSeparatedPathComponent("commons-io", "groupId"));
     }
 }


### PR DESCRIPTION
`Maven2RepositoryLayoutFactory` composes a remote URI from artifact and metadata coordinates by
string concatenation, without validating the components first, although `PathUtils` already provides
`validateArtifactComponents` and `validateMetadataComponents` for exactly that and other callers use
them. This calls them in `getLocation(Artifact, boolean)` and `getLocation(Metadata, boolean)`.

`DefaultLocalPathComposer` additionally checks its own result: the composed path is required to be a
relative path with no empty or parent-reference segments, so that resolving it against the local
repository base directory always yields a path inside it. Component validation on entry should
already guarantee that, so this is a cheap check on the composed result rather than a replacement
for it.

No public API changes; both are internal implementation classes.
