### PR TITLE
Resolve file transport locations with path operations instead of substring matching

### DIFF
--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -163,10 +163,22 @@ final class FileTransporter extends AbstractTransporter {
 
     private Path getPath(TransportTask task, boolean required) throws Exception {
         String path = task.getLocation().getPath();
-        if (path.contains("../")) {
+        if (path == null) {
+            throw new IllegalArgumentException("illegal resource path: null");
+        }
+        Path relative = fileSystem.getPath(path);
+        if (relative.isAbsolute()) {
             throw new IllegalArgumentException("illegal resource path: " + path);
         }
-        Path file = basePath.resolve(path);
+        for (Path segment : relative) {
+            if ("..".equals(segment.toString())) {
+                throw new IllegalArgumentException("illegal resource path: " + path);
+            }
+        }
+        Path file = basePath.resolve(relative).normalize();
+        if (!file.startsWith(basePath.normalize())) {
+            throw new IllegalArgumentException("illegal resource path: " + path);
+        }
         if (required && !Files.isRegularFile(file)) {
             throw new ResourceNotFoundException("Could not locate " + file);
         }

--- a/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
+++ b/maven-resolver-transport-file/src/test/java/org/eclipse/aether/transport/file/FileTransporterTest.java
@@ -106,6 +106,20 @@ public class FileTransporterTest {
         transporter = factory.newInstance(session, newRepo(url));
     }
 
+    /**
+     * Builds a task location URI carrying the absolute path of the given resource within the repository base
+     * directory, in a platform and file system neutral way (e.g. {@code /C:/repo/file.txt} on Windows).
+     */
+    private URI absoluteLocation(String resource) throws Exception {
+        Path absolute =
+                ((FileTransporter) transporter).getBasePath().resolve(resource).toAbsolutePath();
+        String rawPath = absolute.toString().replace('\\', '/');
+        if (!rawPath.startsWith("/")) {
+            rawPath = "/" + rawPath;
+        }
+        return new URI(null, null, rawPath, null);
+    }
+
     void setUp(FS fs) {
         try {
             fileSystem = fs.name().startsWith("JIMFS") ? Jimfs.newFileSystem() : null;
@@ -302,6 +316,43 @@ public class FileTransporterTest {
 
     @ParameterizedTest
     @EnumSource(FS.class)
+    void testGet_AbsoluteResourcePathRejected(FS fs) throws Exception {
+        setUp(fs);
+        GetTask task = new GetTask(absoluteLocation("file.txt"));
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(task));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_ParentReferenceRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create("../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_BareParentDirRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create(".."))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testGet_NestedParentReferenceRejected(FS fs) {
+        setUp(fs);
+        assertThrows(
+                IllegalArgumentException.class, () -> transporter.get(new GetTask(URI.create("a/../../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPeek_ParentReferenceRejected(FS fs) {
+        setUp(fs);
+        assertThrows(IllegalArgumentException.class, () -> transporter.peek(new PeekTask(URI.create("../file.txt"))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
     void testGet_Closed(FS fs) throws Exception {
         setUp(fs);
         transporter.close();
@@ -447,6 +498,38 @@ public class FileTransporterTest {
             assertTrue(Files.deleteIfExists(src), i + ", " + src.toAbsolutePath());
             assertTrue(Files.deleteIfExists(dst), i + ", " + dst.toAbsolutePath());
         }
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_AbsoluteResourcePathRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(absoluteLocation("absolute-upload.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        assertFalse(Files.exists(repoDir.resolve("absolute-upload.txt")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_ParentReferenceRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(URI.create("../sibling.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        Path base = ((FileTransporter) transporter).getBasePath();
+        assertFalse(Files.exists(base.getParent().resolve("sibling.txt")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FS.class)
+    void testPut_NestedParentReferenceRejected(FS fs) throws Exception {
+        assumeTrue(fs.writable);
+        setUp(fs);
+        PutTask task = new PutTask(URI.create("a/../../sibling.txt")).setDataString("upload");
+        assertThrows(IllegalArgumentException.class, () -> transporter.put(task));
+        Path base = ((FileTransporter) transporter).getBasePath();
+        assertFalse(Files.exists(base.getParent().resolve("sibling.txt")));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
`FileTransporter.getPath` tested the raw location string with `path.contains("../")` before resolving
it against the repository base directory. A substring test on an unparsed string is a fragile way to
decide whether a resolved path stays where it should, and it does not consider an absolute location
at all.

This replaces it with file system path operations:

- reject a null location,
- reject a location that parses as an absolute path,
- reject any location with a `..` segment,
- resolve against the base directory, normalize, and require the result to remain under it.

The tests run against both a real file system and an in-memory one (Jimfs), including on Windows,
where an absolute location has a different shape. `absoluteLocation` in the test builds that URI in a
platform-neutral way rather than hard-coding a separator.
