### PR TITLE
Backport path composition and repository provenance changes to 1.9.x

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/impl/RemoteRepositoryManager.java
@@ -55,6 +55,42 @@ public interface RemoteRepositoryManager {
             boolean recessiveIsRaw);
 
     /**
+     * Aggregates repository definitions by merging duplicate repositories and optionally applies mirror, proxy and
+     * authentication settings from the supplied session, additionally distinguishing the provenance of the recessive
+     * repository definitions. Repository definitions that originate from a remote artifact descriptor (i.e. a POM
+     * downloaded during dependency collection) are remotely supplied input: implementations may withhold session
+     * authentication from them unless an operator-defined mirror has been selected for them, so that session
+     * authentication is applied only to repositories the operator configured. Repository definitions supplied
+     * by the build itself must keep receiving mirror, proxy and authentication settings as documented for
+     * {@link #aggregateRepositories(RepositorySystemSession, List, List, boolean)}.
+     * <p>
+     * The default implementation ignores the provenance hint and delegates to
+     * {@link #aggregateRepositories(RepositorySystemSession, List, List, boolean)}.
+     *
+     * @param session The repository session during which the repositories will be accessed, must not be {@code null}.
+     * @param dominantRepositories The current list of remote repositories to merge the new definitions into, must not
+     *            be {@code null}.
+     * @param recessiveRepositories The remote repositories to merge into the existing list, must not be {@code null}.
+     * @param recessiveIsRaw {@code true} if the recessive repository definitions have not yet been subjected to mirror,
+     *            proxy and authentication settings, {@code false} otherwise.
+     * @param recessiveIsFromDescriptor {@code true} if the recessive repository definitions were declared by a remote
+     *            artifact descriptor (POM) rather than by the build itself, {@code false} otherwise.
+     * @return The aggregated list of remote repositories, never {@code null}.
+     * @since 1.9.28
+     * @see RepositorySystemSession#getMirrorSelector()
+     * @see RepositorySystemSession#getProxySelector()
+     * @see RepositorySystemSession#getAuthenticationSelector()
+     */
+    default List<RemoteRepository> aggregateRepositories(
+            RepositorySystemSession session,
+            List<RemoteRepository> dominantRepositories,
+            List<RemoteRepository> recessiveRepositories,
+            boolean recessiveIsRaw,
+            boolean recessiveIsFromDescriptor) {
+        return aggregateRepositories(session, dominantRepositories, recessiveRepositories, recessiveIsRaw);
+    }
+
+    /**
      * Gets the effective repository policy for the specified remote repository by merging the applicable
      * snapshot/release policy of the repository with global settings from the supplied session.
      *

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposer.java
@@ -25,6 +25,8 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.metadata.Metadata;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validateArtifactComponents;
+import static org.eclipse.aether.util.PathUtils.validateMetadataComponents;
 
 /**
  * Default implementation of {@link LocalPathComposer}.
@@ -37,6 +39,7 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
     @Override
     public String getPathForArtifact(Artifact artifact, boolean local) {
         requireNonNull(artifact);
+        validateArtifactComponents(artifact);
 
         StringBuilder path = new StringBuilder(128);
 
@@ -61,13 +64,14 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
             path.append('.').append(artifact.getExtension());
         }
 
-        return path.toString();
+        return requireContainedPath(path.toString());
     }
 
     @Override
     public String getPathForMetadata(Metadata metadata, String repositoryKey) {
         requireNonNull(metadata);
         requireNonNull(repositoryKey);
+        validateMetadataComponents(metadata);
 
         StringBuilder path = new StringBuilder(128);
 
@@ -85,7 +89,26 @@ public final class DefaultLocalPathComposer implements LocalPathComposer {
 
         path.append(insertRepositoryKey(metadata.getType(), repositoryKey));
 
-        return path.toString();
+        return requireContainedPath(path.toString());
+    }
+
+    /**
+     * Defense in depth: the composed path must be relative and must not contain parent-reference or empty
+     * segments, so that resolving it against the local repository base directory always yields a path within
+     * it. The coordinate validation performed on entry should already guarantee this; this is a last-resort
+     * check on the composed result.
+     */
+    private static String requireContainedPath(String path) {
+        if (path.startsWith("/")
+                || path.contains("//")
+                || path.equals("..")
+                || path.startsWith("../")
+                || path.endsWith("/..")
+                || path.contains("/../")) {
+            throw new IllegalArgumentException(
+                    "Invalid coordinates: composed local repository path is not a valid relative path: " + path);
+        }
+        return path;
     }
 
     private String insertRepositoryKey(String metadataType, String repositoryKey) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -41,6 +41,7 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
 import org.eclipse.aether.spi.locator.Service;
 import org.eclipse.aether.spi.locator.ServiceLocator;
+import org.eclipse.aether.util.ConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,26 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRemoteRepositoryManager.class);
 
+    /**
+     * Flag indicating whether session authentication (i.e. credentials configured in {@code settings.xml}) may be
+     * applied, matched by plain repository ID, to repositories declared by remote artifact descriptors (POMs) that
+     * are merged into the effective repository list during dependency collection. When disabled (the default),
+     * session authentication is only applied to such a repository when an operator-defined mirror has been selected
+     * for it; if credentials would have matched a descriptor-declared repository, a warning naming the repository ID
+     * and URL is logged instead. Repositories supplied by the build itself are unaffected and keep receiving
+     * matching credentials. Enabling this restores the legacy behavior of applying matching session authentication
+     * to descriptor declared repositories regardless of their provenance.
+     *
+     * @since 1.9.28
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_AUTH_TO_DESCRIPTOR_REPOSITORIES}
+     */
+    public static final String CONFIG_PROP_AUTH_TO_DESCRIPTOR_REPOSITORIES =
+            "aether.remoteRepositoryManager.authToDescriptorRepositories";
+
+    public static final boolean DEFAULT_AUTH_TO_DESCRIPTOR_REPOSITORIES = false;
+
     private UpdatePolicyAnalyzer updatePolicyAnalyzer;
 
     private ChecksumPolicyProvider checksumPolicyProvider;
@@ -115,6 +136,16 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
             List<RemoteRepository> dominantRepositories,
             List<RemoteRepository> recessiveRepositories,
             boolean recessiveIsRaw) {
+        return aggregateRepositories(session, dominantRepositories, recessiveRepositories, recessiveIsRaw, false);
+    }
+
+    @Override
+    public List<RemoteRepository> aggregateRepositories(
+            RepositorySystemSession session,
+            List<RemoteRepository> dominantRepositories,
+            List<RemoteRepository> recessiveRepositories,
+            boolean recessiveIsRaw,
+            boolean recessiveIsFromDescriptor) {
         requireNonNull(session, "session cannot be null");
         requireNonNull(dominantRepositories, "dominantRepositories cannot be null");
         requireNonNull(recessiveRepositories, "recessiveRepositories cannot be null");
@@ -126,11 +157,15 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
         AuthenticationSelector authSelector = session.getAuthenticationSelector();
         ProxySelector proxySelector = session.getProxySelector();
 
+        boolean authToDescriptorRepositories = ConfigUtils.getBoolean(
+                session, DEFAULT_AUTH_TO_DESCRIPTOR_REPOSITORIES, CONFIG_PROP_AUTH_TO_DESCRIPTOR_REPOSITORIES);
+
         List<RemoteRepository> result = new ArrayList<>(dominantRepositories);
 
         next:
         for (RemoteRepository recessiveRepository : recessiveRepositories) {
             RemoteRepository repository = recessiveRepository;
+            boolean mirrored = false;
 
             if (recessiveIsRaw) {
                 RemoteRepository mirrorRepository = mirrorSelector.getMirror(recessiveRepository);
@@ -138,6 +173,7 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
                 if (mirrorRepository != null) {
                     logMirror(session, recessiveRepository, mirrorRepository);
                     repository = mirrorRepository;
+                    mirrored = true;
                 }
             }
 
@@ -163,8 +199,18 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
                 RemoteRepository.Builder builder = null;
                 Authentication auth = authSelector.getAuthentication(repository);
                 if (auth != null) {
-                    builder = new RemoteRepository.Builder(repository);
-                    builder.setAuthentication(auth);
+                    if (!recessiveIsFromDescriptor || mirrored || authToDescriptorRepositories) {
+                        builder = new RemoteRepository.Builder(repository);
+                        builder.setAuthentication(auth);
+                    } else if (auth != repository.getAuthentication()) {
+                        LOGGER.warn(
+                                "Not applying session authentication to repository {} ({}) declared by a remote"
+                                        + " artifact descriptor; set {}=true to restore the legacy behavior of"
+                                        + " matching credentials to such repositories by repository ID",
+                                repository.getId(),
+                                repository.getUrl(),
+                                CONFIG_PROP_AUTH_TO_DESCRIPTOR_REPOSITORIES);
+                    }
                 }
                 Proxy proxy = proxySelector.getProxy(repository);
                 if (proxy != null) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory.java
@@ -44,6 +44,8 @@ import org.eclipse.aether.transfer.NoRepositoryLayoutException;
 import org.eclipse.aether.util.ConfigUtils;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.util.PathUtils.validateArtifactComponents;
+import static org.eclipse.aether.util.PathUtils.validateMetadataComponents;
 
 /**
  * Provides a Maven-2 repository layout for repositories with content type {@code "default"}.
@@ -171,6 +173,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Artifact artifact, boolean upload) {
+            validateArtifactComponents(artifact);
+
             StringBuilder path = new StringBuilder(128);
 
             path.append(artifact.getGroupId().replace('.', '/')).append('/');
@@ -194,6 +198,8 @@ public final class Maven2RepositoryLayoutFactory implements RepositoryLayoutFact
 
         @Override
         public URI getLocation(Metadata metadata, boolean upload) {
+            validateMetadataComponents(metadata);
+
             StringBuilder path = new StringBuilder(128);
 
             if (metadata.getGroupId().length() > 0) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate.java
@@ -187,7 +187,7 @@ public abstract class DependencyCollectorDelegate implements DependencyCollector
 
             if (!session.isIgnoreArtifactDescriptorRepositories()) {
                 repositories = remoteRepositoryManager.aggregateRepositories(
-                        session, repositories, descriptorResult.getRepositories(), true);
+                        session, repositories, descriptorResult.getRepositories(), true, true);
             }
             dependencies = mergeDeps(dependencies, descriptorResult.getDependencies());
             managedDependencies = mergeDeps(managedDependencies, descriptorResult.getManagedDependencies());

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -345,7 +345,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate implement
         final List<RemoteRepository> childRepos = args.ignoreRepos
                 ? parentContext.repositories
                 : remoteRepositoryManager.aggregateRepositories(
-                        args.session, parentContext.repositories, descriptorResult.getRepositories(), true);
+                        args.session, parentContext.repositories, descriptorResult.getRepositories(), true, true);
 
         Object key = args.pool.toKey(
                 parentContext.dependency.getArtifact(),

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
@@ -329,7 +329,7 @@ public class DfDependencyCollector extends DependencyCollectorDelegate implement
         final List<RemoteRepository> childRepos = args.ignoreRepos
                 ? repositories
                 : remoteRepositoryManager.aggregateRepositories(
-                        args.session, repositories, descriptorResult.getRepositories(), true);
+                        args.session, repositories, descriptorResult.getRepositories(), true, true);
 
         Object key =
                 args.pool.toKey(d.getArtifact(), childRepos, childSelector, childManager, childTraverser, childFilter);

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/BasedirNameMapper.java
@@ -61,10 +61,26 @@ public class BasedirNameMapper implements NameMapper {
             final Path basedir = DirectoryUtils.resolveDirectory(session, ".locks", CONFIG_PROP_LOCKS_DIR, false);
 
             return delegate.nameLocks(session, artifacts, metadatas).stream()
-                    .map(name -> basedir.resolve(name).toAbsolutePath().toString())
+                    .map(name -> resolveContained(basedir, name))
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Resolves the delegate-provided lock name against the locks base directory, rejecting names that are
+     * not contained under it, as the file lock factory creates (and deletes on close) lock files at the
+     * resolved path.
+     *
+     * @since 1.9.28
+     */
+    private static String resolveContained(Path basedir, String name) {
+        Path resolved = basedir.resolve(name).toAbsolutePath();
+        if (!resolved.normalize().startsWith(basedir.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException(
+                    "Lock name '" + name + "' is not contained in the locks base directory " + basedir);
+        }
+        return resolved.toString();
     }
 }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapper.java
@@ -39,27 +39,27 @@ public class GAECVNameMapper extends GAVNameMapper {
 
     @Override
     protected String getArtifactName(Artifact artifact) {
-        if (artifact.getClassifier().isEmpty()) {
+        if (fieldToSegment(artifact.getClassifier()).isEmpty()) {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         } else {
             return artifactPrefix
-                    + artifact.getGroupId()
+                    + fieldToSegment(artifact.getGroupId())
                     + fieldSeparator
-                    + artifact.getArtifactId()
+                    + fieldToSegment(artifact.getArtifactId())
                     + fieldSeparator
-                    + artifact.getExtension()
+                    + fieldToSegment(artifact.getExtension())
                     + fieldSeparator
-                    + artifact.getClassifier()
+                    + fieldToSegment(artifact.getClassifier())
                     + fieldSeparator
-                    + artifact.getBaseVersion()
+                    + fieldToSegment(artifact.getBaseVersion())
                     + artifactSuffix;
         }
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper.java
@@ -91,13 +91,26 @@ public class GAVNameMapper implements NameMapper {
         return keys;
     }
 
+    /**
+     * Returns the given coordinate field in a form that is safe to use as (part of) a file name: when this
+     * mapper is {@link #isFileSystemFriendly()}, characters that act as path separators or are otherwise
+     * illegal in file names are replaced via {@link PathUtils#stringToPathSegment(String)}. File-system
+     * friendly names are resolved against the locks base directory by {@link BasedirNameMapper}, so every
+     * field must be a valid path segment.
+     *
+     * @since 1.9.28
+     */
+    protected String fieldToSegment(String field) {
+        return fileSystemFriendly ? PathUtils.stringToPathSegment(field) : field;
+    }
+
     protected String getArtifactName(Artifact artifact) {
         return artifactPrefix
-                + artifact.getGroupId()
+                + fieldToSegment(artifact.getGroupId())
                 + fieldSeparator
-                + artifact.getArtifactId()
+                + fieldToSegment(artifact.getArtifactId())
                 + fieldSeparator
-                + artifact.getBaseVersion()
+                + fieldToSegment(artifact.getBaseVersion())
                 + artifactSuffix;
     }
 
@@ -106,11 +119,11 @@ public class GAVNameMapper implements NameMapper {
     protected String getMetadataName(Metadata metadata) {
         String name = metadataPrefix;
         if (!metadata.getGroupId().isEmpty()) {
-            name += metadata.getGroupId();
+            name += fieldToSegment(metadata.getGroupId());
             if (!metadata.getArtifactId().isEmpty()) {
-                name += fieldSeparator + metadata.getArtifactId();
+                name += fieldSeparator + fieldToSegment(metadata.getArtifactId());
                 if (!metadata.getVersion().isEmpty()) {
-                    name += fieldSeparator + metadata.getVersion();
+                    name += fieldSeparator + fieldToSegment(metadata.getVersion());
                 }
             }
             if (!MAVEN_METADATA.equals(metadata.getType())) {

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
@@ -18,25 +18,6 @@
  */
 package org.eclipse.aether.internal.impl;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.DefaultMetadata;

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultLocalPathComposerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DefaultLocalPathComposerTest {
+    private final DefaultLocalPathComposer composer = new DefaultLocalPathComposer();
+
+    @Test
+    public void testGetPathForArtifactAcceptsNormalCoordinates() {
+        String path =
+                composer.getPathForArtifact(new DefaultArtifact("org.apache.maven", "commons-io", "jar", "1.0"), true);
+        assertEquals("org/apache/maven/commons-io/1.0/commons-io-1.0.jar", path);
+    }
+
+    @Test
+    public void testGetPathForArtifactRejectsGroupIdWithEmptyDotSegments() {
+        assertRejected(new DefaultArtifact(".leading", "a-id", "jar", "1.0"));
+        assertRejected(new DefaultArtifact("..leading", "a-id", "jar", "1.0"));
+        assertRejected(new DefaultArtifact("g..id", "a-id", "jar", "1.0"));
+        assertRejected(new DefaultArtifact("g.id.", "a-id", "jar", "1.0"));
+    }
+
+    @Test
+    public void testGetPathForArtifactRejectsColon() {
+        assertRejected(new DefaultArtifact("g:id", "a-id", "jar", "1.0"));
+        assertRejected(new DefaultArtifact("g.id", "a-id", "jar", "1.0:1"));
+    }
+
+    @Test
+    public void testGetPathForMetadataAcceptsNormalCoordinates() {
+        Metadata metadata =
+                new DefaultMetadata("g.id", "a-id", "1.0.0-SNAPSHOT", "maven-metadata.xml", Metadata.Nature.SNAPSHOT);
+        String path = composer.getPathForMetadata(metadata, "central");
+        assertEquals("g/id/a-id/1.0.0-SNAPSHOT/maven-metadata-central.xml", path);
+    }
+
+    @Test
+    public void testGetPathForMetadataRejectsGroupIdWithEmptyDotSegments() {
+        Metadata metadata =
+                new DefaultMetadata(".leading", "a-id", "1.0", "maven-metadata.xml", Metadata.Nature.RELEASE);
+        try {
+            composer.getPathForMetadata(metadata, "central");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    private void assertRejected(Artifact artifact) {
+        try {
+            composer.getPathForArtifact(artifact, true);
+            fail("expected IllegalArgumentException for " + artifact);
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManagerTest.java
@@ -26,6 +26,8 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.UpdatePolicyAnalyzer;
 import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.AuthenticationSelector;
 import org.eclipse.aether.repository.MirrorSelector;
 import org.eclipse.aether.repository.Proxy;
 import org.eclipse.aether.repository.ProxySelector;
@@ -38,6 +40,7 @@ import org.junit.Test;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -271,5 +274,94 @@ public class DefaultRemoteRepositoryManagerTest {
             requireNonNull(session, "session cannot be null");
             return false;
         }
+    }
+
+    @Test
+    public void testDescriptorRepositoryAuthenticationNotAppliedByDefault() {
+        RemoteRepository repo =
+                newRepo("a", "http://example.org/", true, "", "").build();
+        final Authentication auth = new org.eclipse.aether.util.repository.AuthenticationBuilder()
+                .addUsername("test")
+                .build();
+        session.setAuthenticationSelector(new AuthenticationSelector() {
+            public Authentication getAuthentication(RemoteRepository repository) {
+                return "a".equals(repository.getId()) ? auth : null;
+            }
+        });
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Collections.emptyList(), Arrays.asList(repo), true, true);
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getAuthentication());
+    }
+
+    @Test
+    public void testDescriptorRepositoryAuthenticationAppliedWhenEnabled() {
+        RemoteRepository repo =
+                newRepo("a", "http://example.org/", true, "", "").build();
+        final Authentication auth = new org.eclipse.aether.util.repository.AuthenticationBuilder()
+                .addUsername("test")
+                .build();
+        session.setAuthenticationSelector(new AuthenticationSelector() {
+            public Authentication getAuthentication(RemoteRepository repository) {
+                return "a".equals(repository.getId()) ? auth : null;
+            }
+        });
+        session.setConfigProperty(
+                DefaultRemoteRepositoryManager.CONFIG_PROP_AUTH_TO_DESCRIPTOR_REPOSITORIES, Boolean.TRUE);
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Collections.emptyList(), Arrays.asList(repo), true, true);
+
+        assertEquals(1, result.size());
+        assertSame(auth, result.get(0).getAuthentication());
+    }
+
+    @Test
+    public void testDescriptorRepositoryAuthenticationAppliedToSelectedMirror() {
+        RemoteRepository repo =
+                newRepo("a", "http://example.org/", true, "", "").build();
+        final RemoteRepository mirror =
+                newRepo("m", "http://mirror.example.org/", true, "", "").build();
+        final Authentication auth = new org.eclipse.aether.util.repository.AuthenticationBuilder()
+                .addUsername("test")
+                .build();
+        session.setAuthenticationSelector(new AuthenticationSelector() {
+            public Authentication getAuthentication(RemoteRepository repository) {
+                return "m".equals(repository.getId()) ? auth : null;
+            }
+        });
+        session.setMirrorSelector(new MirrorSelector() {
+            public RemoteRepository getMirror(RemoteRepository repository) {
+                return mirror;
+            }
+        });
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Collections.emptyList(), Arrays.asList(repo), true, true);
+
+        assertEquals(1, result.size());
+        assertSame(auth, result.get(0).getAuthentication());
+    }
+
+    @Test
+    public void testResolutionRepositoryAuthenticationStillApplied() {
+        RemoteRepository repo =
+                newRepo("a", "http://example.org/", true, "", "").build();
+        final Authentication auth = new org.eclipse.aether.util.repository.AuthenticationBuilder()
+                .addUsername("test")
+                .build();
+        session.setAuthenticationSelector(new AuthenticationSelector() {
+            public Authentication getAuthentication(RemoteRepository repository) {
+                return "a".equals(repository.getId()) ? auth : null;
+            }
+        });
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Collections.emptyList(), Arrays.asList(repo), true);
+
+        assertEquals(1, result.size());
+        assertSame(auth, result.get(0).getAuthentication());
     }
 }

--- a/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
+++ b/maven-resolver-transport-file/src/main/java/org/eclipse/aether/transport/file/FileTransporter.java
@@ -20,6 +20,8 @@ package org.eclipse.aether.transport.file;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.transport.AbstractTransporter;
@@ -85,14 +87,27 @@ final class FileTransporter extends AbstractTransporter {
 
     private File getFile(TransportTask task, boolean required) throws Exception {
         String path = task.getLocation().getPath();
-        if (path.contains("../")) {
+        if (path == null) {
+            throw new IllegalArgumentException("illegal resource path: null");
+        }
+        Path relative = Paths.get(path);
+        if (relative.isAbsolute()) {
             throw new IllegalArgumentException("illegal resource path: " + path);
         }
-        File file = new File(basedir, path);
-        if (required && !file.exists()) {
-            throw new ResourceNotFoundException("Could not locate " + file);
+        for (Path segment : relative) {
+            if ("..".equals(segment.toString())) {
+                throw new IllegalArgumentException("illegal resource path: " + path);
+            }
         }
-        return file;
+        Path file = basedir.toPath().resolve(relative).normalize();
+        if (!file.startsWith(basedir.toPath().normalize())) {
+            throw new IllegalArgumentException("illegal resource path: " + path);
+        }
+        File result = file.toFile();
+        if (required && !result.exists()) {
+            throw new ResourceNotFoundException("Could not locate " + result);
+        }
+        return result;
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/PathUtils.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -70,6 +73,80 @@ public final class PathUtils {
                 pos = result.indexOf(illegal);
             }
         }
-        return result.toString();
+        // Strings consisting solely of dots contain no illegal character, yet "." and ".." carry path
+        // meaning when used as a path segment. Map them to explicit tokens, mirroring the character
+        // replacements above.
+        String segment = result.toString();
+        if (".".equals(segment)) {
+            return "-DOT-";
+        } else if ("..".equals(segment)) {
+            return "-DOTDOT-";
+        }
+        return segment;
+    }
+
+    /**
+     * Validates that a coordinate component may be used as a single repository path segment: it must not equal
+     * {@code ".."} and must not contain path separator characters or ':'.
+     *
+     * @since 1.9.28
+     */
+    public static void validatePathComponent(String value, String label) {
+        if (value != null && value.length() > 0) {
+            // Important: "equals .." and not "contains ..", as a component containing more dots
+            // is a valid version string (e.g. "1..").
+            // Colon is not a valid character in a coordinate component.
+            if (value.equals("..") || value.contains("/") || value.contains("\\") || value.contains(":")) {
+                throw new IllegalArgumentException(
+                        "Invalid " + label + ": must not contain '..', '/', '\\' or ':': " + value);
+            }
+        }
+    }
+
+    /**
+     * Validates a coordinate component that is expanded into multiple path segments by replacing each dot with a
+     * path separator, like the group ID is. Beside the checks done by {@link #validatePathComponent(String, String)},
+     * it rejects values containing empty dot-separated segments (leading, trailing or consecutive dots), as the
+     * expansion of such values does not compose a valid relative path.
+     *
+     * @since 1.9.28
+     */
+    public static void validateDotSeparatedPathComponent(String value, String label) {
+        validatePathComponent(value, label);
+        if (value != null && value.length() > 0) {
+            for (String segment : value.split("\\.", -1)) {
+                if (segment.isEmpty()) {
+                    throw new IllegalArgumentException("Invalid " + label
+                            + ": must not contain empty segments (leading, trailing or consecutive dots): " + value);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates all coordinate components of an {@link Artifact}.
+     *
+     * @see #validatePathComponent(String, String)
+     * @since 1.9.28
+     */
+    public static void validateArtifactComponents(Artifact artifact) {
+        validateDotSeparatedPathComponent(artifact.getGroupId(), "groupId");
+        validatePathComponent(artifact.getArtifactId(), "artifactId");
+        validatePathComponent(artifact.getVersion(), "version");
+        validatePathComponent(artifact.getBaseVersion(), "baseVersion");
+        validatePathComponent(artifact.getClassifier(), "classifier");
+        validatePathComponent(artifact.getExtension(), "extension");
+    }
+
+    /**
+     * Validates all coordinate components of a {@link Metadata}.
+     *
+     * @see #validatePathComponent(String, String)
+     * @since 1.9.28
+     */
+    public static void validateMetadataComponents(Metadata metadata) {
+        validateDotSeparatedPathComponent(metadata.getGroupId(), "groupId");
+        validatePathComponent(metadata.getArtifactId(), "artifactId");
+        validatePathComponent(metadata.getVersion(), "version");
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
@@ -18,25 +18,6 @@
  */
 package org.eclipse.aether.util;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/PathUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PathUtilsTest {
+    @Test
+    public void testStringToPathSegmentDotTokens() {
+        // "." and ".." contain no illegal character, but carry path meaning when used as a path segment
+        assertEquals("-DOT-", PathUtils.stringToPathSegment("."));
+        assertEquals("-DOTDOT-", PathUtils.stringToPathSegment(".."));
+        // dotted names and longer dot runs are inert as single path segments and stay untouched
+        assertEquals("...", PathUtils.stringToPathSegment("..."));
+        assertEquals("my.repo", PathUtils.stringToPathSegment("my.repo"));
+        assertEquals("repo..id", PathUtils.stringToPathSegment("repo..id"));
+        assertEquals("..id", PathUtils.stringToPathSegment("..id"));
+    }
+
+    @Test
+    public void testValidatePathComponentRejectsSeparatorsAndColon() {
+        assertRejected("..", "version");
+        assertRejected("1.0/../etc", "version");
+        assertRejected("1.0\\..\\etc", "version");
+        assertRejected("a:b", "groupId");
+    }
+
+    @Test
+    public void testValidatePathComponentAcceptsNormalValues() {
+        PathUtils.validatePathComponent(null, "version");
+        PathUtils.validatePathComponent("", "version");
+        PathUtils.validatePathComponent("commons-io", "artifactId");
+        PathUtils.validatePathComponent("1.0-SNAPSHOT", "version");
+        // version "1.." is a valid version string, and is not dot-expanded into path segments
+        PathUtils.validatePathComponent("1..", "version");
+    }
+
+    @Test
+    public void testValidateDotSeparatedPathComponentRejectsEmptyDotSegments() {
+        // every dot-separated segment must be non-empty
+        assertDotSeparatedRejected(".a.b");
+        assertDotSeparatedRejected("..a");
+        assertDotSeparatedRejected("com..example");
+        assertDotSeparatedRejected("com.example.");
+        assertDotSeparatedRejected(".");
+        // checks of validatePathComponent still apply
+        assertDotSeparatedRejected("a:b");
+        assertDotSeparatedRejected("a/b");
+    }
+
+    @Test
+    public void testValidateDotSeparatedPathComponentAcceptsNormalValues() {
+        PathUtils.validateDotSeparatedPathComponent(null, "groupId");
+        PathUtils.validateDotSeparatedPathComponent("", "groupId");
+        PathUtils.validateDotSeparatedPathComponent("org.apache.maven", "groupId");
+        PathUtils.validateDotSeparatedPathComponent("commons-io", "groupId");
+    }
+
+    private static void assertRejected(String value, String label) {
+        try {
+            PathUtils.validatePathComponent(value, label);
+            fail("expected IllegalArgumentException for " + value);
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    private static void assertDotSeparatedRejected(String value) {
+        try {
+            PathUtils.validateDotSeparatedPathComponent(value, "groupId");
+            fail("expected IllegalArgumentException for " + value);
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+}


### PR DESCRIPTION
Ports three changes from master to the `maven-resolver-1.9.x` maintenance line so the two lines
behave consistently:

- coordinate component validation in the Maven 2 layout and local path composition (#2087),
- lock names composed one segment per coordinate field, with the resolved lock path required to stay
  under the locks base directory (#2091),
- the repository-provenance overload on `RemoteRepositoryManager`, defaulting to the existing
  behaviour (#2090).

`PathUtils` does not exist on this line, so it is added here along with its tests. The rest follows
the master changes, adapted to the 1.9.x API.

Please review the three master pull requests first; this one is mechanical once those are settled.
