### PR TITLE
[MRESOLVER-1954] Add maven-resolver-transport-apache5 module backed by Apache HttpComponents 5.x

### DIFF
--- a/maven-resolver-transport-apache5/pom.xml
+++ b/maven-resolver-transport-apache5/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.resolver</groupId>
+    <artifactId>maven-resolver</artifactId>
+    <version>2.0.23-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-resolver-transport-apache5</artifactId>
+
+  <name>Maven Artifact Resolver Transport Apache 5</name>
+  <description>A transport implementation for repositories using http:// and https:// URLs based on Apache HTTP Client 4.5.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+      <exclusions>
+        <exclusion>
+          <!-- using jcl-over-slf4j instead -->
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- httpclient uses old codec -->
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.16</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.22.1</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${version.slf4j}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-test-http</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-resolver-transport-apache5/pom.xml
+++ b/maven-resolver-transport-apache5/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>maven-resolver-transport-apache5</artifactId>
 
   <name>Maven Artifact Resolver Transport Apache 5</name>
-  <description>A transport implementation for repositories using http:// and https:// URLs based on Apache HTTP Client 4.5.</description>
+  <description>A transport implementation for repositories using http:// and https:// URLs based on Apache HTTP Client 5.x.</description>
 
   <dependencies>
     <dependency>
@@ -45,26 +45,14 @@
       <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
-      <exclusions>
-        <exclusion>
-          <!-- using jcl-over-slf4j instead -->
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- httpclient uses old codec -->
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.4.2</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.16</version>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>5.3.3</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -75,12 +63,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>${version.slf4j}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/Apache5TransporterFactory.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/Apache5TransporterFactory.java
@@ -35,8 +35,8 @@ import static java.util.Objects.requireNonNull;
  * A transporter factory for repositories using the {@code http:} or {@code https:} protocol. The provided transporters
  * support uploads to WebDAV servers and resumable downloads.
  */
-@Named(ApacheTransporterFactory.NAME)
-public final class ApacheTransporterFactory implements HttpTransporterFactory {
+@Named(Apache5TransporterFactory.NAME)
+public final class Apache5TransporterFactory implements HttpTransporterFactory {
     public static final String NAME = "apache5";
 
     private float priority = 5.0f;
@@ -46,7 +46,7 @@ public final class ApacheTransporterFactory implements HttpTransporterFactory {
     private final PathProcessor pathProcessor;
 
     @Inject
-    public ApacheTransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
+    public Apache5TransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
         this.checksumExtractor = requireNonNull(checksumExtractor, "checksumExtractor");
         this.pathProcessor = requireNonNull(pathProcessor, "pathProcessor");
     }
@@ -62,7 +62,7 @@ public final class ApacheTransporterFactory implements HttpTransporterFactory {
      * @param priority The priority.
      * @return This component for chaining, never {@code null}.
      */
-    public ApacheTransporterFactory setPriority(float priority) {
+    public Apache5TransporterFactory setPriority(float priority) {
         this.priority = priority;
         return this;
     }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheRFC9457Reporter.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheRFC9457Reporter.java
@@ -21,16 +21,16 @@ package org.eclipse.aether.transport.apache5;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpRequest;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.hc.client5.http.HttpResponseException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
 import org.eclipse.aether.spi.connector.transport.http.HttpConstants;
 import org.eclipse.aether.spi.connector.transport.http.RFC9457.RFC9457Reporter;
 
-public class ApacheRFC9457Reporter extends RFC9457Reporter<CloseableHttpResponse, HttpResponseException, HttpRequest> {
+public class ApacheRFC9457Reporter extends RFC9457Reporter<ClassicHttpResponse, HttpResponseException, HttpRequest> {
     public static final ApacheRFC9457Reporter INSTANCE = new ApacheRFC9457Reporter();
 
     private ApacheRFC9457Reporter() {}
@@ -41,7 +41,7 @@ public class ApacheRFC9457Reporter extends RFC9457Reporter<CloseableHttpResponse
     }
 
     @Override
-    protected boolean isRFC9457Message(final CloseableHttpResponse response) {
+    protected boolean isRFC9457Message(final ClassicHttpResponse response) {
         Header[] headers = response.getHeaders(HttpHeaders.CONTENT_TYPE);
         if (headers.length > 0) {
             String contentType = headers[0].getValue();
@@ -51,13 +51,13 @@ public class ApacheRFC9457Reporter extends RFC9457Reporter<CloseableHttpResponse
     }
 
     @Override
-    protected int getStatusCode(final CloseableHttpResponse response) {
-        return response.getStatusLine().getStatusCode();
+    protected int getStatusCode(final ClassicHttpResponse response) {
+        return response.getCode();
     }
 
     @Override
-    protected String getReasonPhrase(final CloseableHttpResponse response) {
-        String reasonPhrase = response.getStatusLine().getReasonPhrase();
+    protected String getReasonPhrase(final ClassicHttpResponse response) {
+        String reasonPhrase = response.getReasonPhrase();
         if (reasonPhrase == null || reasonPhrase.isEmpty()) {
             return "";
         }
@@ -66,7 +66,7 @@ public class ApacheRFC9457Reporter extends RFC9457Reporter<CloseableHttpResponse
     }
 
     @Override
-    protected String getBody(final CloseableHttpResponse response) throws IOException {
+    protected String getBody(final ClassicHttpResponse response) throws IOException {
         HttpEntity entity = response.getEntity();
         if (entity == null) {
             return "";

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheRFC9457Reporter.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheRFC9457Reporter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.eclipse.aether.spi.connector.transport.http.HttpConstants;
+import org.eclipse.aether.spi.connector.transport.http.RFC9457.RFC9457Reporter;
+
+public class ApacheRFC9457Reporter extends RFC9457Reporter<CloseableHttpResponse, HttpResponseException, HttpRequest> {
+    public static final ApacheRFC9457Reporter INSTANCE = new ApacheRFC9457Reporter();
+
+    private ApacheRFC9457Reporter() {}
+
+    @Override
+    public void prepareRequest(HttpRequest request) {
+        request.addHeader(HttpConstants.ACCEPT, CONTENT_TYPE_PROBLEM_DETAILS_JSON_AND_ANY);
+    }
+
+    @Override
+    protected boolean isRFC9457Message(final CloseableHttpResponse response) {
+        Header[] headers = response.getHeaders(HttpHeaders.CONTENT_TYPE);
+        if (headers.length > 0) {
+            String contentType = headers[0].getValue();
+            return hasRFC9457ContentType(contentType);
+        }
+        return false;
+    }
+
+    @Override
+    protected int getStatusCode(final CloseableHttpResponse response) {
+        return response.getStatusLine().getStatusCode();
+    }
+
+    @Override
+    protected String getReasonPhrase(final CloseableHttpResponse response) {
+        String reasonPhrase = response.getStatusLine().getReasonPhrase();
+        if (reasonPhrase == null || reasonPhrase.isEmpty()) {
+            return "";
+        }
+        int statusCode = getStatusCode(response);
+        return reasonPhrase + " (" + statusCode + ")";
+    }
+
+    @Override
+    protected String getBody(final CloseableHttpResponse response) throws IOException {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            return "";
+        }
+        InputStream is = entity.getContent();
+        if (is == null) {
+            return "";
+        }
+        try (InputStream stream = is) {
+            return readBody(stream);
+        }
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
@@ -314,16 +314,18 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
             // moment an explicit planner is installed via setRoutePlanner(). Reproduce whichever planner the
             // builder would otherwise have chosen and only override determineLocalAddress(...), so configuring a
             // local bind address does not silently disable system-property/proxy routing.
-            if (useSystemProperties) {
-                builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()) {
+            // Same precedence as HttpClientBuilder.build(): an explicitly configured proxy wins over system
+            // properties, so a repository proxy from the settings is not dropped when both are present.
+            if (proxy != null) {
+                builder.setRoutePlanner(new DefaultProxyRoutePlanner(proxy) {
                     @Override
                     protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context)
                             throws HttpException {
                         return localAddress;
                     }
                 });
-            } else if (proxy != null) {
-                builder.setRoutePlanner(new DefaultProxyRoutePlanner(proxy) {
+            } else if (useSystemProperties) {
+                builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()) {
                     @Override
                     protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context)
                             throws HttpException {

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
@@ -25,71 +25,71 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 
-import org.apache.http.Header;
-import org.apache.http.HttpClientConnection;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.HttpException;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.auth.AuthScheme;
-import org.apache.http.auth.AuthSchemeProvider;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpRequestRetryHandler;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.ServiceUnavailableRetryStrategy;
-import org.apache.http.client.config.AuthSchemes;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.DateUtils;
-import org.apache.http.client.utils.URIUtils;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.config.SocketConfig;
-import org.apache.http.conn.ManagedHttpClientConnection;
-import org.apache.http.entity.AbstractHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.impl.NoConnectionReuseStrategy;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.auth.BasicSchemeFactory;
-import org.apache.http.impl.auth.DigestSchemeFactory;
-import org.apache.http.impl.auth.KerberosSchemeFactory;
-import org.apache.http.impl.auth.NTLMSchemeFactory;
-import org.apache.http.impl.auth.SPNegoSchemeFactory;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpCoreContext;
-import org.apache.http.protocol.HttpRequestExecutor;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.HttpResponseException;
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpHead;
+import org.apache.hc.client5.http.classic.methods.HttpOptions;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+import org.apache.hc.client5.http.impl.auth.BasicScheme;
+import org.apache.hc.client5.http.impl.auth.BasicSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.DigestSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.KerberosSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.NTLMSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
+import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
+import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.utils.DateUtils;
+import org.apache.hc.client5.http.utils.URIUtils;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.io.entity.AbstractHttpEntity;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.AuthenticationContext;
@@ -118,28 +118,24 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.aether.spi.connector.transport.http.HttpConstants.CONTENT_RANGE_PATTERN;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_NAME;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_MAX_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_USE_SYSTEM_PROPERTIES;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_INSECURE_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_MAX_REDIRECTS;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_USE_SYSTEM_PROPERTIES;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_DEFAULT;
-import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_STANDARD;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_NAME;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_MAX_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.CONFIG_PROP_USE_SYSTEM_PROPERTIES;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_INSECURE_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.DEFAULT_MAX_REDIRECTS;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.DEFAULT_USE_SYSTEM_PROPERTIES;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_DEFAULT;
+import static org.eclipse.aether.transport.apache5.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_STANDARD;
 
 /**
- * A transporter for HTTP/HTTPS.
+ * A transporter for HTTP/HTTPS based on Apache HttpClient 5.x.
  */
 final class ApacheTransporter extends AbstractTransporter implements HttpTransporter {
-    /**
-     * Custom context attribute name to store the SSL session in the HTTP context. This is populated by a custom request executor.
-     */
-    private static final String CONTEXT_ATTRIBUTE_NAME_SSL_SESSION = "ssl.session";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApacheTransporter.class);
 
@@ -171,6 +167,10 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
 
     private final boolean sendRfc9457Accept;
 
+    private final CredentialsProvider credentialsProvider;
+
+    private final RequestConfig requestConfig;
+
     private final AuthCache authCache;
 
     @SuppressWarnings("checkstyle:methodlength")
@@ -184,10 +184,11 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         this.pathProcessor = pathProcessor;
         try {
             this.baseUri = HttpTransporterUtils.getBaseUri(repository);
-            this.server = URIUtils.extractHost(baseUri);
-            if (server == null) {
+            HttpHost rawServer = URIUtils.extractHost(baseUri);
+            if (rawServer == null) {
                 throw new URISyntaxException(repository.getUrl(), "URL lacks host name");
             }
+            this.server = new HttpHost(rawServer.getSchemeName(), rawServer.getHostName(), effectivePort(rawServer));
         } catch (URISyntaxException e) {
             throw new NoTransporterException(repository, e.getMessage(), e);
         }
@@ -242,59 +243,49 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS);
         String userAgent = HttpTransporterUtils.getUserAgent(session, repository);
 
-        Charset credentialsCharset = HttpTransporterUtils.getHttpCredentialsEncoding(session, repository);
-        Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-                .register(AuthSchemes.BASIC, new BasicSchemeFactory(credentialsCharset))
-                .register(AuthSchemes.DIGEST, new DigestSchemeFactory(credentialsCharset))
-                .register(AuthSchemes.NTLM, new NTLMSchemeFactory())
-                .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory())
-                .register(AuthSchemes.KERBEROS, new KerberosSchemeFactory())
-                .build();
-        SocketConfig socketConfig =
-                // the time to establish connection (low level)
-                SocketConfig.custom().setSoTimeout(requestTimeout).build();
-        RequestConfig requestConfig = RequestConfig.custom()
-                .setMaxRedirects(maxRedirects)
-                .setRedirectsEnabled(followRedirects)
-                .setRelativeRedirectsAllowed(followRedirects)
-                // the time waiting for data; max time between two data packets
-                .setSocketTimeout(requestTimeout)
-                // the time to establish the connection (high level)
-                .setConnectTimeout(connectTimeout)
-                // the time to wait for a connection from the connection manager/pool
-                .setConnectionRequestTimeout(connectTimeout)
-                .setLocalAddress(HttpTransporterUtils.getHttpLocalAddress(session, repository)
-                        .orElse(null))
-                .setCookieSpec(CookieSpecs.STANDARD)
+        // NOTE: aether.transport.http.credentialEncoding has no effect with this (Apache HttpClient 5) transport.
+        // BasicSchemeFactory/DigestSchemeFactory in httpclient5 5.4.x never pass their configured charset on to the
+        // BasicScheme/DigestScheme they create (verified against the 5.4.2 bytecode: create() calls the no-arg
+        // constructor), so the scheme always negotiates its own charset (UTF-8 for Basic, absent a server-supplied
+        // "charset" auth-param) regardless of what is configured here. Kept for config-key compatibility only.
+        Lookup<AuthSchemeFactory> authSchemeRegistry = RegistryBuilder.<AuthSchemeFactory>create()
+                .register(StandardAuthScheme.BASIC, BasicSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.DIGEST, DigestSchemeFactory.INSTANCE)
+                .register(StandardAuthScheme.NTLM, new NTLMSchemeFactory())
+                .register(StandardAuthScheme.SPNEGO, SPNegoSchemeFactory.DEFAULT)
+                .register(StandardAuthScheme.KERBEROS, KerberosSchemeFactory.DEFAULT)
                 .build();
 
-        HttpRequestRetryHandler retryHandler;
-        if (HTTP_RETRY_HANDLER_NAME_STANDARD.equals(retryHandlerName)) {
-            retryHandler = new StandardHttpRequestRetryHandler(retryCount, retryHandlerRequestSentEnabled);
-        } else if (HTTP_RETRY_HANDLER_NAME_DEFAULT.equals(retryHandlerName)) {
-            retryHandler = new DefaultHttpRequestRetryHandler(retryCount, retryHandlerRequestSentEnabled);
-        } else {
-            throw new IllegalArgumentException(
-                    "Unsupported parameter " + CONFIG_PROP_HTTP_RETRY_HANDLER_NAME + " value: " + retryHandlerName);
-        }
-        ServiceUnavailableRetryStrategy serviceUnavailableRetryStrategy = new ResolverServiceUnavailableRetryStrategy(
+        this.requestConfig = RequestConfig.custom()
+                .setMaxRedirects(maxRedirects)
+                .setRedirectsEnabled(followRedirects)
+                .setResponseTimeout(Timeout.ofMilliseconds(requestTimeout))
+                .setConnectTimeout(Timeout.ofMilliseconds(connectTimeout))
+                .setConnectionRequestTimeout(Timeout.ofMilliseconds(connectTimeout))
+                .setExpectContinueEnabled(true)
+                .setCookieSpec(StandardCookieSpec.RELAXED)
+                .build();
+
+        HttpRequestRetryStrategy retryStrategy = new ResolverHttpRequestRetryStrategy(
                 retryCount,
                 retryInterval,
                 retryIntervalMax,
-                HttpTransporterUtils.getHttpServiceUnavailableCodes(session, repository));
+                HttpTransporterUtils.getHttpServiceUnavailableCodes(session, repository),
+                retryHandlerName,
+                retryHandlerRequestSentEnabled);
 
+        this.credentialsProvider = toCredentialsProvider(server, repoAuthContext, proxy, proxyAuthContext);
         HttpClientBuilder builder = HttpClientBuilder.create()
                 .setUserAgent(userAgent)
                 .setRedirectStrategy(new ResolverRedirectStrategy(followInsecureRedirects))
-                .setDefaultSocketConfig(socketConfig)
                 .setDefaultRequestConfig(requestConfig)
-                .setServiceUnavailableRetryStrategy(serviceUnavailableRetryStrategy)
-                .setRetryHandler(retryHandler)
+                .setRetryStrategy(retryStrategy)
                 .setDefaultAuthSchemeRegistry(authSchemeRegistry)
                 .setConnectionManager(state.getConnectionManager())
                 .setConnectionManagerShared(true)
-                .setDefaultCredentialsProvider(toCredentialsProvider(server, repoAuthContext, proxy, proxyAuthContext))
+                .setDefaultCredentialsProvider(credentialsProvider)
                 .setProxy(proxy);
+
         if (ConfigUtils.getBoolean(
                 session,
                 ApacheTransporterConfigurationKeys.DEFAULT_ORIGIN_SCOPED_HEADERS,
@@ -303,7 +294,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
             // Configured headers are per-repository data and frequently carry credentials; scope them to the
             // repository origin so a cross-origin redirect hop does not replay them to the redirect target.
             // Challenge-based credentials are host-scoped by the credentials provider already.
-            builder.addInterceptorLast(new OriginScopedHeadersInterceptor(server, this.headers.keySet()));
+            builder.addRequestInterceptorLast(new OriginScopedHeadersInterceptor(server, this.headers.keySet()));
         }
         final boolean useSystemProperties = ConfigUtils.getBoolean(
                 session,
@@ -317,23 +308,42 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
             builder.useSystemProperties();
         }
 
-        // capture SSL session for logging purposes (https://issues.apache.org/jira/browse/HTTPCLIENT-2164)
-        builder.setRequestExecutor(new HttpRequestExecutor() {
-
-            @Override
-            public HttpResponse execute(HttpRequest request, HttpClientConnection conn, HttpContext context)
-                    throws IOException, HttpException {
-                if (conn instanceof ManagedHttpClientConnection) {
-                    context.setAttribute(
-                            CONTEXT_ATTRIBUTE_NAME_SSL_SESSION, ((ManagedHttpClientConnection) conn).getSSLSession());
-                }
-                return super.execute(request, conn, context);
+        HttpTransporterUtils.getHttpLocalAddress(session, repository).ifPresent(localAddress -> {
+            // HttpClientBuilder.build() short-circuits ALL of its own route-planner selection - including the
+            // useSystemProperties()-driven SystemDefaultRoutePlanner branch that honors -Dhttp.proxyHost etc. - the
+            // moment an explicit planner is installed via setRoutePlanner(). Reproduce whichever planner the
+            // builder would otherwise have chosen and only override determineLocalAddress(...), so configuring a
+            // local bind address does not silently disable system-property/proxy routing.
+            if (useSystemProperties) {
+                builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()) {
+                    @Override
+                    protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context)
+                            throws HttpException {
+                        return localAddress;
+                    }
+                });
+            } else if (proxy != null) {
+                builder.setRoutePlanner(new DefaultProxyRoutePlanner(proxy) {
+                    @Override
+                    protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context)
+                            throws HttpException {
+                        return localAddress;
+                    }
+                });
+            } else {
+                builder.setRoutePlanner(new DefaultRoutePlanner(null) {
+                    @Override
+                    protected InetAddress determineLocalAddress(HttpHost firstHop, HttpContext context)
+                            throws HttpException {
+                        return localAddress;
+                    }
+                });
             }
         });
 
         HttpTransporterUtils.getHttpExpectContinue(session, repository).ifPresent(state::setExpectContinue);
         if (!HttpTransporterUtils.isHttpReuseConnections(session, repository)) {
-            builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+            builder.setConnectionReuseStrategy((request, response, context) -> false);
         }
 
         if (session.getCache() != null) {
@@ -343,9 +353,9 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                             Keys.of(
                                     getClass(),
                                     repository.getId() + "-" + StringDigestUtil.sha1(repository.toString())),
-                            ConcurrentAuthCache::new);
+                            BasicAuthCache::new);
         } else {
-            this.authCache = new ConcurrentAuthCache();
+            this.authCache = new BasicAuthCache();
         }
         this.client = builder.build();
     }
@@ -353,33 +363,27 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
     private static HttpHost toHost(Proxy proxy) {
         HttpHost host = null;
         if (proxy != null) {
-            // in Maven, the proxy.protocol is used for proxy matching against remote repository protocol; no TLS proxy
-            // support
-            // https://github.com/apache/maven/issues/2519
-            // https://github.com/apache/maven-resolver/issues/745
-            host = new HttpHost(proxy.getHost(), proxy.getPort());
+            // Proxy.getType() denotes the repository protocol this proxy was selected for, not the protocol used to
+            // talk to the proxy itself: the connection to a forward proxy is plain HTTP even when the repository
+            // behind it is HTTPS. Using proxy.getType() as the HttpHost scheme would make HttpClient attempt a TLS
+            // handshake with a plain-HTTP proxy whenever <proxy><protocol>https</protocol> is set in settings.xml.
+            // See apache/maven#2519 and maven-resolver#745.
+            HttpHost plainHost = new HttpHost(proxy.getHost(), proxy.getPort());
+            host = new HttpHost(plainHost.getHostName(), effectivePort(plainHost));
         }
         return host;
     }
 
     private static CredentialsProvider toCredentialsProvider(
             HttpHost server, AuthenticationContext serverAuthCtx, HttpHost proxy, AuthenticationContext proxyAuthCtx) {
-        CredentialsProvider provider =
-                toCredentialsProvider(server.getHostName(), effectivePort(server), serverAuthCtx);
+        CredentialsProvider provider = toCredentialsProvider(server, serverAuthCtx);
         if (proxy != null) {
-            CredentialsProvider p = toCredentialsProvider(proxy.getHostName(), proxy.getPort(), proxyAuthCtx);
+            CredentialsProvider p = toCredentialsProvider(proxy, proxyAuthCtx);
             provider = new DemuxCredentialsProvider(provider, p, proxy);
         }
         return provider;
     }
 
-    /**
-     * Determines the effective port of the given host: the explicit port if present, otherwise the default port
-     * implied by the scheme. Used to bind repository credentials to the repository's own origin (host and port)
-     * instead of {@link AuthScope#ANY_PORT}: with any-port scoping, a request landing on the same host but a
-     * different port - for example after an https-to-http downgrade redirect - would still be eligible to
-     * receive the credentials.
-     */
     static int effectivePort(HttpHost host) {
         if (host.getPort() >= 0) {
             return host.getPort();
@@ -387,13 +391,13 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         return "https".equalsIgnoreCase(host.getSchemeName()) ? 443 : 80;
     }
 
-    private static CredentialsProvider toCredentialsProvider(String host, int port, AuthenticationContext ctx) {
+    private static CredentialsProvider toCredentialsProvider(HttpHost host, AuthenticationContext ctx) {
         DeferredCredentialsProvider provider = new DeferredCredentialsProvider();
         if (ctx != null) {
-            AuthScope basicScope = new AuthScope(host, port);
+            AuthScope basicScope = new AuthScope(host, null, null);
             provider.setCredentials(basicScope, new DeferredCredentialsProvider.BasicFactory(ctx));
 
-            AuthScope ntlmScope = new AuthScope(host, port, AuthScope.ANY_REALM, "ntlm");
+            AuthScope ntlmScope = new AuthScope(host, null, "ntlm");
             provider.setCredentials(ntlmScope, new DeferredCredentialsProvider.NtlmFactory(ctx));
         }
         return provider;
@@ -458,7 +462,8 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         } catch (HttpResponseException e) {
             if (e.getStatusCode() == HttpStatus.SC_EXPECTATION_FAILED && request.containsHeader(HttpHeaders.EXPECT)) {
                 state.setExpectContinue(false);
-                request = commonHeaders(entity(new HttpPut(request.getURI()), entity));
+                HttpPut retryRequest = new HttpPut(request.getUri());
+                request = commonHeaders(entity(retryRequest, entity));
                 execute(request, null, task.getListener());
                 return;
             }
@@ -466,9 +471,18 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
     }
 
-    private void execute(HttpUriRequest request, EntityGetter getter, TransportListener listener) throws Exception {
+    private void execute(ClassicHttpRequest request, EntityGetter getter, TransportListener listener) throws Exception {
         try {
             SharingHttpContext context = new SharingHttpContext(state);
+            RequestConfig config = requestConfig;
+            Boolean expectContinue = state.isExpectContinue();
+            if (expectContinue != null && expectContinue != config.isExpectContinueEnabled()) {
+                config = RequestConfig.copy(config)
+                        .setExpectContinueEnabled(expectContinue)
+                        .build();
+            }
+            context.setRequestConfig(config);
+            context.setCredentialsProvider(credentialsProvider);
             context.setAuthCache(authCache);
             prepare(request, context);
             try (CloseableHttpResponse response = client.execute(server, request, context)) {
@@ -484,6 +498,10 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                     EntityUtils.consumeQuietly(response.getEntity());
                 }
             }
+            Object userToken = context.getUserToken();
+            if (userToken != null) {
+                state.setUserToken(userToken);
+            }
         } catch (IOException e) {
             if (e.getCause() instanceof TransferCancelledException) {
                 throw (Exception) e.getCause();
@@ -492,14 +510,27 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
     }
 
-    private void prepare(HttpUriRequest request, SharingHttpContext context) throws Exception {
+    private void prepare(ClassicHttpRequest request, SharingHttpContext context) throws Exception {
         final boolean put = HttpPut.METHOD_NAME.equalsIgnoreCase(request.getMethod());
         if (preemptiveAuth || (preemptivePutAuth && put)) {
-            context.getAuthCache().put(server, new BasicScheme());
+            Credentials credentials = credentialsProvider.getCredentials(new AuthScope(server, null, null), context);
+            if (credentials != null) {
+                BasicScheme basicScheme = new BasicScheme();
+                basicScheme.initPreemptive(credentials);
+                authCache.put(server, basicScheme);
+            }
+            if (proxy != null) {
+                Credentials proxyCreds = credentialsProvider.getCredentials(new AuthScope(proxy, null, null), context);
+                if (proxyCreds != null) {
+                    BasicScheme proxyScheme = new BasicScheme();
+                    proxyScheme.initPreemptive(proxyCreds);
+                    authCache.put(proxy, proxyScheme);
+                }
+            }
         }
         if (supportWebDav) {
             if (state.getWebDav() == null && (put || isPayloadPresent(request))) {
-                HttpOptions req = commonHeaders(new HttpOptions(request.getURI()));
+                HttpOptions req = commonHeaders(new HttpOptions(request.getUri()));
                 try (CloseableHttpResponse response = client.execute(server, req, context)) {
                     state.setWebDav(response.containsHeader(HttpHeaders.DAV));
                     EntityUtils.consumeQuietly(response.getEntity());
@@ -508,7 +539,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 }
             }
             if (put && Boolean.TRUE.equals(state.getWebDav())) {
-                mkdirs(request.getURI(), context);
+                mkdirs(request.getUri(), context);
             }
         }
     }
@@ -520,7 +551,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
             try (CloseableHttpResponse response =
                     client.execute(server, commonHeaders(new HttpMkCol(dirs.get(index))), context)) {
                 try {
-                    int status = response.getStatusLine().getStatusCode();
+                    int status = response.getCode();
                     if (status < 300 || status == HttpStatus.SC_METHOD_NOT_ALLOWED) {
                         break;
                     } else if (status == HttpStatus.SC_CONFLICT) {
@@ -550,20 +581,17 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
     }
 
-    private <T extends HttpEntityEnclosingRequest> T entity(T request, HttpEntity entity) {
+    private <T extends ClassicHttpRequest> T entity(T request, HttpEntity entity) {
         request.setEntity(entity);
         return request;
     }
 
-    private boolean isPayloadPresent(HttpUriRequest request) {
-        if (request instanceof HttpEntityEnclosingRequest) {
-            HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
-            return entity != null && entity.getContentLength() != 0;
-        }
-        return false;
+    private boolean isPayloadPresent(ClassicHttpRequest request) {
+        HttpEntity entity = request.getEntity();
+        return entity != null && entity.getContentLength() != 0;
     }
 
-    private <T extends HttpUriRequest> T commonHeaders(T request) {
+    private <T extends ClassicHttpRequest> T commonHeaders(T request) {
         request.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store");
         request.setHeader(HttpHeaders.PRAGMA, "no-cache");
 
@@ -588,19 +616,20 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         return request;
     }
 
-    private <T extends HttpUriRequest> void resume(T request, GetTask task) throws IOException {
+    private <T extends ClassicHttpRequest> void resume(T request, GetTask task) throws IOException {
         long resumeOffset = task.getResumeOffset();
         if (resumeOffset > 0L && task.getDataPath() != null) {
             long lastModified = Files.getLastModifiedTime(task.getDataPath()).toMillis();
             request.setHeader(HttpHeaders.RANGE, "bytes=" + resumeOffset + '-');
             request.setHeader(
-                    HttpHeaders.IF_UNMODIFIED_SINCE, DateUtils.formatDate(new Date(lastModified - 60L * 1000L)));
+                    HttpHeaders.IF_UNMODIFIED_SINCE,
+                    DateUtils.formatStandardDate(java.time.Instant.ofEpochMilli(lastModified - 60L * 1000L)));
             request.setHeader(HttpHeaders.ACCEPT_ENCODING, "identity");
         }
     }
 
-    private void handleStatus(CloseableHttpResponse response) throws Exception {
-        int status = response.getStatusLine().getStatusCode();
+    private void handleStatus(ClassicHttpResponse response) throws Exception {
+        int status = response.getCode();
         if (status >= 300) {
             ApacheRFC9457Reporter.INSTANCE.generateException(response, (statusCode, reasonPhrase) -> {
                 throw new HttpResponseException(statusCode, reasonPhrase + " (" + statusCode + ")");
@@ -628,10 +657,10 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
             this.task = task;
         }
 
-        public void handle(CloseableHttpResponse response) throws IOException, TransferCancelledException {
+        public void handle(ClassicHttpResponse response) throws IOException, TransferCancelledException {
             HttpEntity entity = response.getEntity();
             if (entity == null) {
-                entity = new ByteArrayEntity(new byte[0]);
+                entity = new ByteArrayEntity(new byte[0], ContentType.APPLICATION_OCTET_STREAM);
             }
 
             long offset = 0L, length = entity.getContentLength();
@@ -677,18 +706,18 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
                 Header lastModifiedHeader =
                         response.getFirstHeader(HttpHeaders.LAST_MODIFIED); // note: Wagon also does first not last
                 if (lastModifiedHeader != null) {
-                    Date lastModified = DateUtils.parseDate(lastModifiedHeader.getValue());
+                    java.time.Instant lastModified = DateUtils.parseStandardDate(lastModifiedHeader.getValue());
                     if (lastModified != null) {
                         pathProcessor.setLastModified(
                                 task.getDataPath(),
-                                HttpTransporterUtils.clampRemoteLastModified(lastModified.getTime()));
+                                HttpTransporterUtils.clampRemoteLastModified(lastModified.toEpochMilli()));
                     }
                 }
             }
             extractChecksums(response);
         }
 
-        private void extractChecksums(CloseableHttpResponse response) {
+        private void extractChecksums(ClassicHttpResponse response) {
             Map<String, String> checksums = checksumExtractor.extractChecksums(headerGetter(response));
             if (checksums != null && !checksums.isEmpty()) {
                 checksums.forEach(task::setChecksum);
@@ -697,19 +726,22 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
     }
 
     private static Map<TransferEvent.TransportPropertyKey, Object> createTransportProperties(
-            CloseableHttpResponse response, HttpCoreContext context) {
+            ClassicHttpResponse response, HttpCoreContext context) {
         HttpTransportPropertiesBuilder builder =
-                new HttpTransportPropertiesBuilder(toHttpVersion(response.getProtocolVersion()));
-        SSLSession sslSession = context.getAttribute(CONTEXT_ATTRIBUTE_NAME_SSL_SESSION, SSLSession.class);
+                new HttpTransportPropertiesBuilder(toHttpVersion(response.getVersion()));
+        HttpClientContext clientContext = HttpClientContext.cast(context);
+        SSLSession sslSession = clientContext.getSSLSession();
         if (sslSession != null) {
             builder.withSslProtocol(sslSession.getProtocol());
             builder.withSslCipherSuite(sslSession.getCipherSuite());
         }
-        // content encoding is not available (see https://issues.apache.org/jira/browse/HTTPCORE-792)
         return builder.build();
     }
 
     static HttpVersion toHttpVersion(ProtocolVersion version) {
+        if (version == null) {
+            return HttpVersion.HTTP_1_1;
+        }
         switch (version.getMajor()) {
             case 1:
                 if (version.getMinor() == 0) {
@@ -726,7 +758,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         }
     }
 
-    private static Function<String, String> headerGetter(CloseableHttpResponse closeableHttpResponse) {
+    private static Function<String, String> headerGetter(ClassicHttpResponse closeableHttpResponse) {
         return s -> {
             Header header = closeableHttpResponse.getFirstHeader(s);
             return header != null ? header.getValue() : null;
@@ -738,6 +770,7 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
         private final PutTask task;
 
         PutTaskEntity(PutTask task) {
+            super((ContentType) null, (String) null, false);
             this.task = task;
         }
 
@@ -763,136 +796,190 @@ final class ApacheTransporter extends AbstractTransporter implements HttpTranspo
 
         @Override
         public void writeTo(OutputStream os) throws IOException {
+            if (isConnectionTerminationDrain()) {
+                // DefaultBHttpClientConnection#terminateRequest(ClassicHttpRequest) (org.apache.hc.core5, verified
+                // against 5.3.3 bytecode) calls HttpEntity#writeTo(...) directly - bypassing sendRequestEntity(...)
+                // entirely - to drain a small (0 < Content-Length <= 1024) body that was never sent because a final
+                // response (e.g. an auth challenge) arrived before the entity was written, so the connection can
+                // still be pooled for reuse; skipping this write, as previously done, leaves a re-pooled connection
+                // with the server still awaiting body bytes. This is HTTP wire-protocol framing housekeeping, not a
+                // real upload attempt though, so write the bytes directly instead of through utilPut(): going
+                // through utilPut() here would fire TransportListener#transportStarted()/transportProgressed() for
+                // requests that never actually attempted to upload anything.
+                try (InputStream is = task.newInputStream()) {
+                    byte[] buffer = new byte[1024];
+                    int n;
+                    while ((n = is.read(buffer)) >= 0) {
+                        os.write(buffer, 0, n);
+                    }
+                }
+                return;
+            }
             try {
                 utilPut(task, os, false);
             } catch (TransferCancelledException e) {
                 throw (IOException) new InterruptedIOException().initCause(e);
             }
         }
+
+        private boolean isConnectionTerminationDrain() {
+            for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+                if ("terminateRequest".equals(ste.getMethodName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            // no-op
+        }
     }
 
-    private static class ResolverServiceUnavailableRetryStrategy implements ServiceUnavailableRetryStrategy {
+    /**
+     * Retry strategy restoring HC4-compatible retry semantics on top of HC5's {@link DefaultHttpRequestRetryStrategy}:
+     * I/O-exception retries fire immediately (HC4 did not sleep between them, unlike HC5's default), a response
+     * carrying a Retry-After that would exceed {@code retryIntervalMax} fails the request instead of being retried
+     * after a truncated sleep, and both the historical "standard" and "default" {@code retryHandler.name} modes are
+     * preserved.
+     */
+    private static class ResolverHttpRequestRetryStrategy extends DefaultHttpRequestRetryStrategy {
+
+        private static final Set<Class<? extends IOException>> NON_RETRIABLE_IO_EXCEPTIONS =
+                new java.util.HashSet<>(java.util.Arrays.asList(
+                        InterruptedIOException.class,
+                        javax.net.ssl.SSLException.class,
+                        java.net.UnknownHostException.class,
+                        java.net.ConnectException.class));
+
         private final int retryCount;
 
         private final long retryInterval;
 
         private final long retryIntervalMax;
 
-        private final Set<Integer> serviceUnavailableHttpCodes;
+        private final boolean requestSentRetryEnabled;
 
-        /**
-         * Ugly, but forced by HttpClient API {@link ServiceUnavailableRetryStrategy}: the calls for
-         * {@link #retryRequest(HttpResponse, int, HttpContext)} and {@link #getRetryInterval()} are done by same
-         * thread and are actually done from spot that are very close to each other (almost subsequent calls).
-         */
-        private static final ThreadLocal<Long> RETRY_INTERVAL_HOLDER = new ThreadLocal<>();
+        private final boolean standard;
 
-        private ResolverServiceUnavailableRetryStrategy(
-                int retryCount, long retryInterval, long retryIntervalMax, Set<Integer> serviceUnavailableHttpCodes) {
-            if (retryCount < 0) {
-                throw new IllegalArgumentException("retryCount must be >= 0");
-            }
-            if (retryInterval < 0L) {
-                throw new IllegalArgumentException("retryInterval must be >= 0");
-            }
+        private ResolverHttpRequestRetryStrategy(
+                int retryCount,
+                long retryInterval,
+                long retryIntervalMax,
+                Set<Integer> serviceUnavailableHttpCodes,
+                String retryHandlerName,
+                boolean requestSentRetryEnabled) {
+            super(
+                    validateNotNegative(retryCount, "retryCount"),
+                    TimeValue.ofMilliseconds(validateNotNegative(retryInterval, "retryInterval")),
+                    NON_RETRIABLE_IO_EXCEPTIONS,
+                    requireNonNull(serviceUnavailableHttpCodes, "serviceUnavailableHttpCodes"));
             if (retryIntervalMax < 0L) {
                 throw new IllegalArgumentException("retryIntervalMax must be >= 0");
             }
             this.retryCount = retryCount;
             this.retryInterval = retryInterval;
             this.retryIntervalMax = retryIntervalMax;
-            this.serviceUnavailableHttpCodes = requireNonNull(serviceUnavailableHttpCodes);
+            this.requestSentRetryEnabled = requestSentRetryEnabled;
+            if (HTTP_RETRY_HANDLER_NAME_STANDARD.equals(retryHandlerName)) {
+                this.standard = true;
+            } else if (HTTP_RETRY_HANDLER_NAME_DEFAULT.equals(retryHandlerName)) {
+                this.standard = false;
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported parameter " + CONFIG_PROP_HTTP_RETRY_HANDLER_NAME + " value: " + retryHandlerName);
+            }
+        }
+
+        private static int validateNotNegative(int value, String name) {
+            if (value < 0) {
+                throw new IllegalArgumentException(name + " must be >= 0");
+            }
+            return value;
+        }
+
+        private static long validateNotNegative(long value, String name) {
+            if (value < 0L) {
+                throw new IllegalArgumentException(name + " must be >= 0");
+            }
+            return value;
         }
 
         @Override
-        public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
-            final boolean retry = executionCount <= retryCount
-                    && (serviceUnavailableHttpCodes.contains(
-                            response.getStatusLine().getStatusCode()));
-            if (retry) {
-                Long retryInterval = retryInterval(response, executionCount, context);
-                if (retryInterval != null) {
-                    RETRY_INTERVAL_HOLDER.set(retryInterval);
-                    return true;
+        public boolean retryRequest(HttpRequest request, IOException exception, int execCount, HttpContext context) {
+            if (execCount > retryCount) {
+                return false;
+            }
+            for (Class<? extends IOException> nonRetriable : NON_RETRIABLE_IO_EXCEPTIONS) {
+                if (nonRetriable.isInstance(exception)) {
+                    return false;
                 }
             }
-            RETRY_INTERVAL_HOLDER.remove();
-            return false;
+            if (standard) {
+                String method = request.getMethod();
+                if ("GET".equalsIgnoreCase(method)
+                        || "HEAD".equalsIgnoreCase(method)
+                        || "PUT".equalsIgnoreCase(method)
+                        || "OPTIONS".equalsIgnoreCase(method)) {
+                    return true;
+                }
+                return requestSentRetryEnabled;
+            }
+            // HC4's "default" handler retried any request that had not yet been fully sent, i.e.
+            // (!requestSent || requestSentRetryEnabled). HC5's HttpRequestRetryStrategy exposes no signal for
+            // whether the request line/body was actually written to the wire, so !requestSent cannot be
+            // reproduced here. Widen coverage as far as the HC5 API permits by additionally retrying idempotent
+            // methods (DefaultHttpRequestRetryStrategy#handleAsIdempotent), instead of narrowing to bare
+            // requestSentRetryEnabled as before.
+            return requestSentRetryEnabled || handleAsIdempotent(request);
         }
 
-        /**
-         * Calculates retry interval in milliseconds. If {@link HttpHeaders#RETRY_AFTER} header present, it obeys it.
-         * Otherwise, it returns {@link this#retryInterval} long value multiplied with {@code executionCount} (starts
-         * from 1 and goes 2, 3,...).
-         *
-         * @return Long representing the retry interval as millis, or {@code null} if the request should be failed.
-         */
-        private Long retryInterval(HttpResponse httpResponse, int executionCount, HttpContext httpContext) {
-            Long result = null;
-            Header header = httpResponse.getFirstHeader(HttpHeaders.RETRY_AFTER);
+        @Override
+        public TimeValue getRetryInterval(
+                HttpRequest request, IOException exception, int execCount, HttpContext context) {
+            // HC4 retried I/O errors immediately; reproduce that instead of HC5's default inter-attempt sleep.
+            return TimeValue.ZERO_MILLISECONDS;
+        }
+
+        @Override
+        public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
+            if (!super.retryRequest(response, execCount, context)) {
+                return false;
+            }
+            // Fail fast instead of retrying when the computed interval (including a server Retry-After) would
+            // exceed retryIntervalMax, per the documented contract of
+            // aether.connector.http.retryHandler.intervalMax.
+            return getRetryInterval(response, execCount, context).toMilliseconds() <= retryIntervalMax;
+        }
+
+        @Override
+        public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
+            // Deliberately not delegated to DefaultHttpRequestRetryStrategy#getRetryInterval(HttpResponse,...):
+            // that base implementation falls back to a constant defaultRetryInterval when no Retry-After header is
+            // present, whereas this transport's documented/tested contract is a linear back-off
+            // (execCount * retryInterval) for that case. Retry-After parsing below mirrors the base class but uses
+            // the non-deprecated DateUtils.parseStandardDate. The result is intentionally left uncapped here;
+            // retryRequest(HttpResponse,...) above is what compares it against retryIntervalMax and fails fast.
+            Header header = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
             if (header != null && header.getValue() != null) {
                 String headerValue = header.getValue();
-                if (headerValue.contains(":")) { // is date when to retry
-                    Date when = DateUtils.parseDate(headerValue); // presumably future
+                if (headerValue.contains(":")) {
+                    java.time.Instant when = DateUtils.parseStandardDate(headerValue);
                     if (when != null) {
-                        result = Math.max(when.getTime() - System.currentTimeMillis(), 0L);
+                        long diff = Math.max(when.toEpochMilli() - System.currentTimeMillis(), 0L);
+                        return TimeValue.ofMilliseconds(diff);
                     }
                 } else {
                     try {
-                        result = Long.parseLong(headerValue) * 1000L; // is in seconds
+                        long seconds = Long.parseLong(headerValue);
+                        return TimeValue.ofMilliseconds(seconds * 1000L);
                     } catch (NumberFormatException e) {
-                        // fall through
+                        // fall through to the linear back-off below
                     }
                 }
             }
-            if (result == null) {
-                result = executionCount * this.retryInterval;
-            }
-            if (result > retryIntervalMax) {
-                return null;
-            }
-            return result;
-        }
-
-        @Override
-        public long getRetryInterval() {
-            Long ri = RETRY_INTERVAL_HOLDER.get();
-            if (ri == null) {
-                return 0L;
-            }
-            RETRY_INTERVAL_HOLDER.remove();
-            return ri;
-        }
-    }
-
-    static class ConcurrentAuthCache implements AuthCache {
-        private final ConcurrentHashMap<HttpHost, AuthScheme> map = new ConcurrentHashMap<>();
-
-        @Override
-        public void put(HttpHost host, AuthScheme authScheme) {
-            if (host != null && authScheme != null) {
-                map.put(host, authScheme);
-            }
-        }
-
-        @Override
-        public AuthScheme get(HttpHost host) {
-            if (host == null) {
-                return null;
-            }
-            return map.get(host);
-        }
-
-        @Override
-        public void remove(HttpHost host) {
-            if (host != null) {
-                map.remove(host);
-            }
-        }
-
-        @Override
-        public void clear() {
-            map.clear();
+            return TimeValue.ofMilliseconds((long) execCount * retryInterval);
         }
     }
 }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporter.java
@@ -1,0 +1,898 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import javax.net.ssl.SSLSession;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+
+import org.apache.http.Header;
+import org.apache.http.HttpClientConnection;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.auth.AuthScheme;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.DateUtils;
+import org.apache.http.client.utils.URIUtils;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.ManagedHttpClientConnection;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.NoConnectionReuseStrategy;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.auth.BasicSchemeFactory;
+import org.apache.http.impl.auth.DigestSchemeFactory;
+import org.apache.http.impl.auth.KerberosSchemeFactory;
+import org.apache.http.impl.auth.NTLMSchemeFactory;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.aether.Keys;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.AbstractTransporter;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportListener;
+import org.eclipse.aether.spi.connector.transport.TransportTask;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransportPropertiesBuilder;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransporter;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransporterException;
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transfer.HttpTransportProperty.HttpVersion;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.transfer.TransferCancelledException;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.StringDigestUtil;
+import org.eclipse.aether.util.connector.transport.http.HttpTransporterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.aether.spi.connector.transport.http.HttpConstants.CONTENT_RANGE_PATTERN;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_NAME;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_MAX_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.CONFIG_PROP_USE_SYSTEM_PROPERTIES;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_INSECURE_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_FOLLOW_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_MAX_REDIRECTS;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.DEFAULT_USE_SYSTEM_PROPERTIES;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_DEFAULT;
+import static org.eclipse.aether.transport.apache.ApacheTransporterConfigurationKeys.HTTP_RETRY_HANDLER_NAME_STANDARD;
+
+/**
+ * A transporter for HTTP/HTTPS.
+ */
+final class ApacheTransporter extends AbstractTransporter implements HttpTransporter {
+    /**
+     * Custom context attribute name to store the SSL session in the HTTP context. This is populated by a custom request executor.
+     */
+    private static final String CONTEXT_ATTRIBUTE_NAME_SSL_SESSION = "ssl.session";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApacheTransporter.class);
+
+    private final ChecksumExtractor checksumExtractor;
+
+    private final PathProcessor pathProcessor;
+
+    private final AuthenticationContext repoAuthContext;
+
+    private final AuthenticationContext proxyAuthContext;
+
+    private final URI baseUri;
+
+    private final HttpHost server;
+
+    private final HttpHost proxy;
+
+    private final CloseableHttpClient client;
+
+    private final Map<?, ?> headers;
+
+    private final LocalState state;
+
+    private final boolean preemptiveAuth;
+
+    private final boolean preemptivePutAuth;
+
+    private final boolean supportWebDav;
+
+    private final boolean sendRfc9457Accept;
+
+    private final AuthCache authCache;
+
+    @SuppressWarnings("checkstyle:methodlength")
+    ApacheTransporter(
+            RemoteRepository repository,
+            RepositorySystemSession session,
+            ChecksumExtractor checksumExtractor,
+            PathProcessor pathProcessor)
+            throws NoTransporterException {
+        this.checksumExtractor = checksumExtractor;
+        this.pathProcessor = pathProcessor;
+        try {
+            this.baseUri = HttpTransporterUtils.getBaseUri(repository);
+            this.server = URIUtils.extractHost(baseUri);
+            if (server == null) {
+                throw new URISyntaxException(repository.getUrl(), "URL lacks host name");
+            }
+        } catch (URISyntaxException e) {
+            throw new NoTransporterException(repository, e.getMessage(), e);
+        }
+        this.proxy = toHost(repository.getProxy());
+
+        this.repoAuthContext = AuthenticationContext.forRepository(session, repository);
+        this.proxyAuthContext = AuthenticationContext.forProxy(session, repository);
+
+        String httpsSecurityMode = HttpTransporterUtils.getHttpsSecurityMode(session, repository);
+        final int connectionMaxTtlSeconds = HttpTransporterUtils.getHttpConnectionMaxTtlSeconds(session, repository);
+        final int maxConnectionsPerRoute = HttpTransporterUtils.getHttpMaxConnectionsPerRoute(session, repository);
+        this.state = new LocalState(
+                session,
+                repository,
+                new ConnMgrConfig(
+                        session, repoAuthContext, httpsSecurityMode, connectionMaxTtlSeconds, maxConnectionsPerRoute));
+
+        this.headers = HttpTransporterUtils.getHttpHeaders(session, repository);
+        this.preemptiveAuth = HttpTransporterUtils.isHttpPreemptiveAuth(session, repository);
+        this.preemptivePutAuth = HttpTransporterUtils.isHttpPreemptivePutAuth(session, repository);
+        this.supportWebDav = HttpTransporterUtils.isHttpSupportWebDav(session, repository);
+        this.sendRfc9457Accept = HttpTransporterUtils.isHttpSendRfc9457Accept(session, repository);
+        int connectTimeout = HttpTransporterUtils.getHttpConnectTimeout(session, repository);
+        int requestTimeout = HttpTransporterUtils.getHttpRequestTimeout(session, repository);
+        int retryCount = HttpTransporterUtils.getHttpRetryHandlerCount(session, repository);
+        long retryInterval = HttpTransporterUtils.getHttpRetryHandlerInterval(session, repository);
+        long retryIntervalMax = HttpTransporterUtils.getHttpRetryHandlerIntervalMax(session, repository);
+        String retryHandlerName = ConfigUtils.getString(
+                session,
+                HTTP_RETRY_HANDLER_NAME_STANDARD,
+                CONFIG_PROP_HTTP_RETRY_HANDLER_NAME + "." + repository.getId(),
+                CONFIG_PROP_HTTP_RETRY_HANDLER_NAME);
+        boolean retryHandlerRequestSentEnabled = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED,
+                CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED + "." + repository.getId(),
+                CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED);
+        int maxRedirects = ConfigUtils.getInteger(
+                session,
+                DEFAULT_MAX_REDIRECTS,
+                CONFIG_PROP_MAX_REDIRECTS + "." + repository.getId(),
+                CONFIG_PROP_MAX_REDIRECTS);
+        boolean followRedirects = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_FOLLOW_REDIRECTS,
+                CONFIG_PROP_FOLLOW_REDIRECTS + "." + repository.getId(),
+                CONFIG_PROP_FOLLOW_REDIRECTS);
+        boolean followInsecureRedirects = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_FOLLOW_INSECURE_REDIRECTS,
+                CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS + "." + repository.getId(),
+                CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS);
+        String userAgent = HttpTransporterUtils.getUserAgent(session, repository);
+
+        Charset credentialsCharset = HttpTransporterUtils.getHttpCredentialsEncoding(session, repository);
+        Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
+                .register(AuthSchemes.BASIC, new BasicSchemeFactory(credentialsCharset))
+                .register(AuthSchemes.DIGEST, new DigestSchemeFactory(credentialsCharset))
+                .register(AuthSchemes.NTLM, new NTLMSchemeFactory())
+                .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory())
+                .register(AuthSchemes.KERBEROS, new KerberosSchemeFactory())
+                .build();
+        SocketConfig socketConfig =
+                // the time to establish connection (low level)
+                SocketConfig.custom().setSoTimeout(requestTimeout).build();
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setMaxRedirects(maxRedirects)
+                .setRedirectsEnabled(followRedirects)
+                .setRelativeRedirectsAllowed(followRedirects)
+                // the time waiting for data; max time between two data packets
+                .setSocketTimeout(requestTimeout)
+                // the time to establish the connection (high level)
+                .setConnectTimeout(connectTimeout)
+                // the time to wait for a connection from the connection manager/pool
+                .setConnectionRequestTimeout(connectTimeout)
+                .setLocalAddress(HttpTransporterUtils.getHttpLocalAddress(session, repository)
+                        .orElse(null))
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
+
+        HttpRequestRetryHandler retryHandler;
+        if (HTTP_RETRY_HANDLER_NAME_STANDARD.equals(retryHandlerName)) {
+            retryHandler = new StandardHttpRequestRetryHandler(retryCount, retryHandlerRequestSentEnabled);
+        } else if (HTTP_RETRY_HANDLER_NAME_DEFAULT.equals(retryHandlerName)) {
+            retryHandler = new DefaultHttpRequestRetryHandler(retryCount, retryHandlerRequestSentEnabled);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported parameter " + CONFIG_PROP_HTTP_RETRY_HANDLER_NAME + " value: " + retryHandlerName);
+        }
+        ServiceUnavailableRetryStrategy serviceUnavailableRetryStrategy = new ResolverServiceUnavailableRetryStrategy(
+                retryCount,
+                retryInterval,
+                retryIntervalMax,
+                HttpTransporterUtils.getHttpServiceUnavailableCodes(session, repository));
+
+        HttpClientBuilder builder = HttpClientBuilder.create()
+                .setUserAgent(userAgent)
+                .setRedirectStrategy(new ResolverRedirectStrategy(followInsecureRedirects))
+                .setDefaultSocketConfig(socketConfig)
+                .setDefaultRequestConfig(requestConfig)
+                .setServiceUnavailableRetryStrategy(serviceUnavailableRetryStrategy)
+                .setRetryHandler(retryHandler)
+                .setDefaultAuthSchemeRegistry(authSchemeRegistry)
+                .setConnectionManager(state.getConnectionManager())
+                .setConnectionManagerShared(true)
+                .setDefaultCredentialsProvider(toCredentialsProvider(server, repoAuthContext, proxy, proxyAuthContext))
+                .setProxy(proxy);
+        if (ConfigUtils.getBoolean(
+                session,
+                ApacheTransporterConfigurationKeys.DEFAULT_ORIGIN_SCOPED_HEADERS,
+                ApacheTransporterConfigurationKeys.CONFIG_PROP_ORIGIN_SCOPED_HEADERS + "." + repository.getId(),
+                ApacheTransporterConfigurationKeys.CONFIG_PROP_ORIGIN_SCOPED_HEADERS)) {
+            // Configured headers are per-repository data and frequently carry credentials; scope them to the
+            // repository origin so a cross-origin redirect hop does not replay them to the redirect target.
+            // Challenge-based credentials are host-scoped by the credentials provider already.
+            builder.addInterceptorLast(new OriginScopedHeadersInterceptor(server, this.headers.keySet()));
+        }
+        final boolean useSystemProperties = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_USE_SYSTEM_PROPERTIES,
+                CONFIG_PROP_USE_SYSTEM_PROPERTIES + "." + repository.getId(),
+                CONFIG_PROP_USE_SYSTEM_PROPERTIES);
+        if (useSystemProperties) {
+            LOGGER.warn(
+                    "Transport used Apache HttpClient is instructed to use system properties: this may yield in unwanted side-effects!");
+            LOGGER.warn("Please use documented means to configure resolver transport.");
+            builder.useSystemProperties();
+        }
+
+        // capture SSL session for logging purposes (https://issues.apache.org/jira/browse/HTTPCLIENT-2164)
+        builder.setRequestExecutor(new HttpRequestExecutor() {
+
+            @Override
+            public HttpResponse execute(HttpRequest request, HttpClientConnection conn, HttpContext context)
+                    throws IOException, HttpException {
+                if (conn instanceof ManagedHttpClientConnection) {
+                    context.setAttribute(
+                            CONTEXT_ATTRIBUTE_NAME_SSL_SESSION, ((ManagedHttpClientConnection) conn).getSSLSession());
+                }
+                return super.execute(request, conn, context);
+            }
+        });
+
+        HttpTransporterUtils.getHttpExpectContinue(session, repository).ifPresent(state::setExpectContinue);
+        if (!HttpTransporterUtils.isHttpReuseConnections(session, repository)) {
+            builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+        }
+
+        if (session.getCache() != null) {
+            this.authCache = (AuthCache) session.getCache()
+                    .computeIfAbsent(
+                            session,
+                            Keys.of(
+                                    getClass(),
+                                    repository.getId() + "-" + StringDigestUtil.sha1(repository.toString())),
+                            ConcurrentAuthCache::new);
+        } else {
+            this.authCache = new ConcurrentAuthCache();
+        }
+        this.client = builder.build();
+    }
+
+    private static HttpHost toHost(Proxy proxy) {
+        HttpHost host = null;
+        if (proxy != null) {
+            // in Maven, the proxy.protocol is used for proxy matching against remote repository protocol; no TLS proxy
+            // support
+            // https://github.com/apache/maven/issues/2519
+            // https://github.com/apache/maven-resolver/issues/745
+            host = new HttpHost(proxy.getHost(), proxy.getPort());
+        }
+        return host;
+    }
+
+    private static CredentialsProvider toCredentialsProvider(
+            HttpHost server, AuthenticationContext serverAuthCtx, HttpHost proxy, AuthenticationContext proxyAuthCtx) {
+        CredentialsProvider provider =
+                toCredentialsProvider(server.getHostName(), effectivePort(server), serverAuthCtx);
+        if (proxy != null) {
+            CredentialsProvider p = toCredentialsProvider(proxy.getHostName(), proxy.getPort(), proxyAuthCtx);
+            provider = new DemuxCredentialsProvider(provider, p, proxy);
+        }
+        return provider;
+    }
+
+    /**
+     * Determines the effective port of the given host: the explicit port if present, otherwise the default port
+     * implied by the scheme. Used to bind repository credentials to the repository's own origin (host and port)
+     * instead of {@link AuthScope#ANY_PORT}: with any-port scoping, a request landing on the same host but a
+     * different port - for example after an https-to-http downgrade redirect - would still be eligible to
+     * receive the credentials.
+     */
+    static int effectivePort(HttpHost host) {
+        if (host.getPort() >= 0) {
+            return host.getPort();
+        }
+        return "https".equalsIgnoreCase(host.getSchemeName()) ? 443 : 80;
+    }
+
+    private static CredentialsProvider toCredentialsProvider(String host, int port, AuthenticationContext ctx) {
+        DeferredCredentialsProvider provider = new DeferredCredentialsProvider();
+        if (ctx != null) {
+            AuthScope basicScope = new AuthScope(host, port);
+            provider.setCredentials(basicScope, new DeferredCredentialsProvider.BasicFactory(ctx));
+
+            AuthScope ntlmScope = new AuthScope(host, port, AuthScope.ANY_REALM, "ntlm");
+            provider.setCredentials(ntlmScope, new DeferredCredentialsProvider.NtlmFactory(ctx));
+        }
+        return provider;
+    }
+
+    LocalState getState() {
+        return state;
+    }
+
+    private URI resolve(TransportTask task) {
+        return UriUtils.resolve(baseUri, task.getLocation());
+    }
+
+    @Override
+    protected void implPeek(PeekTask task) throws Exception {
+        HttpHead request = commonHeaders(new HttpHead(resolve(task)));
+        try {
+            execute(request, null, task.getListener());
+        } catch (HttpResponseException e) {
+            throw new HttpTransporterException(e.getStatusCode());
+        }
+    }
+
+    @Override
+    protected void implGet(GetTask task) throws Exception {
+        boolean resume = true;
+
+        EntityGetter getter = new EntityGetter(task);
+        HttpGet request = commonHeaders(new HttpGet(resolve(task)));
+        if (sendRfc9457Accept) {
+            ApacheRFC9457Reporter.INSTANCE.prepareRequest(request);
+        }
+        while (true) {
+            try {
+                if (resume) {
+                    resume(request, task);
+                }
+                execute(request, getter, task.getListener());
+                break;
+            } catch (HttpResponseException e) {
+                if (resume
+                        && e.getStatusCode() == HttpStatus.SC_PRECONDITION_FAILED
+                        && request.containsHeader(HttpHeaders.RANGE)) {
+                    request = commonHeaders(new HttpGet(resolve(task)));
+                    resume = false;
+                    continue;
+                }
+                throw new HttpTransporterException(e.getStatusCode());
+            }
+        }
+    }
+
+    @Override
+    protected void implPut(PutTask task) throws Exception {
+        PutTaskEntity entity = new PutTaskEntity(task);
+        HttpPut request = commonHeaders(entity(new HttpPut(resolve(task)), entity));
+        if (sendRfc9457Accept) {
+            ApacheRFC9457Reporter.INSTANCE.prepareRequest(request);
+        }
+        try {
+            execute(request, null, task.getListener());
+        } catch (HttpResponseException e) {
+            if (e.getStatusCode() == HttpStatus.SC_EXPECTATION_FAILED && request.containsHeader(HttpHeaders.EXPECT)) {
+                state.setExpectContinue(false);
+                request = commonHeaders(entity(new HttpPut(request.getURI()), entity));
+                execute(request, null, task.getListener());
+                return;
+            }
+            throw new HttpTransporterException(e.getStatusCode());
+        }
+    }
+
+    private void execute(HttpUriRequest request, EntityGetter getter, TransportListener listener) throws Exception {
+        try {
+            SharingHttpContext context = new SharingHttpContext(state);
+            context.setAuthCache(authCache);
+            prepare(request, context);
+            try (CloseableHttpResponse response = client.execute(server, request, context)) {
+                try {
+                    Map<TransferEvent.TransportPropertyKey, Object> transportProperties =
+                            createTransportProperties(response, context);
+                    listener.transportPropertiesAvailable(transportProperties);
+                    handleStatus(response);
+                    if (getter != null) {
+                        getter.handle(response);
+                    }
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            }
+        } catch (IOException e) {
+            if (e.getCause() instanceof TransferCancelledException) {
+                throw (Exception) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    private void prepare(HttpUriRequest request, SharingHttpContext context) throws Exception {
+        final boolean put = HttpPut.METHOD_NAME.equalsIgnoreCase(request.getMethod());
+        if (preemptiveAuth || (preemptivePutAuth && put)) {
+            context.getAuthCache().put(server, new BasicScheme());
+        }
+        if (supportWebDav) {
+            if (state.getWebDav() == null && (put || isPayloadPresent(request))) {
+                HttpOptions req = commonHeaders(new HttpOptions(request.getURI()));
+                try (CloseableHttpResponse response = client.execute(server, req, context)) {
+                    state.setWebDav(response.containsHeader(HttpHeaders.DAV));
+                    EntityUtils.consumeQuietly(response.getEntity());
+                } catch (IOException e) {
+                    LOGGER.debug("Failed to prepare HTTP context", e);
+                }
+            }
+            if (put && Boolean.TRUE.equals(state.getWebDav())) {
+                mkdirs(request.getURI(), context);
+            }
+        }
+    }
+
+    private void mkdirs(URI uri, SharingHttpContext context) throws Exception {
+        List<URI> dirs = UriUtils.getDirectories(baseUri, uri);
+        int index = 0;
+        for (; index < dirs.size(); index++) {
+            try (CloseableHttpResponse response =
+                    client.execute(server, commonHeaders(new HttpMkCol(dirs.get(index))), context)) {
+                try {
+                    int status = response.getStatusLine().getStatusCode();
+                    if (status < 300 || status == HttpStatus.SC_METHOD_NOT_ALLOWED) {
+                        break;
+                    } else if (status == HttpStatus.SC_CONFLICT) {
+                        continue;
+                    }
+                    handleStatus(response);
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            } catch (IOException e) {
+                LOGGER.debug("Failed to create parent directory {}", dirs.get(index), e);
+                return;
+            }
+        }
+        for (index--; index >= 0; index--) {
+            try (CloseableHttpResponse response =
+                    client.execute(server, commonHeaders(new HttpMkCol(dirs.get(index))), context)) {
+                try {
+                    handleStatus(response);
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            } catch (IOException e) {
+                LOGGER.debug("Failed to create parent directory {}", dirs.get(index), e);
+                return;
+            }
+        }
+    }
+
+    private <T extends HttpEntityEnclosingRequest> T entity(T request, HttpEntity entity) {
+        request.setEntity(entity);
+        return request;
+    }
+
+    private boolean isPayloadPresent(HttpUriRequest request) {
+        if (request instanceof HttpEntityEnclosingRequest) {
+            HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
+            return entity != null && entity.getContentLength() != 0;
+        }
+        return false;
+    }
+
+    private <T extends HttpUriRequest> T commonHeaders(T request) {
+        request.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store");
+        request.setHeader(HttpHeaders.PRAGMA, "no-cache");
+
+        if (state.isExpectContinue() && isPayloadPresent(request)) {
+            request.setHeader(HttpHeaders.EXPECT, "100-continue");
+        }
+
+        for (Map.Entry<?, ?> entry : headers.entrySet()) {
+            if (!(entry.getKey() instanceof String)) {
+                continue;
+            }
+            if (entry.getValue() instanceof String) {
+                request.setHeader(entry.getKey().toString(), entry.getValue().toString());
+            } else {
+                request.removeHeaders(entry.getKey().toString());
+            }
+        }
+
+        if (!state.isExpectContinue()) {
+            request.removeHeaders(HttpHeaders.EXPECT);
+        }
+        return request;
+    }
+
+    private <T extends HttpUriRequest> void resume(T request, GetTask task) throws IOException {
+        long resumeOffset = task.getResumeOffset();
+        if (resumeOffset > 0L && task.getDataPath() != null) {
+            long lastModified = Files.getLastModifiedTime(task.getDataPath()).toMillis();
+            request.setHeader(HttpHeaders.RANGE, "bytes=" + resumeOffset + '-');
+            request.setHeader(
+                    HttpHeaders.IF_UNMODIFIED_SINCE, DateUtils.formatDate(new Date(lastModified - 60L * 1000L)));
+            request.setHeader(HttpHeaders.ACCEPT_ENCODING, "identity");
+        }
+    }
+
+    private void handleStatus(CloseableHttpResponse response) throws Exception {
+        int status = response.getStatusLine().getStatusCode();
+        if (status >= 300) {
+            ApacheRFC9457Reporter.INSTANCE.generateException(response, (statusCode, reasonPhrase) -> {
+                throw new HttpResponseException(statusCode, reasonPhrase + " (" + statusCode + ")");
+            });
+        }
+    }
+
+    @Override
+    protected void implClose() {
+        try {
+            client.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        AuthenticationContext.close(repoAuthContext);
+        AuthenticationContext.close(proxyAuthContext);
+        state.close();
+    }
+
+    private class EntityGetter {
+
+        private final GetTask task;
+
+        EntityGetter(GetTask task) {
+            this.task = task;
+        }
+
+        public void handle(CloseableHttpResponse response) throws IOException, TransferCancelledException {
+            HttpEntity entity = response.getEntity();
+            if (entity == null) {
+                entity = new ByteArrayEntity(new byte[0]);
+            }
+
+            long offset = 0L, length = entity.getContentLength();
+            Header rangeHeader = response.getFirstHeader(HttpHeaders.CONTENT_RANGE);
+            String range = rangeHeader != null ? rangeHeader.getValue() : null;
+            if (range != null) {
+                Matcher m = CONTENT_RANGE_PATTERN.matcher(range);
+                if (!m.matches()) {
+                    throw new IOException("Invalid Content-Range header for partial download: " + range);
+                }
+                offset = Long.parseLong(m.group(1));
+                length = Long.parseLong(m.group(2)) + 1L;
+                if (offset < 0L || offset >= length || (offset > 0L && offset != task.getResumeOffset())) {
+                    throw new IOException("Invalid Content-Range header for partial download from offset "
+                            + task.getResumeOffset() + ": " + range);
+                }
+            }
+
+            final boolean resume = offset > 0L;
+            final Path dataFile = task.getDataPath();
+            if (dataFile == null) {
+                try (InputStream is = entity.getContent()) {
+                    utilGet(task, is, true, length, resume);
+                    extractChecksums(response);
+                }
+            } else {
+                try (PathProcessor.CollocatedTempFile tempFile = pathProcessor.newTempFile(dataFile)) {
+                    task.setDataPath(tempFile.getPath(), resume);
+                    if (resume && Files.isRegularFile(dataFile)) {
+                        try (InputStream inputStream = Files.newInputStream(dataFile)) {
+                            Files.copy(inputStream, tempFile.getPath(), StandardCopyOption.REPLACE_EXISTING);
+                        }
+                    }
+                    try (InputStream is = entity.getContent()) {
+                        utilGet(task, is, true, length, resume);
+                    }
+                    tempFile.move();
+                } finally {
+                    task.setDataPath(dataFile);
+                }
+            }
+            if (task.getDataPath() != null) {
+                Header lastModifiedHeader =
+                        response.getFirstHeader(HttpHeaders.LAST_MODIFIED); // note: Wagon also does first not last
+                if (lastModifiedHeader != null) {
+                    Date lastModified = DateUtils.parseDate(lastModifiedHeader.getValue());
+                    if (lastModified != null) {
+                        pathProcessor.setLastModified(
+                                task.getDataPath(),
+                                HttpTransporterUtils.clampRemoteLastModified(lastModified.getTime()));
+                    }
+                }
+            }
+            extractChecksums(response);
+        }
+
+        private void extractChecksums(CloseableHttpResponse response) {
+            Map<String, String> checksums = checksumExtractor.extractChecksums(headerGetter(response));
+            if (checksums != null && !checksums.isEmpty()) {
+                checksums.forEach(task::setChecksum);
+            }
+        }
+    }
+
+    private static Map<TransferEvent.TransportPropertyKey, Object> createTransportProperties(
+            CloseableHttpResponse response, HttpCoreContext context) {
+        HttpTransportPropertiesBuilder builder =
+                new HttpTransportPropertiesBuilder(toHttpVersion(response.getProtocolVersion()));
+        SSLSession sslSession = context.getAttribute(CONTEXT_ATTRIBUTE_NAME_SSL_SESSION, SSLSession.class);
+        if (sslSession != null) {
+            builder.withSslProtocol(sslSession.getProtocol());
+            builder.withSslCipherSuite(sslSession.getCipherSuite());
+        }
+        // content encoding is not available (see https://issues.apache.org/jira/browse/HTTPCORE-792)
+        return builder.build();
+    }
+
+    static HttpVersion toHttpVersion(ProtocolVersion version) {
+        switch (version.getMajor()) {
+            case 1:
+                if (version.getMinor() == 0) {
+                    return HttpVersion.HTTP_1_0;
+                } else {
+                    return HttpVersion.HTTP_1_1;
+                }
+            case 2:
+                return HttpVersion.HTTP_2;
+            case 3:
+                return HttpVersion.HTTP_3;
+            default:
+                throw new IllegalArgumentException("Unknown version " + version.toString());
+        }
+    }
+
+    private static Function<String, String> headerGetter(CloseableHttpResponse closeableHttpResponse) {
+        return s -> {
+            Header header = closeableHttpResponse.getFirstHeader(s);
+            return header != null ? header.getValue() : null;
+        };
+    }
+
+    private class PutTaskEntity extends AbstractHttpEntity {
+
+        private final PutTask task;
+
+        PutTaskEntity(PutTask task) {
+            this.task = task;
+        }
+
+        @Override
+        public boolean isRepeatable() {
+            return true;
+        }
+
+        @Override
+        public boolean isStreaming() {
+            return false;
+        }
+
+        @Override
+        public long getContentLength() {
+            return task.getDataLength();
+        }
+
+        @Override
+        public InputStream getContent() throws IOException {
+            return task.newInputStream();
+        }
+
+        @Override
+        public void writeTo(OutputStream os) throws IOException {
+            try {
+                utilPut(task, os, false);
+            } catch (TransferCancelledException e) {
+                throw (IOException) new InterruptedIOException().initCause(e);
+            }
+        }
+    }
+
+    private static class ResolverServiceUnavailableRetryStrategy implements ServiceUnavailableRetryStrategy {
+        private final int retryCount;
+
+        private final long retryInterval;
+
+        private final long retryIntervalMax;
+
+        private final Set<Integer> serviceUnavailableHttpCodes;
+
+        /**
+         * Ugly, but forced by HttpClient API {@link ServiceUnavailableRetryStrategy}: the calls for
+         * {@link #retryRequest(HttpResponse, int, HttpContext)} and {@link #getRetryInterval()} are done by same
+         * thread and are actually done from spot that are very close to each other (almost subsequent calls).
+         */
+        private static final ThreadLocal<Long> RETRY_INTERVAL_HOLDER = new ThreadLocal<>();
+
+        private ResolverServiceUnavailableRetryStrategy(
+                int retryCount, long retryInterval, long retryIntervalMax, Set<Integer> serviceUnavailableHttpCodes) {
+            if (retryCount < 0) {
+                throw new IllegalArgumentException("retryCount must be >= 0");
+            }
+            if (retryInterval < 0L) {
+                throw new IllegalArgumentException("retryInterval must be >= 0");
+            }
+            if (retryIntervalMax < 0L) {
+                throw new IllegalArgumentException("retryIntervalMax must be >= 0");
+            }
+            this.retryCount = retryCount;
+            this.retryInterval = retryInterval;
+            this.retryIntervalMax = retryIntervalMax;
+            this.serviceUnavailableHttpCodes = requireNonNull(serviceUnavailableHttpCodes);
+        }
+
+        @Override
+        public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+            final boolean retry = executionCount <= retryCount
+                    && (serviceUnavailableHttpCodes.contains(
+                            response.getStatusLine().getStatusCode()));
+            if (retry) {
+                Long retryInterval = retryInterval(response, executionCount, context);
+                if (retryInterval != null) {
+                    RETRY_INTERVAL_HOLDER.set(retryInterval);
+                    return true;
+                }
+            }
+            RETRY_INTERVAL_HOLDER.remove();
+            return false;
+        }
+
+        /**
+         * Calculates retry interval in milliseconds. If {@link HttpHeaders#RETRY_AFTER} header present, it obeys it.
+         * Otherwise, it returns {@link this#retryInterval} long value multiplied with {@code executionCount} (starts
+         * from 1 and goes 2, 3,...).
+         *
+         * @return Long representing the retry interval as millis, or {@code null} if the request should be failed.
+         */
+        private Long retryInterval(HttpResponse httpResponse, int executionCount, HttpContext httpContext) {
+            Long result = null;
+            Header header = httpResponse.getFirstHeader(HttpHeaders.RETRY_AFTER);
+            if (header != null && header.getValue() != null) {
+                String headerValue = header.getValue();
+                if (headerValue.contains(":")) { // is date when to retry
+                    Date when = DateUtils.parseDate(headerValue); // presumably future
+                    if (when != null) {
+                        result = Math.max(when.getTime() - System.currentTimeMillis(), 0L);
+                    }
+                } else {
+                    try {
+                        result = Long.parseLong(headerValue) * 1000L; // is in seconds
+                    } catch (NumberFormatException e) {
+                        // fall through
+                    }
+                }
+            }
+            if (result == null) {
+                result = executionCount * this.retryInterval;
+            }
+            if (result > retryIntervalMax) {
+                return null;
+            }
+            return result;
+        }
+
+        @Override
+        public long getRetryInterval() {
+            Long ri = RETRY_INTERVAL_HOLDER.get();
+            if (ri == null) {
+                return 0L;
+            }
+            RETRY_INTERVAL_HOLDER.remove();
+            return ri;
+        }
+    }
+
+    static class ConcurrentAuthCache implements AuthCache {
+        private final ConcurrentHashMap<HttpHost, AuthScheme> map = new ConcurrentHashMap<>();
+
+        @Override
+        public void put(HttpHost host, AuthScheme authScheme) {
+            if (host != null && authScheme != null) {
+                map.put(host, authScheme);
+            }
+        }
+
+        @Override
+        public AuthScheme get(HttpHost host) {
+            if (host == null) {
+                return null;
+            }
+            return map.get(host);
+        }
+
+        @Override
+        public void remove(HttpHost host) {
+            if (host != null) {
+                map.remove(host);
+            }
+        }
+
+        @Override
+        public void clear() {
+            map.clear();
+        }
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterConfigurationKeys.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterConfigurationKeys.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Configuration for Apache Transport.
+ *
+ * @since 2.0.0
+ */
+public final class ApacheTransporterConfigurationKeys {
+    private ApacheTransporterConfigurationKeys() {}
+
+    static final String CONFIG_PROPS_PREFIX =
+            ConfigurationProperties.PREFIX_TRANSPORT + ApacheTransporterFactory.NAME + ".";
+
+    /**
+     * If enabled, underlying Apache HttpClient will use system properties as well to configure itself (typically
+     * used to set up HTTP Proxy via Java system properties). See HttpClientBuilder for used properties. This mode
+     * is not recommended, better use documented ways of configuration instead.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_USE_SYSTEM_PROPERTIES}
+     * @configurationRepoIdSuffix Yes
+     */
+    public static final String CONFIG_PROP_USE_SYSTEM_PROPERTIES = CONFIG_PROPS_PREFIX + "useSystemProperties";
+
+    public static final boolean DEFAULT_USE_SYSTEM_PROPERTIES = false;
+
+    /**
+     * The name of retryHandler, supported values are “standard”, that obeys RFC-2616, regarding idempotent methods,
+     * and “default” that considers requests w/o payload as idempotent.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.String}
+     * @configurationDefaultValue {@link #HTTP_RETRY_HANDLER_NAME_STANDARD}
+     * @configurationRepoIdSuffix Yes
+     */
+    public static final String CONFIG_PROP_HTTP_RETRY_HANDLER_NAME = CONFIG_PROPS_PREFIX + "retryHandler.name";
+
+    public static final String HTTP_RETRY_HANDLER_NAME_STANDARD = "standard";
+
+    public static final String HTTP_RETRY_HANDLER_NAME_DEFAULT = "default";
+
+    /**
+     * Set to true if it is acceptable to retry non-idempotent requests, that have been sent.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED}
+     * @configurationRepoIdSuffix Yes
+     */
+    public static final String CONFIG_PROP_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED =
+            CONFIG_PROPS_PREFIX + "retryHandler.requestSentEnabled";
+
+    public static final boolean DEFAULT_HTTP_RETRY_HANDLER_REQUEST_SENT_ENABLED = false;
+
+    /**
+     * Comma-separated list of
+     * <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#ciphersuites">Cipher
+     * Suites</a> which are enabled for HTTPS connections.
+     *
+     * @since 2.0.0
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.String}
+     */
+    public static final String CONFIG_PROP_CIPHER_SUITES = CONFIG_PROPS_PREFIX + "https.cipherSuites";
+
+    /**
+     * Comma-separated list of
+     * <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#jssenames">Protocols
+     * </a> which are enabled for HTTPS connections.
+     *
+     * @since 2.0.0
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.String}
+     */
+    public static final String CONFIG_PROP_PROTOCOLS = CONFIG_PROPS_PREFIX + "https.protocols";
+
+    /**
+     * If enabled, Apache HttpClient will follow HTTP redirects.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_FOLLOW_REDIRECTS}
+     * @configurationRepoIdSuffix Yes
+     * @since 2.0.2
+     */
+    public static final String CONFIG_PROP_FOLLOW_REDIRECTS = CONFIG_PROPS_PREFIX + "followRedirects";
+
+    public static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
+
+    /**
+     * If enabled (default), operator-configured request headers ({@code aether.transport.http.headers}) are only
+     * sent on requests targeting the repository origin (the scheme, host and port the repository URL denotes).
+     * Apache HttpClient re-sends the original request headers on redirects, so without origin scoping a
+     * cross-origin redirect replays the configured headers - which frequently carry credentials such as
+     * {@code Authorization}, cookies or private token headers - to the redirect target host. Disable only when a
+     * redirect target legitimately requires the configured headers.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_ORIGIN_SCOPED_HEADERS}
+     * @configurationRepoIdSuffix Yes
+     * @since 2.0.23
+     */
+    public static final String CONFIG_PROP_ORIGIN_SCOPED_HEADERS = CONFIG_PROPS_PREFIX + "originScopedHeaders";
+
+    public static final boolean DEFAULT_ORIGIN_SCOPED_HEADERS = true;
+
+    /**
+     * The max redirect count to follow.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Integer}
+     * @configurationDefaultValue {@link #DEFAULT_MAX_REDIRECTS}
+     * @configurationRepoIdSuffix Yes
+     * @since 2.0.2
+     */
+    public static final String CONFIG_PROP_MAX_REDIRECTS = CONFIG_PROPS_PREFIX + "maxRedirects";
+
+    public static final int DEFAULT_MAX_REDIRECTS = 5;
+
+    /**
+     * If enabled, Apache HttpClient will follow redirects that downgrade the protocol from https to http. Disabled
+     * by default: such a downgrade strips transport encryption from artifact and checksum bytes and makes repository
+     * credentials eligible for transmission over plaintext, so a downgrading redirect fails the transfer instead.
+     *
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_FOLLOW_INSECURE_REDIRECTS}
+     * @configurationRepoIdSuffix Yes
+     * @since 2.0.23
+     */
+    public static final String CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS = CONFIG_PROPS_PREFIX + "followInsecureRedirects";
+
+    public static final boolean DEFAULT_FOLLOW_INSECURE_REDIRECTS = false;
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterConfigurationKeys.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterConfigurationKeys.java
@@ -30,7 +30,7 @@ public final class ApacheTransporterConfigurationKeys {
     private ApacheTransporterConfigurationKeys() {}
 
     static final String CONFIG_PROPS_PREFIX =
-            ConfigurationProperties.PREFIX_TRANSPORT + ApacheTransporterFactory.NAME + ".";
+            ConfigurationProperties.PREFIX_TRANSPORT + Apache5TransporterFactory.NAME + ".";
 
     /**
      * If enabled, underlying Apache HttpClient will use system properties as well to configure itself (typically

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterFactory.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ApacheTransporterFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.http.ChecksumExtractor;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransporter;
+import org.eclipse.aether.spi.connector.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.spi.io.PathProcessor;
+import org.eclipse.aether.transfer.NoTransporterException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A transporter factory for repositories using the {@code http:} or {@code https:} protocol. The provided transporters
+ * support uploads to WebDAV servers and resumable downloads.
+ */
+@Named(ApacheTransporterFactory.NAME)
+public final class ApacheTransporterFactory implements HttpTransporterFactory {
+    public static final String NAME = "apache5";
+
+    private float priority = 5.0f;
+
+    private final ChecksumExtractor checksumExtractor;
+
+    private final PathProcessor pathProcessor;
+
+    @Inject
+    public ApacheTransporterFactory(ChecksumExtractor checksumExtractor, PathProcessor pathProcessor) {
+        this.checksumExtractor = requireNonNull(checksumExtractor, "checksumExtractor");
+        this.pathProcessor = requireNonNull(pathProcessor, "pathProcessor");
+    }
+
+    @Override
+    public float getPriority() {
+        return priority;
+    }
+
+    /**
+     * Sets the priority of this component.
+     *
+     * @param priority The priority.
+     * @return This component for chaining, never {@code null}.
+     */
+    public ApacheTransporterFactory setPriority(float priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public HttpTransporter newInstance(RepositorySystemSession session, RemoteRepository repository)
+            throws NoTransporterException {
+        requireNonNull(session, "session cannot be null");
+        requireNonNull(repository, "repository cannot be null");
+
+        if (!"http".equalsIgnoreCase(repository.getProtocol()) && !"https".equalsIgnoreCase(repository.getProtocol())) {
+            throw new NoTransporterException(repository);
+        }
+
+        return new ApacheTransporter(repository, session, checksumExtractor, pathProcessor);
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ConnMgrConfig.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ConnMgrConfig.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.util.ConfigUtils;
+
+/**
+ * Connection manager config: among other SSL-related configuration and cache key for connection pools (whose scheme
+ * registries are derived from this config).
+ */
+final class ConnMgrConfig {
+
+    /**
+     * Comma-separated list of <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#ciphersuites">Cipher Suites</a> which are enabled for HTTPS connections.
+     */
+    private static final String CIPHER_SUITES = "https.cipherSuites";
+
+    /**
+     * Comma-separated list of <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#jssenames">Protocols</a> which are enabled for HTTPS connections.
+     */
+    private static final String PROTOCOLS = "https.protocols";
+
+    final SSLContext context;
+
+    final HostnameVerifier verifier;
+
+    final String[] cipherSuites;
+
+    final String[] protocols;
+
+    final String httpsSecurityMode;
+
+    final int connectionMaxTtlSeconds;
+
+    final int maxConnectionsPerRoute;
+
+    ConnMgrConfig(
+            RepositorySystemSession session,
+            AuthenticationContext authContext,
+            String httpsSecurityMode,
+            int connectionMaxTtlSeconds,
+            int maxConnectionsPerRoute) {
+        context = (authContext != null) ? authContext.get(AuthenticationContext.SSL_CONTEXT, SSLContext.class) : null;
+        verifier = (authContext != null)
+                ? authContext.get(AuthenticationContext.SSL_HOSTNAME_VERIFIER, HostnameVerifier.class)
+                : null;
+
+        cipherSuites = split(getCipherSuites(session));
+        protocols = split(getProtocols(session));
+        this.httpsSecurityMode = httpsSecurityMode;
+        this.connectionMaxTtlSeconds = connectionMaxTtlSeconds;
+        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+    }
+
+    private static String getCipherSuites(RepositorySystemSession session) {
+        String value = ConfigUtils.getString(
+                session, null, ApacheTransporterConfigurationKeys.CONFIG_PROP_CIPHER_SUITES, CIPHER_SUITES);
+        if (value == null) {
+            value = System.getProperty(CIPHER_SUITES);
+        }
+        return value;
+    }
+
+    private static String getProtocols(RepositorySystemSession session) {
+        String value = ConfigUtils.getString(
+                session, null, ApacheTransporterConfigurationKeys.CONFIG_PROP_PROTOCOLS, PROTOCOLS);
+        if (value == null) {
+            value = System.getProperty(PROTOCOLS);
+        }
+        return value;
+    }
+
+    private static String[] split(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return value.split(",+");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || !getClass().equals(obj.getClass())) {
+            return false;
+        }
+        ConnMgrConfig that = (ConnMgrConfig) obj;
+        return Objects.equals(context, that.context)
+                && Objects.equals(verifier, that.verifier)
+                && Arrays.equals(cipherSuites, that.cipherSuites)
+                && Arrays.equals(protocols, that.protocols)
+                && Objects.equals(httpsSecurityMode, that.httpsSecurityMode)
+                && connectionMaxTtlSeconds == that.connectionMaxTtlSeconds
+                && maxConnectionsPerRoute == that.maxConnectionsPerRoute;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 17;
+        hash = hash * 31 + hash(context);
+        hash = hash * 31 + hash(verifier);
+        hash = hash * 31 + Arrays.hashCode(cipherSuites);
+        hash = hash * 31 + Arrays.hashCode(protocols);
+        hash = hash * 31 + hash(httpsSecurityMode);
+        hash = hash * 31 + hash(connectionMaxTtlSeconds);
+        hash = hash * 31 + hash(maxConnectionsPerRoute);
+        return hash;
+    }
+
+    private static int hash(Object obj) {
+        return obj != null ? obj.hashCode() : 0;
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DeferredCredentialsProvider.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DeferredCredentialsProvider.java
@@ -24,12 +24,13 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.Credentials;
-import org.apache.http.auth.NTCredentials;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.NTCredentials;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.eclipse.aether.repository.AuthenticationContext;
 
 /**
@@ -37,7 +38,7 @@ import org.eclipse.aether.repository.AuthenticationContext;
  */
 final class DeferredCredentialsProvider implements CredentialsProvider {
 
-    private final CredentialsProvider delegate;
+    private final BasicCredentialsProvider delegate;
 
     private final ConcurrentHashMap<AuthScope, Factory> factories;
 
@@ -50,13 +51,12 @@ final class DeferredCredentialsProvider implements CredentialsProvider {
         factories.put(authScope, factory);
     }
 
-    @Override
     public void setCredentials(AuthScope authScope, Credentials credentials) {
         delegate.setCredentials(authScope, credentials);
     }
 
     @Override
-    public Credentials getCredentials(AuthScope authScope) {
+    public Credentials getCredentials(AuthScope authScope, HttpContext context) {
         synchronized (factories) {
             for (Iterator<Map.Entry<AuthScope, Factory>> it =
                             factories.entrySet().iterator();
@@ -64,14 +64,16 @@ final class DeferredCredentialsProvider implements CredentialsProvider {
                 Map.Entry<AuthScope, Factory> entry = it.next();
                 if (authScope.match(entry.getKey()) >= 0) {
                     it.remove();
-                    delegate.setCredentials(entry.getKey(), entry.getValue().newCredentials());
+                    Credentials creds = entry.getValue().newCredentials();
+                    if (creds != null) {
+                        delegate.setCredentials(entry.getKey(), creds);
+                    }
                 }
             }
-            return delegate.getCredentials(authScope);
+            return delegate.getCredentials(authScope, context);
         }
     }
 
-    @Override
     public void clear() {
         delegate.clear();
     }
@@ -96,7 +98,7 @@ final class DeferredCredentialsProvider implements CredentialsProvider {
                 return null;
             }
             String password = authContext.get(AuthenticationContext.PASSWORD);
-            return new UsernamePasswordCredentials(username, password);
+            return new UsernamePasswordCredentials(username, password != null ? password.toCharArray() : new char[0]);
         }
     }
 
@@ -131,7 +133,8 @@ final class DeferredCredentialsProvider implements CredentialsProvider {
                 workstation = guessWorkstation();
             }
 
-            return new NTCredentials(username, password, workstation, domain);
+            return new NTCredentials(
+                    username, password != null ? password.toCharArray() : new char[0], workstation, domain);
         }
 
         private static String guessDomain() {

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DeferredCredentialsProvider.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DeferredCredentialsProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.NTCredentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.eclipse.aether.repository.AuthenticationContext;
+
+/**
+ * Credentials provider that defers calls into the auth context until authentication is actually requested.
+ */
+final class DeferredCredentialsProvider implements CredentialsProvider {
+
+    private final CredentialsProvider delegate;
+
+    private final ConcurrentHashMap<AuthScope, Factory> factories;
+
+    DeferredCredentialsProvider() {
+        delegate = new BasicCredentialsProvider();
+        factories = new ConcurrentHashMap<>();
+    }
+
+    public void setCredentials(AuthScope authScope, Factory factory) {
+        factories.put(authScope, factory);
+    }
+
+    @Override
+    public void setCredentials(AuthScope authScope, Credentials credentials) {
+        delegate.setCredentials(authScope, credentials);
+    }
+
+    @Override
+    public Credentials getCredentials(AuthScope authScope) {
+        synchronized (factories) {
+            for (Iterator<Map.Entry<AuthScope, Factory>> it =
+                            factories.entrySet().iterator();
+                    it.hasNext(); ) {
+                Map.Entry<AuthScope, Factory> entry = it.next();
+                if (authScope.match(entry.getKey()) >= 0) {
+                    it.remove();
+                    delegate.setCredentials(entry.getKey(), entry.getValue().newCredentials());
+                }
+            }
+            return delegate.getCredentials(authScope);
+        }
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    interface Factory {
+
+        Credentials newCredentials();
+    }
+
+    static class BasicFactory implements Factory {
+
+        private final AuthenticationContext authContext;
+
+        BasicFactory(AuthenticationContext authContext) {
+            this.authContext = authContext;
+        }
+
+        @Override
+        public Credentials newCredentials() {
+            String username = authContext.get(AuthenticationContext.USERNAME);
+            if (username == null) {
+                return null;
+            }
+            String password = authContext.get(AuthenticationContext.PASSWORD);
+            return new UsernamePasswordCredentials(username, password);
+        }
+    }
+
+    static class NtlmFactory implements Factory {
+
+        private final AuthenticationContext authContext;
+
+        NtlmFactory(AuthenticationContext authContext) {
+            this.authContext = authContext;
+        }
+
+        @Override
+        public Credentials newCredentials() {
+            String username = authContext.get(AuthenticationContext.USERNAME);
+            if (username == null) {
+                return null;
+            }
+            String password = authContext.get(AuthenticationContext.PASSWORD);
+            String domain = authContext.get(AuthenticationContext.NTLM_DOMAIN);
+            String workstation = authContext.get(AuthenticationContext.NTLM_WORKSTATION);
+
+            if (domain == null) {
+                int backslash = username.indexOf('\\');
+                if (backslash < 0) {
+                    domain = guessDomain();
+                } else {
+                    domain = username.substring(0, backslash);
+                    username = username.substring(backslash + 1);
+                }
+            }
+            if (workstation == null) {
+                workstation = guessWorkstation();
+            }
+
+            return new NTCredentials(username, password, workstation, domain);
+        }
+
+        private static String guessDomain() {
+            return safeNtlmString(System.getProperty("http.auth.ntlm.domain"), System.getenv("USERDOMAIN"));
+        }
+
+        private static String guessWorkstation() {
+            String localHost = null;
+            try {
+                localHost = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                // well, we have other options to try
+            }
+            return safeNtlmString(System.getProperty("http.auth.ntlm.host"), System.getenv("COMPUTERNAME"), localHost);
+        }
+
+        private static String safeNtlmString(String... strings) {
+            for (String string : strings) {
+                if (string != null) {
+                    return string;
+                }
+            }
+            // avoid NPE from httpclient and trigger proper auth failure instead
+            return "";
+        }
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DemuxCredentialsProvider.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DemuxCredentialsProvider.java
@@ -18,10 +18,11 @@
  */
 package org.eclipse.aether.transport.apache5;
 
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.Credentials;
-import org.apache.http.client.CredentialsProvider;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * Credentials provider that helps to isolate server from proxy credentials. Apache HttpClient uses a single provider
@@ -54,18 +55,7 @@ final class DemuxCredentialsProvider implements CredentialsProvider {
     }
 
     @Override
-    public Credentials getCredentials(AuthScope authScope) {
-        return getDelegate(authScope).getCredentials(authScope);
-    }
-
-    @Override
-    public void setCredentials(AuthScope authScope, Credentials credentials) {
-        getDelegate(authScope).setCredentials(authScope, credentials);
-    }
-
-    @Override
-    public void clear() {
-        serverCredentialsProvider.clear();
-        proxyCredentialsProvider.clear();
+    public Credentials getCredentials(AuthScope authScope, HttpContext context) {
+        return getDelegate(authScope).getCredentials(authScope, context);
     }
 }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DemuxCredentialsProvider.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/DemuxCredentialsProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+
+/**
+ * Credentials provider that helps to isolate server from proxy credentials. Apache HttpClient uses a single provider
+ * for both server and proxy auth, using the auth scope (host, port, etc.) to select the proper credentials. With regard
+ * to redirects, we use an auth scope for server credentials that's not specific enough to not be mistaken for proxy
+ * auth. This provider helps to maintain the proper isolation.
+ */
+final class DemuxCredentialsProvider implements CredentialsProvider {
+
+    private final CredentialsProvider serverCredentialsProvider;
+
+    private final CredentialsProvider proxyCredentialsProvider;
+
+    private final HttpHost proxy;
+
+    DemuxCredentialsProvider(
+            CredentialsProvider serverCredentialsProvider,
+            CredentialsProvider proxyCredentialsProvider,
+            HttpHost proxy) {
+        this.serverCredentialsProvider = serverCredentialsProvider;
+        this.proxyCredentialsProvider = proxyCredentialsProvider;
+        this.proxy = proxy;
+    }
+
+    private CredentialsProvider getDelegate(AuthScope authScope) {
+        if (proxy.getPort() == authScope.getPort() && proxy.getHostName().equalsIgnoreCase(authScope.getHost())) {
+            return proxyCredentialsProvider;
+        }
+        return serverCredentialsProvider;
+    }
+
+    @Override
+    public Credentials getCredentials(AuthScope authScope) {
+        return getDelegate(authScope).getCredentials(authScope);
+    }
+
+    @Override
+    public void setCredentials(AuthScope authScope, Credentials credentials) {
+        getDelegate(authScope).setCredentials(authScope, credentials);
+    }
+
+    @Override
+    public void clear() {
+        serverCredentialsProvider.clear();
+        proxyCredentialsProvider.clear();
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/GlobalState.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/GlobalState.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.conn.DefaultHttpClientConnectionOperator;
+import org.apache.http.impl.conn.DefaultSchemePortResolver;
+import org.apache.http.impl.conn.ManagedHttpClientConnectionFactory;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLInitializationException;
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.Keys;
+import org.eclipse.aether.RepositoryCache;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.util.ConfigUtils;
+
+/**
+ * Container for HTTP-related state that can be shared across incarnations of the transporter to optimize the
+ * communication with servers.
+ */
+final class GlobalState implements Closeable {
+
+    static {
+        // force initialization of SSLConnectionSocketFactory class:
+        // ensure that the connection socket factory is initialized before we start using it in any multithreaded
+        // environment, otherwise we may run into a deadlock.
+        // References:
+        // https://github.com/quarkusio/quarkus/issues/55317
+        // https://github.com/quarkusio/quarkus/pull/55345
+        SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+    }
+
+    static class CompoundKey {
+
+        private final Object[] keys;
+
+        CompoundKey(Object... keys) {
+            this.keys = keys;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || !getClass().equals(obj.getClass())) {
+                return false;
+            }
+            CompoundKey that = (CompoundKey) obj;
+            return Arrays.equals(keys, that.keys);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 17;
+            hash = hash * 31 + Arrays.hashCode(keys);
+            return hash;
+        }
+
+        @Override
+        public String toString() {
+            return Arrays.toString(keys);
+        }
+    }
+
+    private static final Object KEY = Keys.of(GlobalState.class);
+
+    private static final String CONFIG_PROP_CACHE_STATE =
+            ApacheTransporterConfigurationKeys.CONFIG_PROPS_PREFIX + "cacheState";
+
+    private final ConcurrentMap<ConnMgrConfig, HttpClientConnectionManager> connectionManagers;
+
+    private final ConcurrentMap<CompoundKey, Object> userTokens;
+
+    private final ConcurrentMap<CompoundKey, Boolean> expectContinues;
+
+    public static GlobalState get(RepositorySystemSession session) {
+        GlobalState cache;
+        RepositoryCache repoCache = session.getCache();
+        if (repoCache == null || !ConfigUtils.getBoolean(session, true, CONFIG_PROP_CACHE_STATE)) {
+            cache = null;
+        } else {
+            Object tmp = repoCache.get(session, KEY);
+            if (tmp instanceof GlobalState) {
+                cache = (GlobalState) tmp;
+            } else {
+                synchronized (GlobalState.class) {
+                    tmp = repoCache.get(session, KEY);
+                    if (tmp instanceof GlobalState) {
+                        cache = (GlobalState) tmp;
+                    } else {
+                        cache = new GlobalState();
+                        repoCache.put(session, KEY, cache);
+                    }
+                }
+            }
+        }
+        return cache;
+    }
+
+    private GlobalState() {
+        connectionManagers = new ConcurrentHashMap<>();
+        userTokens = new ConcurrentHashMap<>();
+        expectContinues = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void close() {
+        for (Iterator<Map.Entry<ConnMgrConfig, HttpClientConnectionManager>> it =
+                        connectionManagers.entrySet().iterator();
+                it.hasNext(); ) {
+            HttpClientConnectionManager connMgr = it.next().getValue();
+            it.remove();
+            connMgr.shutdown();
+        }
+    }
+
+    public HttpClientConnectionManager getConnectionManager(ConnMgrConfig config) {
+        return connectionManagers.computeIfAbsent(config, GlobalState::newConnectionManager);
+    }
+
+    public static HttpClientConnectionManager newConnectionManager(ConnMgrConfig connMgrConfig) {
+        RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.<ConnectionSocketFactory>create()
+                .register("http", PlainConnectionSocketFactory.getSocketFactory());
+        int connectionMaxTtlSeconds = ConfigurationProperties.DEFAULT_HTTP_CONNECTION_MAX_TTL;
+        int maxConnectionsPerRoute = ConfigurationProperties.DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE;
+
+        if (connMgrConfig == null) {
+            registryBuilder.register("https", SSLConnectionSocketFactory.getSystemSocketFactory());
+        } else {
+            // config present: use provided, if any, or create (depending on httpsSecurityMode)
+            connectionMaxTtlSeconds = connMgrConfig.connectionMaxTtlSeconds;
+            maxConnectionsPerRoute = connMgrConfig.maxConnectionsPerRoute;
+            SSLSocketFactory sslSocketFactory =
+                    connMgrConfig.context != null ? connMgrConfig.context.getSocketFactory() : null;
+            HostnameVerifier hostnameVerifier = connMgrConfig.verifier;
+            if (ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT.equals(connMgrConfig.httpsSecurityMode)) {
+                if (sslSocketFactory == null) {
+                    sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+                }
+                if (hostnameVerifier == null) {
+                    hostnameVerifier = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+                }
+            } else if (ConfigurationProperties.HTTPS_SECURITY_MODE_INSECURE.equals(connMgrConfig.httpsSecurityMode)) {
+                if (sslSocketFactory == null) {
+                    try {
+                        sslSocketFactory = new SSLContextBuilder()
+                                .loadTrustMaterial(null, (chain, auth) -> true)
+                                .build()
+                                .getSocketFactory();
+                    } catch (Exception e) {
+                        throw new SSLInitializationException(
+                                "Could not configure '" + connMgrConfig.httpsSecurityMode + "' HTTPS security mode", e);
+                    }
+                }
+                if (hostnameVerifier == null) {
+                    hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported '" + connMgrConfig.httpsSecurityMode + "' HTTPS security mode.");
+            }
+
+            registryBuilder.register(
+                    "https",
+                    new SSLConnectionSocketFactory(
+                            sslSocketFactory, connMgrConfig.protocols, connMgrConfig.cipherSuites, hostnameVerifier));
+        }
+
+        PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager(
+                new DefaultHttpClientConnectionOperator(
+                        registryBuilder.build(), DefaultSchemePortResolver.INSTANCE, SystemDefaultDnsResolver.INSTANCE),
+                ManagedHttpClientConnectionFactory.INSTANCE,
+                connectionMaxTtlSeconds,
+                TimeUnit.SECONDS);
+        connMgr.setMaxTotal(maxConnectionsPerRoute * 2);
+        connMgr.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+        return connMgr;
+    }
+
+    public Object getUserToken(CompoundKey key) {
+        return userTokens.get(key);
+    }
+
+    public void setUserToken(CompoundKey key, Object userToken) {
+        if (userToken != null) {
+            userTokens.put(key, userToken);
+        } else {
+            userTokens.remove(key);
+        }
+    }
+
+    public Boolean getExpectContinue(CompoundKey key) {
+        return expectContinues.get(key);
+    }
+
+    public void setExpectContinue(CompoundKey key, boolean enabled) {
+        expectContinues.put(key, enabled);
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/GlobalState.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/GlobalState.java
@@ -19,6 +19,7 @@
 package org.eclipse.aether.transport.apache5;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
 import java.io.Closeable;
@@ -27,21 +28,15 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.HttpClientConnectionManager;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.conn.DefaultHttpClientConnectionOperator;
-import org.apache.http.impl.conn.DefaultSchemePortResolver;
-import org.apache.http.impl.conn.ManagedHttpClientConnectionFactory;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.impl.conn.SystemDefaultDnsResolver;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.ssl.SSLInitializationException;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLInitializationException;
+import org.apache.hc.core5.util.TimeValue;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.Keys;
 import org.eclipse.aether.RepositoryCache;
@@ -53,16 +48,6 @@ import org.eclipse.aether.util.ConfigUtils;
  * communication with servers.
  */
 final class GlobalState implements Closeable {
-
-    static {
-        // force initialization of SSLConnectionSocketFactory class:
-        // ensure that the connection socket factory is initialized before we start using it in any multithreaded
-        // environment, otherwise we may run into a deadlock.
-        // References:
-        // https://github.com/quarkusio/quarkus/issues/55317
-        // https://github.com/quarkusio/quarkus/pull/55345
-        SSLConnectionSocketFactory.getDefaultHostnameVerifier();
-    }
 
     static class CompoundKey {
 
@@ -145,7 +130,7 @@ final class GlobalState implements Closeable {
                 it.hasNext(); ) {
             HttpClientConnectionManager connMgr = it.next().getValue();
             it.remove();
-            connMgr.shutdown();
+            connMgr.close(org.apache.hc.core5.io.CloseMode.GRACEFUL);
         }
     }
 
@@ -154,34 +139,32 @@ final class GlobalState implements Closeable {
     }
 
     public static HttpClientConnectionManager newConnectionManager(ConnMgrConfig connMgrConfig) {
-        RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.<ConnectionSocketFactory>create()
-                .register("http", PlainConnectionSocketFactory.getSocketFactory());
+        PoolingHttpClientConnectionManagerBuilder builder = PoolingHttpClientConnectionManagerBuilder.create();
         int connectionMaxTtlSeconds = ConfigurationProperties.DEFAULT_HTTP_CONNECTION_MAX_TTL;
         int maxConnectionsPerRoute = ConfigurationProperties.DEFAULT_HTTP_MAX_CONNECTIONS_PER_ROUTE;
 
         if (connMgrConfig == null) {
-            registryBuilder.register("https", SSLConnectionSocketFactory.getSystemSocketFactory());
+            builder.setSSLSocketFactory(SSLConnectionSocketFactory.getSocketFactory());
         } else {
-            // config present: use provided, if any, or create (depending on httpsSecurityMode)
             connectionMaxTtlSeconds = connMgrConfig.connectionMaxTtlSeconds;
             maxConnectionsPerRoute = connMgrConfig.maxConnectionsPerRoute;
-            SSLSocketFactory sslSocketFactory =
-                    connMgrConfig.context != null ? connMgrConfig.context.getSocketFactory() : null;
+
+            SSLContext sslContext = connMgrConfig.context;
             HostnameVerifier hostnameVerifier = connMgrConfig.verifier;
+
             if (ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT.equals(connMgrConfig.httpsSecurityMode)) {
-                if (sslSocketFactory == null) {
-                    sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
-                }
                 if (hostnameVerifier == null) {
-                    hostnameVerifier = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+                    // HttpsSupport.getDefaultHostnameVerifier(), unlike `new DefaultHostnameVerifier()`, wires up a
+                    // PublicSuffixMatcher so a wildcard certificate spanning a public suffix (e.g. *.github.io,
+                    // *.co.uk) is correctly rejected instead of verified.
+                    hostnameVerifier = HttpsSupport.getDefaultHostnameVerifier();
                 }
             } else if (ConfigurationProperties.HTTPS_SECURITY_MODE_INSECURE.equals(connMgrConfig.httpsSecurityMode)) {
-                if (sslSocketFactory == null) {
+                if (sslContext == null) {
                     try {
-                        sslSocketFactory = new SSLContextBuilder()
+                        sslContext = new SSLContextBuilder()
                                 .loadTrustMaterial(null, (chain, auth) -> true)
-                                .build()
-                                .getSocketFactory();
+                                .build();
                     } catch (Exception e) {
                         throw new SSLInitializationException(
                                 "Could not configure '" + connMgrConfig.httpsSecurityMode + "' HTTPS security mode", e);
@@ -195,21 +178,24 @@ final class GlobalState implements Closeable {
                         "Unsupported '" + connMgrConfig.httpsSecurityMode + "' HTTPS security mode.");
             }
 
-            registryBuilder.register(
-                    "https",
-                    new SSLConnectionSocketFactory(
-                            sslSocketFactory, connMgrConfig.protocols, connMgrConfig.cipherSuites, hostnameVerifier));
+            SSLConnectionSocketFactory sslSocketFactory;
+            if (sslContext != null) {
+                sslSocketFactory = new SSLConnectionSocketFactory(
+                        sslContext, connMgrConfig.protocols, connMgrConfig.cipherSuites, hostnameVerifier);
+            } else {
+                sslSocketFactory = new SSLConnectionSocketFactory(
+                        (SSLSocketFactory) SSLSocketFactory.getDefault(),
+                        connMgrConfig.protocols,
+                        connMgrConfig.cipherSuites,
+                        hostnameVerifier);
+            }
+            builder.setSSLSocketFactory(sslSocketFactory);
         }
 
-        PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager(
-                new DefaultHttpClientConnectionOperator(
-                        registryBuilder.build(), DefaultSchemePortResolver.INSTANCE, SystemDefaultDnsResolver.INSTANCE),
-                ManagedHttpClientConnectionFactory.INSTANCE,
-                connectionMaxTtlSeconds,
-                TimeUnit.SECONDS);
-        connMgr.setMaxTotal(maxConnectionsPerRoute * 2);
-        connMgr.setDefaultMaxPerRoute(maxConnectionsPerRoute);
-        return connMgr;
+        builder.setMaxConnTotal(maxConnectionsPerRoute * 2);
+        builder.setMaxConnPerRoute(maxConnectionsPerRoute);
+        builder.setConnectionTimeToLive(TimeValue.ofSeconds(connectionMaxTtlSeconds));
+        return builder.build();
     }
 
     public Object getUserToken(CompoundKey key) {

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/HttpMkCol.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/HttpMkCol.java
@@ -20,19 +20,16 @@ package org.eclipse.aether.transport.apache5;
 
 import java.net.URI;
 
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 
 /**
  * WebDAV MKCOL request to create parent directories.
  */
-final class HttpMkCol extends HttpRequestBase {
+final class HttpMkCol extends HttpUriRequestBase {
+
+    public static final String METHOD_NAME = "MKCOL";
 
     HttpMkCol(URI uri) {
-        setURI(uri);
-    }
-
-    @Override
-    public String getMethod() {
-        return "MKCOL";
+        super(METHOD_NAME, uri);
     }
 }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/HttpMkCol.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/HttpMkCol.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.net.URI;
+
+import org.apache.http.client.methods.HttpRequestBase;
+
+/**
+ * WebDAV MKCOL request to create parent directories.
+ */
+final class HttpMkCol extends HttpRequestBase {
+
+    HttpMkCol(URI uri) {
+        setURI(uri);
+    }
+
+    @Override
+    public String getMethod() {
+        return "MKCOL";
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/LocalState.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/LocalState.java
@@ -20,7 +20,7 @@ package org.eclipse.aether.transport.apache5;
 
 import java.io.Closeable;
 
-import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 
@@ -102,7 +102,7 @@ final class LocalState implements Closeable {
     @Override
     public void close() {
         if (global == null) {
-            connMgr.shutdown();
+            connMgr.close(org.apache.hc.core5.io.CloseMode.GRACEFUL);
         }
     }
 }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/LocalState.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/LocalState.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.io.Closeable;
+
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Container for HTTP-related state that can be shared across invocations of the transporter to optimize the
+ * communication with server.
+ */
+final class LocalState implements Closeable {
+    private final GlobalState global;
+
+    private final HttpClientConnectionManager connMgr;
+
+    private final GlobalState.CompoundKey userTokenKey;
+
+    private volatile Object userToken;
+
+    private final GlobalState.CompoundKey expectContinueKey;
+
+    private volatile Boolean expectContinue;
+
+    private volatile Boolean webDav;
+
+    LocalState(RepositorySystemSession session, RemoteRepository repo, ConnMgrConfig connMgrConfig) {
+        global = GlobalState.get(session);
+        userToken = this;
+        if (global == null) {
+            connMgr = GlobalState.newConnectionManager(connMgrConfig);
+            userTokenKey = null;
+            expectContinueKey = null;
+        } else {
+            connMgr = global.getConnectionManager(connMgrConfig);
+            userTokenKey =
+                    new GlobalState.CompoundKey(repo.getId(), repo.getUrl(), repo.getAuthentication(), repo.getProxy());
+            expectContinueKey = new GlobalState.CompoundKey(repo.getUrl(), repo.getProxy());
+        }
+    }
+
+    public HttpClientConnectionManager getConnectionManager() {
+        return connMgr;
+    }
+
+    public Object getUserToken() {
+        if (userToken == this) {
+            userToken = (global != null) ? global.getUserToken(userTokenKey) : null;
+        }
+        return userToken;
+    }
+
+    public void setUserToken(Object userToken) {
+        this.userToken = userToken;
+        if (global != null) {
+            global.setUserToken(userTokenKey, userToken);
+        }
+    }
+
+    public boolean isExpectContinue() {
+        if (expectContinue == null) {
+            expectContinue =
+                    !Boolean.FALSE.equals((global != null) ? global.getExpectContinue(expectContinueKey) : null);
+        }
+        return expectContinue;
+    }
+
+    public void setExpectContinue(boolean enabled) {
+        expectContinue = enabled;
+        if (global != null) {
+            global.setExpectContinue(expectContinueKey, enabled);
+        }
+    }
+
+    public Boolean getWebDav() {
+        return webDav;
+    }
+
+    public void setWebDav(boolean webDav) {
+        this.webDav = webDav;
+    }
+
+    @Override
+    public void close() {
+        if (global == null) {
+            connMgr.shutdown();
+        }
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptor.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptor.java
@@ -18,15 +18,18 @@
  */
 package org.eclipse.aether.transport.apache5;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpCoreContext;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * Scopes operator-configured request headers ({@code aether.transport.http.headers}) to the repository origin.
@@ -58,13 +61,20 @@ final class OriginScopedHeadersInterceptor implements HttpRequestInterceptor {
     }
 
     @Override
-    public void process(HttpRequest request, HttpContext context) {
+    public void process(HttpRequest request, EntityDetails entity, HttpContext context)
+            throws HttpException, IOException {
         if (headerNames.isEmpty()) {
             return;
         }
-        Object attribute = context != null ? context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST) : null;
+        HttpHost target = null;
+        if (context != null) {
+            HttpClientContext clientContext = HttpClientContext.cast(context);
+            if (clientContext.getHttpRoute() != null) {
+                target = clientContext.getHttpRoute().getTargetHost();
+            }
+        }
         // fail closed: when the target host cannot be determined, do not attach configured headers
-        if (!(attribute instanceof HttpHost) || !isSameOrigin(origin, (HttpHost) attribute)) {
+        if (target == null || !isSameOrigin(origin, target)) {
             for (String headerName : headerNames) {
                 request.removeHeaders(headerName);
             }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptor.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+/**
+ * Scopes operator-configured request headers ({@code aether.transport.http.headers}) to the repository origin.
+ * <p>
+ * Configured headers are stamped on every request the transport creates and frequently carry credentials
+ * ({@code Authorization}, cookies, private token headers). Apache HttpClient's redirect execution re-sends the
+ * original request headers on each redirect hop, including hops that leave the repository origin, which would
+ * replay those credentials to the redirect target. This interceptor runs in the protocol layer - which HttpClient
+ * re-enters for every redirect hop - and removes the configured headers from any request whose target host is not
+ * the repository origin (same scheme, host and effective port). Challenge- and preemptive-authentication headers
+ * are attached below the protocol layer and are host-scoped by the credentials provider already; they are not
+ * affected by this interceptor.
+ *
+ * @since 2.0.23
+ */
+final class OriginScopedHeadersInterceptor implements HttpRequestInterceptor {
+    private final HttpHost origin;
+
+    private final Set<String> headerNames;
+
+    OriginScopedHeadersInterceptor(HttpHost origin, Collection<?> headerNames) {
+        this.origin = origin;
+        this.headerNames = new HashSet<>();
+        for (Object headerName : headerNames) {
+            if (headerName != null) {
+                this.headerNames.add(String.valueOf(headerName));
+            }
+        }
+    }
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) {
+        if (headerNames.isEmpty()) {
+            return;
+        }
+        Object attribute = context != null ? context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST) : null;
+        // fail closed: when the target host cannot be determined, do not attach configured headers
+        if (!(attribute instanceof HttpHost) || !isSameOrigin(origin, (HttpHost) attribute)) {
+            for (String headerName : headerNames) {
+                request.removeHeaders(headerName);
+            }
+        }
+    }
+
+    static boolean isSameOrigin(HttpHost origin, HttpHost target) {
+        return origin.getSchemeName().equalsIgnoreCase(target.getSchemeName())
+                && origin.getHostName().equalsIgnoreCase(target.getHostName())
+                && schemeDefaultPort(origin) == schemeDefaultPort(target);
+    }
+
+    /**
+     * Determines the effective port of the given host: the explicit port if present, otherwise the default port
+     * implied by the scheme.
+     */
+    static int schemeDefaultPort(HttpHost host) {
+        if (host.getPort() >= 0) {
+            return host.getPort();
+        }
+        return "https".equalsIgnoreCase(host.getSchemeName()) ? 443 : 80;
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategy.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.net.URI;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * A redirect strategy that refuses protocol downgrades: a redirect from an {@code https} URL to an {@code http}
+ * URL strips transport encryption from artifact and checksum bytes and makes repository credentials eligible for
+ * transmission over plaintext, so it fails the transfer instead of being followed silently, unless explicitly
+ * allowed via {@link ApacheTransporterConfigurationKeys#CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS}. All other
+ * redirects behave exactly as {@link LaxRedirectStrategy} handled them before.
+ *
+ * @since 2.0.23
+ */
+final class ResolverRedirectStrategy extends LaxRedirectStrategy {
+    private final boolean followInsecureRedirects;
+
+    ResolverRedirectStrategy(boolean followInsecureRedirects) {
+        this.followInsecureRedirects = followInsecureRedirects;
+    }
+
+    @Override
+    public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context)
+            throws ProtocolException {
+        boolean redirected = super.isRedirected(request, response, context);
+        if (redirected && !followInsecureRedirects) {
+            Header locationHeader = response.getFirstHeader("location");
+            if (locationHeader != null) {
+                URI location = createLocationURI(locationHeader.getValue());
+                String locationScheme = location.getScheme();
+                String currentScheme = currentScheme(request, context);
+                if (locationScheme != null
+                        && "https".equalsIgnoreCase(currentScheme)
+                        && !"https".equalsIgnoreCase(locationScheme)) {
+                    throw new ProtocolException("Insecure redirect to '" + location
+                            + "' not followed: protocol downgrade from https to " + locationScheme
+                            + " would expose credentials and artifact content; set the configuration property "
+                            + ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS
+                            + "=true to allow it");
+                }
+            }
+        }
+        return redirected;
+    }
+
+    private static String currentScheme(HttpRequest request, HttpContext context) {
+        HttpHost target = context != null ? HttpClientContext.adapt(context).getTargetHost() : null;
+        if (target != null) {
+            return target.getSchemeName();
+        }
+        if (request instanceof HttpUriRequest) {
+            URI uri = ((HttpUriRequest) request).getURI();
+            if (uri != null && uri.isAbsolute()) {
+                return uri.getScheme();
+            }
+        }
+        return null;
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategy.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategy.java
@@ -20,26 +20,24 @@ package org.eclipse.aether.transport.apache5;
 
 import java.net.URI;
 
-import org.apache.http.Header;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolException;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * A redirect strategy that refuses protocol downgrades: a redirect from an {@code https} URL to an {@code http}
  * URL strips transport encryption from artifact and checksum bytes and makes repository credentials eligible for
  * transmission over plaintext, so it fails the transfer instead of being followed silently, unless explicitly
  * allowed via {@link ApacheTransporterConfigurationKeys#CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS}. All other
- * redirects behave exactly as {@link LaxRedirectStrategy} handled them before.
+ * redirects behave exactly as {@link DefaultRedirectStrategy} handles them.
  *
  * @since 2.0.23
  */
-final class ResolverRedirectStrategy extends LaxRedirectStrategy {
+final class ResolverRedirectStrategy extends DefaultRedirectStrategy {
     private final boolean followInsecureRedirects;
 
     ResolverRedirectStrategy(boolean followInsecureRedirects) {
@@ -51,9 +49,13 @@ final class ResolverRedirectStrategy extends LaxRedirectStrategy {
             throws ProtocolException {
         boolean redirected = super.isRedirected(request, response, context);
         if (redirected && !followInsecureRedirects) {
-            Header locationHeader = response.getFirstHeader("location");
-            if (locationHeader != null) {
-                URI location = createLocationURI(locationHeader.getValue());
+            URI location;
+            try {
+                location = getLocationURI(request, response, context);
+            } catch (HttpException e) {
+                throw new ProtocolException("Invalid redirect location: " + e.getMessage(), e);
+            }
+            if (location != null) {
                 String locationScheme = location.getScheme();
                 String currentScheme = currentScheme(request, context);
                 if (locationScheme != null
@@ -71,15 +73,22 @@ final class ResolverRedirectStrategy extends LaxRedirectStrategy {
     }
 
     private static String currentScheme(HttpRequest request, HttpContext context) {
-        HttpHost target = context != null ? HttpClientContext.adapt(context).getTargetHost() : null;
-        if (target != null) {
-            return target.getSchemeName();
+        if (context != null) {
+            HttpClientContext clientContext = HttpClientContext.cast(context);
+            if (clientContext.getHttpRoute() != null) {
+                return clientContext.getHttpRoute().getTargetHost().getSchemeName();
+            }
         }
-        if (request instanceof HttpUriRequest) {
-            URI uri = ((HttpUriRequest) request).getURI();
+        if (request.getScheme() != null) {
+            return request.getScheme();
+        }
+        try {
+            URI uri = request.getUri();
             if (uri != null && uri.isAbsolute()) {
                 return uri.getScheme();
             }
+        } catch (Exception e) {
+            // ignore
         }
         return null;
     }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/SharingHttpContext.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/SharingHttpContext.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import org.apache.http.client.protocol.HttpClientContext;
+
+/**
+ * HTTP context that shares certain attributes among requests to optimize the communication with the server.
+ *
+ * @see <a href="http://hc.apache.org/httpcomponents-client-ga/tutorial/html/advanced.html#stateful_conn">Stateful HTTP
+ *      connections</a>
+ */
+final class SharingHttpContext extends HttpClientContext {
+
+    private final LocalState state;
+
+    SharingHttpContext(LocalState state) {
+        this.state = state;
+    }
+
+    @Override
+    public Object getAttribute(String id) {
+        if (HttpClientContext.USER_TOKEN.equals(id)) {
+            return state.getUserToken();
+        }
+        return super.getAttribute(id);
+    }
+
+    @Override
+    public void setAttribute(String id, Object obj) {
+        if (HttpClientContext.USER_TOKEN.equals(id)) {
+            state.setUserToken(obj);
+        } else {
+            super.setAttribute(id, obj);
+        }
+    }
+
+    @Override
+    public Object removeAttribute(String id) {
+        if (HttpClientContext.USER_TOKEN.equals(id)) {
+            state.setUserToken(null);
+            return null;
+        }
+        return super.removeAttribute(id);
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/SharingHttpContext.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/SharingHttpContext.java
@@ -18,45 +18,26 @@
  */
 package org.eclipse.aether.transport.apache5;
 
-import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 
 /**
  * HTTP context that shares certain attributes among requests to optimize the communication with the server.
+ *
+ * <p>Apache HttpClient 5 stores the per-connection user token (see {@link #getUserToken()}/{@link
+ * #setUserToken(Object)}) in a private typed field, not via the generic {@link #getAttribute(String)}/{@link
+ * #setAttribute(String, Object)} map, so seeding and capturing it must go through the typed accessors: this class
+ * seeds the token persisted in {@link LocalState} into the new context here, and the caller reads it back with
+ * {@link #getUserToken()} after the request completes to persist it again.
  *
  * @see <a href="http://hc.apache.org/httpcomponents-client-ga/tutorial/html/advanced.html#stateful_conn">Stateful HTTP
  *      connections</a>
  */
 final class SharingHttpContext extends HttpClientContext {
 
-    private final LocalState state;
-
     SharingHttpContext(LocalState state) {
-        this.state = state;
-    }
-
-    @Override
-    public Object getAttribute(String id) {
-        if (HttpClientContext.USER_TOKEN.equals(id)) {
-            return state.getUserToken();
+        Object token = state.getUserToken();
+        if (token != null) {
+            setUserToken(token);
         }
-        return super.getAttribute(id);
-    }
-
-    @Override
-    public void setAttribute(String id, Object obj) {
-        if (HttpClientContext.USER_TOKEN.equals(id)) {
-            state.setUserToken(obj);
-        } else {
-            super.setAttribute(id, obj);
-        }
-    }
-
-    @Override
-    public Object removeAttribute(String id) {
-        if (HttpClientContext.USER_TOKEN.equals(id)) {
-            state.setUserToken(null);
-            return null;
-        }
-        return super.removeAttribute(id);
     }
 }

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/UriUtils.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/UriUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.client.utils.URIUtils;
+
+/**
+ * Helps to deal with URIs.
+ */
+final class UriUtils {
+
+    public static URI resolve(URI base, URI ref) {
+        String path = ref.getRawPath();
+        if (path != null && !path.isEmpty()) {
+            path = base.getRawPath();
+            if (path == null || !path.endsWith("/")) {
+                try {
+                    base = new URI(base.getScheme(), base.getAuthority(), base.getPath() + '/', null, null);
+                } catch (URISyntaxException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+        return URIUtils.resolve(base, ref);
+    }
+
+    public static List<URI> getDirectories(URI base, URI uri) {
+        List<URI> dirs = new ArrayList<>();
+        for (URI dir = uri.resolve("."); !isBase(base, dir); dir = dir.resolve("..")) {
+            dirs.add(dir);
+        }
+        return dirs;
+    }
+
+    private static boolean isBase(URI base, URI uri) {
+        String path = uri.getRawPath();
+        if (path == null || "/".equals(path)) {
+            return true;
+        }
+        if (base != null) {
+            URI rel = base.relativize(uri);
+            if (rel.getRawPath() == null || rel.getRawPath().isEmpty() || rel.equals(uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/UriUtils.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/UriUtils.java
@@ -23,8 +23,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.http.client.utils.URIUtils;
-
 /**
  * Helps to deal with URIs.
  */
@@ -42,7 +40,7 @@ final class UriUtils {
                 }
             }
         }
-        return URIUtils.resolve(base, ref);
+        return org.apache.hc.client5.http.utils.URIUtils.resolve(base, ref);
     }
 
     public static List<URI> getDirectories(URI base, URI uri) {

--- a/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/package-info.java
+++ b/maven-resolver-transport-apache5/src/main/java/org/eclipse/aether/transport/apache5/package-info.java
@@ -1,0 +1,24 @@
+// CHECKSTYLE_OFF: RegexpHeader
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Support for downloads/uploads via the HTTP and HTTPS protocols. The current implementation is backed by
+ * <a href="http://hc.apache.org/httpcomponents-client-ga/" target="_blank">Apache HttpClient</a>.
+ */
+package org.eclipse.aether.transport.apache5;

--- a/maven-resolver-transport-apache5/src/site/site.xml
+++ b/maven-resolver-transport-apache5/src/site/site.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd" name="Transport Apache">
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="JavaDocs" href="apidocs/index.html"/>
+      <item name="Source Xref" href="xref/index.html"/>
+      <!--item name="FAQ" href="faq.html"/-->
+    </menu>
+
+    <menu ref="parent"/>
+    <menu ref="reports"/>
+  </body>
+</site>

--- a/maven-resolver-transport-apache5/src/site/site.xml
+++ b/maven-resolver-transport-apache5/src/site/site.xml
@@ -21,7 +21,7 @@ under the License.
 
 
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd" name="Transport Apache">
+      xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd" name="Transport Apache 5">
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.apache.http.pool.ConnPoolControl;
+import org.apache.http.pool.PoolStats;
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.DefaultRepositoryCache;
+import org.eclipse.aether.internal.test.util.TestFileUtils;
+import org.eclipse.aether.internal.test.util.http.HttpTransporterTest;
+import org.eclipse.aether.internal.test.util.http.RecordingTransportListener;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.io.PathProcessorSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Apache Transporter UT.
+ * It does support WebDAV.
+ */
+class ApacheTransporterTest extends HttpTransporterTest {
+
+    public ApacheTransporterTest() {
+        super(() -> new ApacheTransporterFactory(standardChecksumExtractor(), new PathProcessorSupport()));
+    }
+
+    @Override
+    protected Stream<String> supportedCompressionAlgorithms() {
+        return Stream.of("gzip", "deflate");
+    }
+
+    protected boolean exposeContentCodingInTransportProperties() {
+        // see https://issues.apache.org/jira/browse/HTTPCORE-792
+        return false;
+    }
+
+    @Override
+    protected boolean supportsHttp3() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsHttp2() {
+        return false;
+    }
+
+    @AfterEach
+    @Override
+    protected void tearDown() throws Exception {
+        // make sure to also release any connection in the global state (otherwise the check for connection leaks will
+        // fail)
+        GlobalState globalState = GlobalState.get(session);
+        if (globalState != null) {
+            globalState.close();
+        }
+        super.tearDown();
+    }
+
+    @Test
+    void testGet_WebDav() throws Exception {
+        httpServer.setWebDav(true);
+        RecordingTransportListener listener = new RecordingTransportListener();
+        GetTask task = new GetTask(URI.create("repo/dir/file.txt")).setListener(listener);
+        ((ApacheTransporter) transporter).getState().setWebDav(true);
+        transporter.get(task);
+        assertEquals("test", task.getDataString());
+        assertEquals(0L, listener.getDataOffset());
+        assertEquals(4L, listener.getDataLength());
+        assertEquals(1, listener.getStartedCount());
+        assertTrue(listener.getProgressedCount() > 0, "Count: " + listener.getProgressedCount());
+        assertEquals(task.getDataString(), new String(listener.getBaos().toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(
+                1, httpServer.getLogEntries().size(), httpServer.getLogEntries().toString());
+    }
+
+    @Test
+    void testPut_WebDav() throws Exception {
+        httpServer.setWebDav(true);
+        session.setConfigProperty(ConfigurationProperties.HTTP_SUPPORT_WEBDAV, true);
+        newTransporter(httpServer.getHttpUrl());
+
+        RecordingTransportListener listener = new RecordingTransportListener();
+        PutTask task = new PutTask(URI.create("repo/dir1/dir2/file.txt"))
+                .setListener(listener)
+                .setDataString("upload");
+        transporter.put(task);
+        assertEquals(0L, listener.getDataOffset());
+        assertEquals(6L, listener.getDataLength());
+        assertEquals(1, listener.getStartedCount());
+        assertTrue(listener.getProgressedCount() > 0, "Count: " + listener.getProgressedCount());
+        assertEquals("upload", TestFileUtils.readString(new File(repoDir, "dir1/dir2/file.txt")));
+
+        assertEquals(
+                5, httpServer.getLogEntries().size(), "Expected 5 requests but got: " + httpServer.getLogEntries());
+        assertEquals("OPTIONS", httpServer.getLogEntries().get(0).getMethod());
+        assertEquals("MKCOL", httpServer.getLogEntries().get(1).getMethod());
+        assertEquals("/repo/dir1/dir2/", httpServer.getLogEntries().get(1).getPath());
+        assertEquals("MKCOL", httpServer.getLogEntries().get(2).getMethod());
+        assertEquals("/repo/dir1/", httpServer.getLogEntries().get(2).getPath());
+        assertEquals("MKCOL", httpServer.getLogEntries().get(3).getMethod());
+        assertEquals("/repo/dir1/dir2/", httpServer.getLogEntries().get(3).getPath());
+        assertEquals("PUT", httpServer.getLogEntries().get(4).getMethod());
+    }
+
+    @Test
+    void testConnectionReuse() throws Exception {
+        httpServer.addHttp2ConnectorWithMutualTLS();
+        session.setCache(new DefaultRepositoryCache());
+        for (int i = 0; i < 3; i++) {
+            newTransporter(httpServer.getHttpsUrl());
+            GetTask task = new GetTask(URI.create("repo/file.txt"));
+            transporter.get(task);
+            assertEquals("test", task.getDataString());
+        }
+        PoolStats stats = ((ConnPoolControl<?>)
+                        ((ApacheTransporter) transporter).getState().getConnectionManager())
+                .getTotalStats();
+        assertEquals(1, stats.getAvailable(), stats.toString());
+    }
+
+    @Test
+    void testConnectionNoReuse() throws Exception {
+        httpServer.addHttp2ConnectorWithMutualTLS();
+        session.setCache(new DefaultRepositoryCache());
+        session.setConfigProperty(ConfigurationProperties.HTTP_REUSE_CONNECTIONS, false);
+        for (int i = 0; i < 3; i++) {
+            newTransporter(httpServer.getHttpsUrl());
+            GetTask task = new GetTask(URI.create("repo/file.txt"));
+            transporter.get(task);
+            assertEquals("test", task.getDataString());
+        }
+        PoolStats stats = ((ConnPoolControl<?>)
+                        ((ApacheTransporter) transporter).getState().getConnectionManager())
+                .getTotalStats();
+        assertEquals(0, stats.getAvailable(), stats.toString());
+    }
+}

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ApacheTransporterTest extends HttpTransporterTest {
 
     public ApacheTransporterTest() {
-        super(() -> new ApacheTransporterFactory(standardChecksumExtractor(), new PathProcessorSupport()));
+        super(() -> new Apache5TransporterFactory(standardChecksumExtractor(), new PathProcessorSupport()));
     }
 
     @Override

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ApacheTransporterTest.java
@@ -23,8 +23,8 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.apache.http.pool.ConnPoolControl;
-import org.apache.http.pool.PoolStats;
+import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.pool.PoolStats;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositoryCache;
 import org.eclipse.aether.internal.test.util.TestFileUtils;

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptorTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.util.Arrays;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UT for {@link OriginScopedHeadersInterceptor}: configured headers must only be sent to the repository origin;
+ * any other target (cross-host, downgraded scheme or different port - e.g. after a redirect) must not receive them.
+ */
+public class OriginScopedHeadersInterceptorTest {
+    private static final HttpHost ORIGIN = new HttpHost("repo.example.com", -1, "https");
+
+    private final OriginScopedHeadersInterceptor interceptor =
+            new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList("Authorization", "Private-Token"));
+
+    private static HttpRequest newRequestWithConfiguredHeaders() {
+        HttpRequest request = new BasicHttpRequest("GET", "/base/g/a/1.0/a-1.0.jar");
+        request.setHeader("Authorization", "Bearer s3cr3t");
+        request.setHeader("Private-Token", "t0ken");
+        request.setHeader("Accept", "*/*");
+        return request;
+    }
+
+    private static HttpContext contextTargeting(HttpHost target) {
+        HttpCoreContext context = HttpCoreContext.create();
+        if (target != null) {
+            context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+        }
+        return context;
+    }
+
+    private static void assertConfiguredHeadersPresent(HttpRequest request) {
+        assertTrue(request.containsHeader("Authorization"));
+        assertTrue(request.containsHeader("Private-Token"));
+        assertTrue(request.containsHeader("Accept"));
+    }
+
+    private static void assertConfiguredHeadersStripped(HttpRequest request) {
+        assertFalse(request.containsHeader("Authorization"));
+        assertFalse(request.containsHeader("Private-Token"));
+        // headers not coming from the configured map are left alone
+        assertTrue(request.containsHeader("Accept"));
+    }
+
+    @Test
+    void keepsHeadersForOrigin() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    void keepsHeadersForOriginWithExplicitDefaultPort() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 443, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    void keepsHeadersForOriginWithDifferentHostCase() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("REPO.Example.COM", -1, "HTTPS")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    void stripsHeadersForCrossHostTarget() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    void stripsHeadersForSchemeDowngradeOnSameHost() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "http")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    void stripsHeadersForDifferentPortOnSameHost() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 8443, "https")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    void stripsHeadersWhenTargetHostUnknown() throws Exception {
+        // fail closed: no determinable target means configured headers are not attached
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(null));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    void noConfiguredHeadersIsNoOp() throws Exception {
+        OriginScopedHeadersInterceptor empty =
+                new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList(new Object[] {null}));
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        empty.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    void effectivePortFollowsScheme() {
+        assertEquals(443, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "https")));
+        assertEquals(80, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "http")));
+        assertEquals(8081, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", 8081, "https")));
+    }
+}

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptorTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/OriginScopedHeadersInterceptorTest.java
@@ -20,11 +20,10 @@ package org.eclipse.aether.transport.apache5;
 
 import java.util.Arrays;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.message.BasicHttpRequest;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * any other target (cross-host, downgraded scheme or different port - e.g. after a redirect) must not receive them.
  */
 public class OriginScopedHeadersInterceptorTest {
-    private static final HttpHost ORIGIN = new HttpHost("repo.example.com", -1, "https");
+    private static final HttpHost ORIGIN = new HttpHost("https", "repo.example.com", -1);
 
     private final OriginScopedHeadersInterceptor interceptor =
             new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList("Authorization", "Private-Token"));
@@ -50,9 +49,15 @@ public class OriginScopedHeadersInterceptorTest {
     }
 
     private static HttpContext contextTargeting(HttpHost target) {
-        HttpCoreContext context = HttpCoreContext.create();
+        org.apache.hc.client5.http.protocol.HttpClientContext context =
+                org.apache.hc.client5.http.protocol.HttpClientContext.create();
         if (target != null) {
-            context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+            int port = target.getPort() >= 0
+                    ? target.getPort()
+                    : ("https".equalsIgnoreCase(target.getSchemeName()) ? 443 : 80);
+            context.setRoute(new org.apache.hc.client5.http.HttpRoute(
+                    new HttpHost(target.getSchemeName(), target.getHostName(), port)));
+            context.setAttribute("http.target_host", target);
         }
         return context;
     }
@@ -73,42 +78,42 @@ public class OriginScopedHeadersInterceptorTest {
     @Test
     void keepsHeadersForOrigin() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "https")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("https", "repo.example.com", -1)));
         assertConfiguredHeadersPresent(request);
     }
 
     @Test
     void keepsHeadersForOriginWithExplicitDefaultPort() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 443, "https")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("https", "repo.example.com", 443)));
         assertConfiguredHeadersPresent(request);
     }
 
     @Test
     void keepsHeadersForOriginWithDifferentHostCase() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("REPO.Example.COM", -1, "HTTPS")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("HTTPS", "REPO.Example.COM", -1)));
         assertConfiguredHeadersPresent(request);
     }
 
     @Test
     void stripsHeadersForCrossHostTarget() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("https", "cdn.example.net", -1)));
         assertConfiguredHeadersStripped(request);
     }
 
     @Test
     void stripsHeadersForSchemeDowngradeOnSameHost() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "http")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("http", "repo.example.com", -1)));
         assertConfiguredHeadersStripped(request);
     }
 
     @Test
     void stripsHeadersForDifferentPortOnSameHost() throws Exception {
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 8443, "https")));
+        interceptor.process(request, null, contextTargeting(new HttpHost("https", "repo.example.com", 8443)));
         assertConfiguredHeadersStripped(request);
     }
 
@@ -116,7 +121,7 @@ public class OriginScopedHeadersInterceptorTest {
     void stripsHeadersWhenTargetHostUnknown() throws Exception {
         // fail closed: no determinable target means configured headers are not attached
         HttpRequest request = newRequestWithConfiguredHeaders();
-        interceptor.process(request, contextTargeting(null));
+        interceptor.process(request, null, contextTargeting(null));
         assertConfiguredHeadersStripped(request);
     }
 
@@ -125,14 +130,14 @@ public class OriginScopedHeadersInterceptorTest {
         OriginScopedHeadersInterceptor empty =
                 new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList(new Object[] {null}));
         HttpRequest request = newRequestWithConfiguredHeaders();
-        empty.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        empty.process(request, null, contextTargeting(new HttpHost("https", "cdn.example.net", -1)));
         assertConfiguredHeadersPresent(request);
     }
 
     @Test
     void effectivePortFollowsScheme() {
-        assertEquals(443, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "https")));
-        assertEquals(80, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "http")));
-        assertEquals(8081, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", 8081, "https")));
+        assertEquals(443, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("https", "h", -1)));
+        assertEquals(80, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("http", "h", -1)));
+        assertEquals(8081, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("https", "h", 8081)));
     }
 }

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategyTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * UT for {@link ResolverRedirectStrategy}: https-to-http downgrade redirects must not be followed silently, and
+ * repository credentials must be bound to the repository's scheme-implied port.
+ */
+class ResolverRedirectStrategyTest {
+    private static HttpResponse redirectResponse(String location) {
+        HttpResponse response = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 302, "Found"));
+        response.setHeader("Location", location);
+        return response;
+    }
+
+    private static HttpContext contextWithTarget(HttpHost target) {
+        HttpClientContext context = HttpClientContext.create();
+        context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+        return context;
+    }
+
+    @Test
+    void httpsToHttpRedirectRefusedByDefault() {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        ProtocolException e =
+                assertThrows(ProtocolException.class, () -> strategy.isRedirected(request, response, context));
+        assertTrue(e.getMessage().contains(ApacheTransporterConfigurationKeys.CONFIG_PROP_FOLLOW_INSECURE_REDIRECTS));
+    }
+
+    @Test
+    void httpsToHttpCrossHostRedirectRefusedByDefault() {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://evil.example.org/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertThrows(ProtocolException.class, () -> strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    void httpsToHttpsRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("https://mirror.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    void relativeRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("/elsewhere/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    void httpToHttpRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://mirror.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 80, "http"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    void httpsToHttpRedirectFollowedWhenExplicitlyAllowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(true);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    void currentSchemeFallsBackToRequestUriWithoutContextTarget() {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+
+        assertThrows(
+                ProtocolException.class, () -> strategy.isRedirected(request, response, HttpClientContext.create()));
+    }
+
+    @Test
+    void repositoryCredentialScopeIsBoundToSchemeImpliedPort() {
+        assertEquals(443, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", -1, "https")));
+        assertEquals(80, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", -1, "http")));
+        assertEquals(8443, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", 8443, "https")));
+        assertEquals(8081, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", 8081, "http")));
+    }
+}

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategyTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/ResolverRedirectStrategyTest.java
@@ -18,16 +18,14 @@
  */
 package org.eclipse.aether.transport.apache5;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpVersion;
-import org.apache.http.ProtocolException;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpCoreContext;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,14 +38,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ResolverRedirectStrategyTest {
     private static HttpResponse redirectResponse(String location) {
-        HttpResponse response = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 302, "Found"));
+        HttpResponse response = new BasicHttpResponse(302, "Found");
         response.setHeader("Location", location);
         return response;
     }
 
     private static HttpContext contextWithTarget(HttpHost target) {
         HttpClientContext context = HttpClientContext.create();
-        context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+        if (target != null) {
+            context.setAttribute("http.target_host", target);
+            context.setRoute(new HttpRoute(target));
+        }
         return context;
     }
 
@@ -56,7 +57,7 @@ class ResolverRedirectStrategyTest {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
         HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+        HttpContext context = contextWithTarget(new HttpHost("https", "repo.example.com", 443));
 
         ProtocolException e =
                 assertThrows(ProtocolException.class, () -> strategy.isRedirected(request, response, context));
@@ -68,47 +69,47 @@ class ResolverRedirectStrategyTest {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
         HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("http://evil.example.org/g/a/1.0/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+        HttpContext context = contextWithTarget(new HttpHost("https", "repo.example.com", 443));
 
         assertThrows(ProtocolException.class, () -> strategy.isRedirected(request, response, context));
     }
 
     @Test
-    void httpsToHttpsRedirectFollowed() throws ProtocolException {
+    void httpsToHttpsRedirectFollowed() throws Exception {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
         HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("https://mirror.example.com/g/a/1.0/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+        HttpContext context = contextWithTarget(new HttpHost("https", "repo.example.com", 443));
 
         assertTrue(strategy.isRedirected(request, response, context));
     }
 
     @Test
-    void relativeRedirectFollowed() throws ProtocolException {
+    void relativeRedirectFollowed() throws Exception {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
         HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("/elsewhere/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+        HttpContext context = contextWithTarget(new HttpHost("https", "repo.example.com", 443));
 
         assertTrue(strategy.isRedirected(request, response, context));
     }
 
     @Test
-    void httpToHttpRedirectFollowed() throws ProtocolException {
+    void httpToHttpRedirectFollowed() throws Exception {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
         HttpGet request = new HttpGet("http://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("http://mirror.example.com/g/a/1.0/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 80, "http"));
+        HttpContext context = contextWithTarget(new HttpHost("http", "repo.example.com", 80));
 
         assertTrue(strategy.isRedirected(request, response, context));
     }
 
     @Test
-    void httpsToHttpRedirectFollowedWhenExplicitlyAllowed() throws ProtocolException {
+    void httpsToHttpRedirectFollowedWhenExplicitlyAllowed() throws Exception {
         ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(true);
         HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
         HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
-        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+        HttpContext context = contextWithTarget(new HttpHost("https", "repo.example.com", 443));
 
         assertTrue(strategy.isRedirected(request, response, context));
     }
@@ -125,9 +126,9 @@ class ResolverRedirectStrategyTest {
 
     @Test
     void repositoryCredentialScopeIsBoundToSchemeImpliedPort() {
-        assertEquals(443, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", -1, "https")));
-        assertEquals(80, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", -1, "http")));
-        assertEquals(8443, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", 8443, "https")));
-        assertEquals(8081, ApacheTransporter.effectivePort(new HttpHost("repo.example.com", 8081, "http")));
+        assertEquals(443, ApacheTransporter.effectivePort(new HttpHost("https", "repo.example.com", -1)));
+        assertEquals(80, ApacheTransporter.effectivePort(new HttpHost("http", "repo.example.com", -1)));
+        assertEquals(8443, ApacheTransporter.effectivePort(new HttpHost("https", "repo.example.com", 8443)));
+        assertEquals(8081, ApacheTransporter.effectivePort(new HttpHost("http", "repo.example.com", 8081)));
     }
 }

--- a/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/UriUtilsTest.java
+++ b/maven-resolver-transport-apache5/src/test/java/org/eclipse/aether/transport/apache5/UriUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.apache5;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UriUtilsTest {
+
+    private String resolve(URI base, String ref) {
+        return UriUtils.resolve(base, URI.create(ref)).toString();
+    }
+
+    @Test
+    void testResolve_BaseEmptyPath() {
+        URI base = URI.create("http://host");
+        assertEquals("http://host/file.jar", resolve(base, "file.jar"));
+        assertEquals("http://host/dir/file.jar", resolve(base, "dir/file.jar"));
+        assertEquals("http://host?arg=val", resolve(base, "?arg=val"));
+        assertEquals("http://host/file?arg=val", resolve(base, "file?arg=val"));
+        assertEquals("http://host/dir/file?arg=val", resolve(base, "dir/file?arg=val"));
+    }
+
+    @Test
+    void testResolve_BaseRootPath() {
+        URI base = URI.create("http://host/");
+        assertEquals("http://host/file.jar", resolve(base, "file.jar"));
+        assertEquals("http://host/dir/file.jar", resolve(base, "dir/file.jar"));
+        assertEquals("http://host/?arg=val", resolve(base, "?arg=val"));
+        assertEquals("http://host/file?arg=val", resolve(base, "file?arg=val"));
+        assertEquals("http://host/dir/file?arg=val", resolve(base, "dir/file?arg=val"));
+    }
+
+    @Test
+    void testResolve_BasePathTrailingSlash() {
+        URI base = URI.create("http://host/sub/dir/");
+        assertEquals("http://host/sub/dir/file.jar", resolve(base, "file.jar"));
+        assertEquals("http://host/sub/dir/dir/file.jar", resolve(base, "dir/file.jar"));
+        assertEquals("http://host/sub/dir/?arg=val", resolve(base, "?arg=val"));
+        assertEquals("http://host/sub/dir/file?arg=val", resolve(base, "file?arg=val"));
+        assertEquals("http://host/sub/dir/dir/file?arg=val", resolve(base, "dir/file?arg=val"));
+    }
+
+    @Test
+    void testResolve_BasePathNoTrailingSlash() {
+        URI base = URI.create("http://host/sub/d%20r");
+        assertEquals("http://host/sub/d%20r/file.jar", resolve(base, "file.jar"));
+        assertEquals("http://host/sub/d%20r/dir/file.jar", resolve(base, "dir/file.jar"));
+        assertEquals("http://host/sub/d%20r?arg=val", resolve(base, "?arg=val"));
+        assertEquals("http://host/sub/d%20r/file?arg=val", resolve(base, "file?arg=val"));
+        assertEquals("http://host/sub/d%20r/dir/file?arg=val", resolve(base, "dir/file?arg=val"));
+    }
+
+    private List<URI> getDirs(String base, String uri) {
+        return UriUtils.getDirectories((base != null) ? URI.create(base) : null, URI.create(uri));
+    }
+
+    private void assertUris(List<URI> actual, String... expected) {
+        List<String> uris = new ArrayList<>(actual.size());
+        for (URI uri : actual) {
+            uris.add(uri.toString());
+        }
+        assertEquals(Arrays.asList(expected), uris);
+    }
+
+    @Test
+    void testGetDirectories_NoBase() {
+        List<URI> parents = getDirs(null, "http://host/repo/sub/dir/file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/", "http://host/repo/");
+
+        parents = getDirs(null, "http://host/repo/sub/dir/?file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/", "http://host/repo/");
+
+        parents = getDirs(null, "http://host/");
+        assertUris(parents);
+    }
+
+    @Test
+    void testGetDirectories_ExplicitBaseTrailingSlash() {
+        List<URI> parents = getDirs("http://host/repo/", "http://host/repo/sub/dir/file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/");
+
+        parents = getDirs("http://host/repo/", "http://host/repo/sub/dir/?file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/");
+
+        parents = getDirs("http://host/repo/", "http://host/");
+        assertUris(parents);
+    }
+
+    @Test
+    void testGetDirectories_ExplicitBaseNoTrailingSlash() {
+        List<URI> parents = getDirs("http://host/repo", "http://host/repo/sub/dir/file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/");
+
+        parents = getDirs("http://host/repo", "http://host/repo/sub/dir/?file.jar");
+        assertUris(parents, "http://host/repo/sub/dir/", "http://host/repo/sub/");
+
+        parents = getDirs("http://host/repo", "http://host/");
+        assertUris(parents);
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtils.java
@@ -247,13 +247,15 @@ public final class HttpTransporterUtils {
      */
     public static Optional<Boolean> getHttpExpectContinue(
             RepositorySystemSession session, RemoteRepository repository) {
-        String expectContinue = ConfigUtils.getString(
-                session,
+        Object val = ConfigUtils.getObject(
+                session.getConfigProperties(),
                 null,
                 ConfigurationProperties.HTTP_EXPECT_CONTINUE + "." + repository.getId(),
                 ConfigurationProperties.HTTP_EXPECT_CONTINUE);
-        if (expectContinue != null) {
-            return Optional.of(Boolean.parseBoolean(expectContinue));
+        if (val instanceof Boolean) {
+            return Optional.of((Boolean) val);
+        } else if (val instanceof String) {
+            return Optional.of(Boolean.parseBoolean((String) val));
         }
         return Optional.empty();
     }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/connector/transport/http/HttpTransporterUtilsTest.java
@@ -21,10 +21,13 @@ package org.eclipse.aether.util.connector.transport.http;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,6 +50,30 @@ public class HttpTransporterUtilsTest {
         assertTrue(clamped >= testStart, "clamped value must not predate the call");
         assertTrue(clamped <= System.currentTimeMillis(), "clamped value must not exceed the local clock");
         assertTrue(clamped < future, "future-dated value must be clamped");
+    }
+
+    @Test
+    void expectContinueAcceptsBooleanAndStringValues() {
+        RemoteRepository repository = new RemoteRepository.Builder("test", "default", "https://host.com/").build();
+
+        DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(h -> false);
+        assertFalse(
+                HttpTransporterUtils.getHttpExpectContinue(session, repository).isPresent());
+
+        session.setConfigProperty(ConfigurationProperties.HTTP_EXPECT_CONTINUE, Boolean.FALSE);
+        assertEquals(
+                Boolean.FALSE,
+                HttpTransporterUtils.getHttpExpectContinue(session, repository).orElse(null));
+
+        session.setConfigProperty(ConfigurationProperties.HTTP_EXPECT_CONTINUE, "true");
+        assertEquals(
+                Boolean.TRUE,
+                HttpTransporterUtils.getHttpExpectContinue(session, repository).orElse(null));
+
+        session.setConfigProperty(ConfigurationProperties.HTTP_EXPECT_CONTINUE + ".test", Boolean.FALSE);
+        assertEquals(
+                Boolean.FALSE,
+                HttpTransporterUtils.getHttpExpectContinue(session, repository).orElse(null));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>maven-resolver-test-http</module>
     <module>maven-resolver-connector-basic</module>
     <module>maven-resolver-transport-apache</module>
+    <module>maven-resolver-transport-apache5</module>
     <module>maven-resolver-transport-classpath</module>
     <module>maven-resolver-transport-file</module>
     <module>maven-resolver-transport-jdk-parent</module>
@@ -197,6 +198,11 @@
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-transport-apache</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-apache5</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Draft PR for https://github.com/apache/maven-resolver/issues/1954

### Overview

Following maintainer feedback (coexistence with Wagon HTTP which shares HttpClient 4.x), this PR introduces a new dedicated transporter module: **`maven-resolver-transport-apache5`**, leaving the existing `maven-resolver-transport-apache` (HttpClient 4.5.x) untouched.

This allows Maven 3.x / 3.10.x to continue using `apache` (HC 4.5.x) while modern integrations (e.g. Maven 4.1+) can adopt Apache HttpClient 5.x. Selection follows the usual transporter factory rules: the module's factory is `Apache5TransporterFactory` (component name `apache5`, default priority 5.0, the same as the HttpClient 4 factory), so it is selected when it is the only Apache transport on the class path, or by raising its priority with `-Daether.priority.Apache5TransporterFactory=<value>` when both are present. The distinct class name keeps that priority key from also matching the HttpClient 4 factory.

### Summary of Changes

1. **New Module:** `maven-resolver-transport-apache5`
   - Artifact: `org.apache.maven.resolver:maven-resolver-transport-apache5`
   - Component: `@Named("apache5")`, class `Apache5TransporterFactory`
   - Config prefix: `aether.transport.apache5.*`
   - Dependencies: Apache HttpClient `5.4.2` / HttpCore `5.3.3`
2. **Behavior Parity & Hardening** (ported from the HttpClient 4 transport as of #2085 and #2081):
   - `ResolverRedirectStrategy` (no https→http redirects unless `aether.transport.apache5.followInsecureRedirects=true`), `OriginScopedHeadersInterceptor` (configured headers and `Authorization` not re-sent cross-origin), credentials scoped to protocol/host/port via HC5 `AuthScope`, bounded RFC 9457 error-body read and `Last-Modified` clamp through the shared helpers.
   - Adapted `SharingHttpContext`, session pooling, TLS `SSLSession` context adaptation, and proxy routing to HC5 APIs. When a local bind address is configured the route planner is rebuilt by hand with the same precedence as `HttpClientBuilder`: an explicit repository proxy wins over system properties.
   - Thread-safe auth scheme caching using HC5 `StateHolder` and `BasicAuthCache`.
   - Subclassed `DefaultHttpRequestRetryStrategy` to maintain backoff & retry parity.
   - Public suffix hostname verification via `HttpsSupport.getDefaultHostnameVerifier()`.
   - Guarded `PutTaskEntity` against premature transmission on expect-continue rejection.
3. **Shared utility change (affects all HTTP transports):** `HttpTransporterUtils.getHttpExpectContinue` now accepts a `Boolean` configuration value as well as a `String`. Previously a `Boolean` set programmatically on the session was ignored and the transport fell back to its default. This also changes the HttpClient 4 and JDK transports, which use the same helper; a unit test covers both value types.

### Verification
- Full reactor build (32 modules) passing cleanly with JDK 21.
- All unit & integration tests passing in `maven-resolver-transport-apache5` (shared `HttpTransporterTest` suite included).
- `maven-resolver-transport-apache` (v4) passes all tests untouched.
- Spotless and Apache RAT checks passing.

*This change was created with AI assistance.*