### PR TITLE
Compose named lock keys one segment per coordinate field

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
@@ -105,7 +105,7 @@ public class BasedirNameMapper implements NameMapper {
      * not contained under it, as the file lock factory creates (and deletes on close) lock files at the
      * resolved path.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     private static String resolveContained(Path basedir, String name) {
         Path resolved = basedir.resolve(name).toAbsolutePath();

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
@@ -93,11 +93,26 @@ public class BasedirNameMapper implements NameMapper {
                     : DirectoryUtils.resolveDirectory(session, DEFAULT_LOCKS_DIR, CONFIG_PROP_LOCKS_DIR, false);
 
             return delegate.nameLocks(session, artifacts, metadatas).stream()
-                    .map(k -> NamedLockKey.of(
-                            basedir.resolve(k.name()).toAbsolutePath().toUri().toASCIIString(), k.resources()))
+                    .map(k -> NamedLockKey.of(resolveContained(basedir, k.name()), k.resources()))
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Resolves the delegate-provided lock name against the locks base directory, rejecting names that are
+     * not contained under it, as the file lock factory creates (and deletes on close) lock files at the
+     * resolved path.
+     *
+     * @since 2.0.22
+     */
+    private static String resolveContained(Path basedir, String name) {
+        Path resolved = basedir.resolve(name).toAbsolutePath();
+        if (!resolved.normalize().startsWith(basedir.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException(
+                    "Lock name '" + name + "' is not contained in the locks base directory " + basedir);
+        }
+        return resolved.toUri().toASCIIString();
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
@@ -41,25 +41,25 @@ public class GAECVNameMapper extends GAVNameMapper {
     protected String getArtifactName(Artifact artifact) {
         if (artifact.getClassifier().isEmpty()) {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         } else {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getClassifier()
+                    + fieldToSegment(artifact.getClassifier())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -111,7 +111,7 @@ public class GAVNameMapper implements NameMapper {
      * friendly names are resolved against the locks base directory by {@link BasedirNameMapper}, so every
      * field must be a valid path segment.
      *
-     * @since 2.0.22
+     * @since 2.0.23
      */
     protected String fieldToSegment(String field) {
         return fileSystemFriendly ? PathUtils.stringToPathSegment(field) : field;

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -96,12 +96,25 @@ public class GAVNameMapper implements NameMapper {
 
     protected String getArtifactName(Artifact artifact) {
         return artifactPrefix
-                + artifact.getGroupId()
+                + fieldToSegment(artifact.getGroupId())
                 + fieldSeparator
-                + artifact.getArtifactId()
+                + fieldToSegment(artifact.getArtifactId())
                 + fieldSeparator
-                + artifact.getBaseVersion()
+                + fieldToSegment(artifact.getBaseVersion())
                 + artifactSuffix;
+    }
+
+    /**
+     * Returns the given coordinate field in a form that is safe to use as (part of) a file name: when this
+     * mapper is {@link #isFileSystemFriendly()}, characters that act as path separators or are otherwise
+     * illegal in file names are replaced via {@link PathUtils#stringToPathSegment(String)}. File-system
+     * friendly names are resolved against the locks base directory by {@link BasedirNameMapper}, so every
+     * field must be a valid path segment.
+     *
+     * @since 2.0.22
+     */
+    protected String fieldToSegment(String field) {
+        return fileSystemFriendly ? PathUtils.stringToPathSegment(field) : field;
     }
 
     protected static final String MAVEN_METADATA = "maven-metadata.xml";
@@ -109,20 +122,19 @@ public class GAVNameMapper implements NameMapper {
     protected String getMetadataName(Metadata metadata) {
         String name = metadataPrefix;
         if (!metadata.getGroupId().isEmpty()) {
-            name += metadata.getGroupId();
+            name += fieldToSegment(metadata.getGroupId());
             if (!metadata.getArtifactId().isEmpty()) {
-                name += fieldSeparator + metadata.getArtifactId();
+                name += fieldSeparator + fieldToSegment(metadata.getArtifactId());
                 if (!metadata.getVersion().isEmpty()) {
-                    name += fieldSeparator + metadata.getVersion();
+                    name += fieldSeparator + fieldToSegment(metadata.getVersion());
                 }
             }
             if (!MAVEN_METADATA.equals(metadata.getType())) {
-                name += fieldSeparator
-                        + (fileSystemFriendly ? PathUtils.stringToPathSegment(metadata.getType()) : metadata.getType());
+                name += fieldSeparator + fieldToSegment(metadata.getType());
             }
         } else {
             if (!MAVEN_METADATA.equals(metadata.getType())) {
-                name += (fileSystemFriendly ? PathUtils.stringToPathSegment(metadata.getType()) : metadata.getType());
+                name += fieldToSegment(metadata.getType());
             }
         }
         return name + metadataSuffix;

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapperTest.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
@@ -166,6 +168,41 @@ public class BasedirNameMapperTest extends NameMapperTestSupport {
         assertEquals(
                 getPrefix() + "metadata~groupId~artifactId~something.xml.lock",
                 names.iterator().next().name());
+    }
+
+    @Test
+    void separatorCoordinatesStayWithinLocksDir() throws IOException {
+        configProperties.put("aether.syncContext.named.hashing.depth", "0");
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "jar", "1/../../../../home/user/x");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        assertEquals(
+                getPrefix()
+                        + "artifact~group~artifact~1-SLASH-..-SLASH-..-SLASH-..-SLASH-..-SLASH-home-SLASH-user-SLASH-x.lock",
+                names.iterator().next().name());
+    }
+
+    @Test
+    void escapingDelegateNameIsRejected() {
+        // even a (custom) delegate that emits separator sequences must not select a path outside the locks dir
+        NameMapper escaping = new NameMapper() {
+            @Override
+            public boolean isFileSystemFriendly() {
+                return true;
+            }
+
+            @Override
+            public Collection<NamedLockKey> nameLocks(
+                    RepositorySystemSession session,
+                    Collection<? extends Artifact> artifacts,
+                    Collection<? extends Metadata> metadatas) {
+                return singletonList(NamedLockKey.of("../../../outside.lock"));
+            }
+        };
+        NameMapper basedirMapper = new BasedirNameMapper(escaping);
+        DefaultArtifact artifact = new DefaultArtifact("group:artifact:1.0");
+        assertThrows(
+                IllegalArgumentException.class, () -> basedirMapper.nameLocks(session, singletonList(artifact), null));
     }
 
     @Test

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapperTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GAVNameMapperTest extends NameMapperTestSupport {
@@ -97,6 +98,32 @@ public class GAVNameMapperTest extends NameMapperTestSupport {
         assertEquals(
                 "metadata~groupId~artifactId~something.xml.lock",
                 names.iterator().next().name());
+    }
+
+    @Test
+    void pathSeparatorsInArtifactCoordinatesAreNeutralized() {
+        // wire-supplied coordinate fields must not be able to select a lock path outside the locks directory
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "jar", "1/../../../../home/user/x");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals(
+                "artifact~group~artifact~1-SLASH-..-SLASH-..-SLASH-..-SLASH-..-SLASH-home-SLASH-user-SLASH-x.lock",
+                name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void pathSeparatorsInMetadataCoordinatesAreNeutralized() {
+        DefaultMetadata metadata = new DefaultMetadata(
+                "group", "artifact", "1\\..\\..\\x", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals("metadata~group~artifact~1-BACKSLASH-..-BACKSLASH-..-BACKSLASH-x.lock", name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
     }
 
     @Test


### PR DESCRIPTION
The named lock mappers build a lock name by concatenating artifact coordinate fields. The fields are
inserted as-is, so a field containing a separator produces a name with more segments than intended.
`BasedirNameMapper` then resolves that name against the locks base directory, and the file lock
factory creates and deletes a lock file at the resolved path.

Two changes:

- `GAVNameMapper` and `GAECVNameMapper` compose each coordinate field through `fieldToSegment`, so a
  field always contributes exactly one segment.
- `BasedirNameMapper` resolves the delegate-provided name against the base directory and requires the
  result to stay under it, since that is where lock files are created and removed.

Marked `@since 2.0.23`. No public API changes.
