### PR TITLE
Validate the repository key used in checksum summary file names

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSource.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSource.java
@@ -49,6 +49,7 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 import org.eclipse.aether.spi.io.PathProcessor;
 import org.eclipse.aether.spi.remoterepo.RepositoryKeyFunctionFactory;
 import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -241,6 +242,9 @@ public final class SummaryFileTrustedChecksumsSource extends FileTrustedChecksum
     private Path summaryFile(Path basedir, boolean originAware, String safeRepositoryId, String checksumExtension) {
         String fileName = CHECKSUMS_FILE_PREFIX;
         if (originAware) {
+            // defense in depth: the repository key is spliced into the summary file name,
+            // so it must be a safe path segment
+            PathUtils.validatePathComponent(safeRepositoryId, "repository key");
             fileName += "-" + safeRepositoryId;
         }
         return basedir.resolve(fileName + "." + checksumExtension);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSourceTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.RepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
@@ -31,8 +32,11 @@ import org.eclipse.aether.internal.impl.DefaultRepositorySystemLifecycle;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryKeyFunction;
 import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
 import org.eclipse.aether.spi.io.PathProcessorSupport;
+import org.eclipse.aether.spi.remoterepo.RepositoryKeyFunctionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +44,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SummaryFileTrustedChecksumsSourceTest extends FileTrustedChecksumsSourceTestSupport {
     @Override
@@ -95,5 +101,45 @@ public class SummaryFileTrustedChecksumsSourceTest extends FileTrustedChecksumsS
                         "000  org/foo/bar/1.2.3/bar-1.2.3.jar",
                         "222  org/zzzz/art/5.6.7/art-5.6.7.jar"),
                 Files.readAllLines(work.resolve(".checksums/checksums-local.sha1")));
+    }
+
+    @Test
+    void unsafeRepositoryKeyIsRejected(@TempDir final Path work) throws NoLocalRepositoryManagerException {
+        // a RepositoryKeyFunctionFactory implementation is not required to sanitize the key it produces, so the
+        // summary file name composition must validate it itself before splicing it into the file name
+        RepositoryKeyFunctionFactory unsafeKeyFunctionFactory = new RepositoryKeyFunctionFactory() {
+            @Override
+            public RepositoryKeyFunction systemRepositoryKeyFunction(RepositorySystemSession session) {
+                return (repository, context) -> repository.getId();
+            }
+
+            @Override
+            public RepositoryKeyFunction repositoryKeyFunction(
+                    Class<?> owner, RepositorySystemSession session, String defaultValue, String configurationKey) {
+                return (repository, context) -> repository.getId();
+            }
+        };
+
+        final RepositorySystemLifecycle lifecycle = new DefaultRepositorySystemLifecycle();
+        final FileTrustedChecksumsSourceSupport src = new SummaryFileTrustedChecksumsSource(
+                unsafeKeyFunctionFactory, new DefaultLocalPathComposer(), lifecycle, new PathProcessorSupport());
+        final DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> false);
+        session.setConfigProperty("aether.trustedChecksumsSource.summaryFile", Boolean.TRUE.toString());
+        final LocalRepository repository = new LocalRepository(work.toFile(), "simple");
+        session.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory().newInstance(session, repository));
+
+        final TrustedChecksumsSource.Writer writer = src.getTrustedArtifactChecksumsWriter(session);
+        assertNotNull(writer);
+
+        RemoteRepository unsafeRepository =
+                new RemoteRepository.Builder("..", "default", "https://repo.example.org/").build();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> writer.addTrustedArtifactChecksums(
+                        new DefaultArtifact("org.foo", "bar", "jar", "1.2.3"),
+                        unsafeRepository,
+                        singletonList(new Sha1ChecksumAlgorithmFactory()),
+                        singletonMap("SHA-1", "000")));
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapperTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/synccontext/named/GAECVNameMapperTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl.synccontext.named;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.named.NamedLockKey;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GAECVNameMapperTest extends NameMapperTestSupport {
+    NameMapper mapper = NameMappers.gaecvNameMapper(true);
+
+    @Test
+    void nullsAndEmptyInputs() {
+        Collection<NamedLockKey> names;
+
+        names = mapper.nameLocks(session, null, null);
+        assertTrue(names.isEmpty());
+
+        names = mapper.nameLocks(session, null, emptyList());
+        assertTrue(names.isEmpty());
+
+        names = mapper.nameLocks(session, emptyList(), null);
+        assertTrue(names.isEmpty());
+
+        names = mapper.nameLocks(session, emptyList(), emptyList());
+        assertTrue(names.isEmpty());
+    }
+
+    @Test
+    void singleArtifactWithoutClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("group:artifact:1.0");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        assertEquals(
+                "artifact~group~artifact~jar~1.0.lock", names.iterator().next().name());
+    }
+
+    @Test
+    void singleArtifactWithClassifier() {
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "classifier", "jar", "1.0");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        assertEquals(
+                "artifact~group~artifact~jar~classifier~1.0.lock",
+                names.iterator().next().name());
+    }
+
+    @Test
+    void singleMetadata() {
+        DefaultMetadata metadata =
+                new DefaultMetadata("group", "artifact", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        assertEquals("metadata~group~artifact.lock", names.iterator().next().name());
+    }
+
+    @Test
+    void pathSeparatorsInArtifactCoordinatesAreNeutralized() {
+        // wire-supplied coordinate fields must not be able to select a lock path outside the locks directory
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "jar", "1/../../../../home/user/x");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals(
+                "artifact~group~artifact~jar~1-SLASH-..-SLASH-..-SLASH-..-SLASH-..-SLASH-home-SLASH-user-SLASH-x.lock",
+                name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void pathSeparatorsInExtensionAreNeutralized() {
+        // extension is one of the coordinate fields GAECV adds on top of GAV, must be neutralized the same way
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "", "j/a\\r", "1.0");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals("artifact~group~artifact~j-SLASH-a-BACKSLASH-r~1.0.lock", name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void pathSeparatorsInClassifierAreNeutralized() {
+        // classifier is the other coordinate field GAECV adds on top of GAV, must be neutralized the same way
+        DefaultArtifact artifact = new DefaultArtifact("group", "artifact", "../../etc/passwd", "jar", "1.0");
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), null);
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals("artifact~group~artifact~jar~..-SLASH-..-SLASH-etc-SLASH-passwd~1.0.lock", name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void pathSeparatorsInMetadataCoordinatesAreNeutralized() {
+        DefaultMetadata metadata = new DefaultMetadata(
+                "group", "artifact", "1\\..\\..\\x", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, null, singletonList(metadata));
+        assertEquals(1, names.size());
+        String name = names.iterator().next().name();
+        assertEquals("metadata~group~artifact~1-BACKSLASH-..-BACKSLASH-..-BACKSLASH-x.lock", name);
+        assertFalse(name.contains("/"));
+        assertFalse(name.contains("\\"));
+    }
+
+    @Test
+    void oneAndOne() {
+        DefaultArtifact artifact = new DefaultArtifact("agroup:artifact:1.0");
+        DefaultMetadata metadata =
+                new DefaultMetadata("bgroup", "artifact", "maven-metadata.xml", Metadata.Nature.RELEASE_OR_SNAPSHOT);
+        Collection<NamedLockKey> names = mapper.nameLocks(session, singletonList(artifact), singletonList(metadata));
+
+        assertEquals(2, names.size());
+        Iterator<NamedLockKey> namesIterator = names.iterator();
+
+        // they are sorted as well
+        assertEquals(
+                "artifact~agroup~artifact~jar~1.0.lock", namesIterator.next().name());
+        assertEquals("metadata~bgroup~artifact.lock", namesIterator.next().name());
+    }
+}


### PR DESCRIPTION
Follow-up to the review notes on #2089 and #2091: `SummaryFileTrustedChecksumsSource` splices the repository key into the summary file name without the point-of-use validation the sparse source received, so this adds the same `PathUtils.validatePathComponent` guard. The built-in key functions already sanitize; the guard matters for custom `RepositoryKeyFunction` implementations, and the new test wires a non-sanitizing key function to exercise it. Also adds the `GAECVNameMapperTest` that was noted as missing.

Verified: `mvn -pl maven-resolver-impl -am test` → 575 tests, 0 failures.

*This change was created with AI assistance.*
