### PR TITLE
Ignore plexus-utils 4.x for maven-resolver-1.9.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       versions: [ "[5.4.0,)" ]
     - dependency-name: "javax.servlet:javax.servlet-api"
       versions: [ "[4.0.0,)" ]
+    - dependency-name: "org.codehaus.plexus:plexus-utils"
+      versions: [ "[4.0.0,)" ]
     - dependency-name: "org.codehaus.plexus:plexus-xml"
       versions: [ "[4.0.0,)" ]
     - dependency-name: "org.eclipse.jetty:*"


### PR DESCRIPTION
Ignore `org.codehaus.plexus:plexus-utils` versions `[4.0.0,)` for the `maven-resolver-1.9.x` target branch.

### Rationale
`plexus-utils 4.x` dropped the `org.codehaus.plexus.util.xml.*` package (which was split into `plexus-xml`), creating runtime binary incompatibility and classloader duplication against the Maven 3.9.x baseline (which bundles `plexus-utils 3.6.x`).