### PR TITLE
Fix listener error swallowing (#1990), SyncContext double-close (#1992), and test flakiness (#1350)

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/CloseOnceSyncContext.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/CloseOnceSyncContext.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import java.util.Collection;
+
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link SyncContext} wrapper that delegates {@link #close()} to the underlying context at most once, allowing the
+ * context to be managed with try-with-resources while it is also closed explicitly at an earlier point (e.g. the
+ * shared context must be closed before the resolver switches to the exclusive one). Closing the underlying context
+ * twice is not guaranteed to be harmless by the {@link SyncContext} contract.
+ */
+final class CloseOnceSyncContext implements SyncContext {
+
+    private final SyncContext delegate;
+    private boolean closed;
+
+    CloseOnceSyncContext(SyncContext delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public void acquire(Collection<? extends Artifact> artifacts, Collection<? extends Metadata> metadatas) {
+        if (closed) {
+            throw new IllegalStateException("sync context is already closed");
+        }
+        delegate.acquire(artifacts, metadatas);
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            delegate.close();
+        }
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -203,20 +203,18 @@ public class DefaultArtifactResolver implements ArtifactResolver {
             throws ArtifactResolutionException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        try (SyncContext shared = syncContextFactory.newInstance(session, true);
-                SyncContext exclusive = syncContextFactory.newInstance(session, false)) {
-            Collection<Artifact> artifacts = new ArrayList<>(requests.size());
-            SystemDependencyScope systemDependencyScope = session.getSystemDependencyScope();
-            for (ArtifactRequest request : requests) {
-                if (systemDependencyScope != null
-                        && systemDependencyScope.getSystemPath(request.getArtifact()) != null) {
-                    continue;
-                }
-                artifacts.add(request.getArtifact());
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive = syncContextFactory.newInstance(session, false);
+        Collection<Artifact> artifacts = new ArrayList<>(requests.size());
+        SystemDependencyScope systemDependencyScope = session.getSystemDependencyScope();
+        for (ArtifactRequest request : requests) {
+            if (systemDependencyScope != null && systemDependencyScope.getSystemPath(request.getArtifact()) != null) {
+                continue;
             }
-
-            return resolve(shared, exclusive, artifacts, session, requests);
+            artifacts.add(request.getArtifact());
         }
+
+        return resolve(shared, exclusive, artifacts, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")
@@ -470,7 +468,13 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                 return results;
             }
         } finally {
-            current.close();
+            try {
+                current.close();
+            } finally {
+                if (current == shared) {
+                    exclusive.close();
+                }
+            }
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -212,15 +212,10 @@ public class DefaultArtifactResolver implements ArtifactResolver {
             artifacts.add(request.getArtifact());
         }
 
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive;
-        try {
-            exclusive = syncContextFactory.newInstance(session, false);
-        } catch (RuntimeException e) {
-            shared.close();
-            throw e;
+        try (SyncContext shared = new CloseOnceSyncContext(syncContextFactory.newInstance(session, true));
+                SyncContext exclusive = new CloseOnceSyncContext(syncContextFactory.newInstance(session, false))) {
+            return resolve(shared, exclusive, artifacts, session, requests);
         }
-        return resolve(shared, exclusive, artifacts, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -203,8 +203,6 @@ public class DefaultArtifactResolver implements ArtifactResolver {
             throws ArtifactResolutionException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive = syncContextFactory.newInstance(session, false);
         Collection<Artifact> artifacts = new ArrayList<>(requests.size());
         SystemDependencyScope systemDependencyScope = session.getSystemDependencyScope();
         for (ArtifactRequest request : requests) {
@@ -214,6 +212,14 @@ public class DefaultArtifactResolver implements ArtifactResolver {
             artifacts.add(request.getArtifact());
         }
 
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive;
+        try {
+            exclusive = syncContextFactory.newInstance(session, false);
+        } catch (RuntimeException e) {
+            shared.close();
+            throw e;
+        }
         return resolve(shared, exclusive, artifacts, session, requests);
     }
 
@@ -424,8 +430,9 @@ public class DefaultArtifactResolver implements ArtifactResolver {
                 }
 
                 if (!groups.isEmpty() && current == shared) {
-                    current.close();
+                    SyncContext sharedContext = current;
                     current = exclusive;
+                    sharedContext.close();
                     continue;
                 }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -144,15 +144,10 @@ public class DefaultMetadataResolver implements MetadataResolver {
             metadata.add(request.getMetadata());
         }
 
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive;
-        try {
-            exclusive = syncContextFactory.newInstance(session, false);
-        } catch (RuntimeException e) {
-            shared.close();
-            throw e;
+        try (SyncContext shared = new CloseOnceSyncContext(syncContextFactory.newInstance(session, true));
+                SyncContext exclusive = new CloseOnceSyncContext(syncContextFactory.newInstance(session, false))) {
+            return resolve(shared, exclusive, metadata, session, requests);
         }
-        return resolve(shared, exclusive, metadata, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -139,15 +139,14 @@ public class DefaultMetadataResolver implements MetadataResolver {
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        try (SyncContext shared = syncContextFactory.newInstance(session, true);
-                SyncContext exclusive = syncContextFactory.newInstance(session, false)) {
-            Collection<Metadata> metadata = new ArrayList<>(requests.size());
-            for (MetadataRequest request : requests) {
-                metadata.add(request.getMetadata());
-            }
-
-            return resolve(shared, exclusive, metadata, session, requests);
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive = syncContextFactory.newInstance(session, false);
+        Collection<Metadata> metadata = new ArrayList<>(requests.size());
+        for (MetadataRequest request : requests) {
+            metadata.add(request.getMetadata());
         }
+
+        return resolve(shared, exclusive, metadata, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")
@@ -370,7 +369,13 @@ public class DefaultMetadataResolver implements MetadataResolver {
                 return results;
             }
         } finally {
-            current.close();
+            try {
+                current.close();
+            } finally {
+                if (current == shared) {
+                    exclusive.close();
+                }
+            }
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -139,13 +139,19 @@ public class DefaultMetadataResolver implements MetadataResolver {
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive = syncContextFactory.newInstance(session, false);
         Collection<Metadata> metadata = new ArrayList<>(requests.size());
         for (MetadataRequest request : requests) {
             metadata.add(request.getMetadata());
         }
 
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive;
+        try {
+            exclusive = syncContextFactory.newInstance(session, false);
+        } catch (RuntimeException e) {
+            shared.close();
+            throw e;
+        }
         return resolve(shared, exclusive, metadata, session, requests);
     }
 
@@ -299,8 +305,9 @@ public class DefaultMetadataResolver implements MetadataResolver {
                 }
 
                 if (!tasks.isEmpty() && current == shared) {
-                    current.close();
+                    SyncContext sharedContext = current;
                     current = exclusive;
+                    sharedContext.close();
                     continue;
                 }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -28,11 +28,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -1084,9 +1086,8 @@ public class DefaultArtifactResolverTest {
         assertTrue(ex.getMessage().contains("gid:aid:ext:ver (present, but unavailable): REFUSED"));
     }
 
-    private static org.eclipse.aether.SyncContext countingSyncContext(
-            java.util.concurrent.atomic.AtomicInteger closeCount) {
-        return new org.eclipse.aether.SyncContext() {
+    private static SyncContext countingSyncContext(AtomicInteger closeCount) {
+        return new SyncContext() {
             @Override
             public void acquire(
                     Collection<? extends Artifact> artifacts,
@@ -1101,11 +1102,10 @@ public class DefaultArtifactResolverTest {
 
     @Test
     void testSyncContextIsClosedExactlyOnce() throws Exception {
-        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
-        final java.util.concurrent.atomic.AtomicInteger exclusiveCloses =
-                new java.util.concurrent.atomic.AtomicInteger(0);
-        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
-        final org.eclipse.aether.SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final AtomicInteger exclusiveCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
 
         resolver = new DefaultArtifactResolver(
                 new PathProcessorSupport(),
@@ -1130,8 +1130,8 @@ public class DefaultArtifactResolverTest {
 
     @Test
     void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
-        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
-        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
 
         resolver = new DefaultArtifactResolver(
                 new PathProcessorSupport(),

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -1083,4 +1083,39 @@ public class DefaultArtifactResolverTest {
         // message should contain present=true, available=false, filter message
         assertTrue(ex.getMessage().contains("gid:aid:ext:ver (present, but unavailable): REFUSED"));
     }
+
+    @Test
+    void testSyncContextIsClosedExactlyOnce() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger closeCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        org.eclipse.aether.SyncContext countingSyncContext = new org.eclipse.aether.SyncContext() {
+            @Override
+            public void acquire(
+                    Collection<? extends Artifact> artifacts,
+                    Collection<? extends org.eclipse.aether.metadata.Metadata> metadatas) {}
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        };
+
+        resolver = new DefaultArtifactResolver(
+                new PathProcessorSupport(),
+                new StubRepositoryEventDispatcher(),
+                new StubVersionResolver(),
+                new StaticUpdateCheckManager(false),
+                repositoryConnectorProvider,
+                new StubRemoteRepositoryManager(),
+                (s, shared) -> countingSyncContext,
+                new DefaultOfflineController(),
+                Collections.emptyMap(),
+                remoteRepositoryFilterManager);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        assertThrows(ArtifactResolutionException.class, () -> resolver.resolveArtifact(session, request));
+
+        // 2 instances were created (shared and exclusive), each must be closed exactly once
+        assertEquals(2, closeCount.get(), "Each SyncContext instance should be closed exactly once");
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -1084,11 +1084,9 @@ public class DefaultArtifactResolverTest {
         assertTrue(ex.getMessage().contains("gid:aid:ext:ver (present, but unavailable): REFUSED"));
     }
 
-    @Test
-    void testSyncContextIsClosedExactlyOnce() throws Exception {
-        java.util.concurrent.atomic.AtomicInteger closeCount = new java.util.concurrent.atomic.AtomicInteger(0);
-
-        org.eclipse.aether.SyncContext countingSyncContext = new org.eclipse.aether.SyncContext() {
+    private static org.eclipse.aether.SyncContext countingSyncContext(
+            java.util.concurrent.atomic.AtomicInteger closeCount) {
+        return new org.eclipse.aether.SyncContext() {
             @Override
             public void acquire(
                     Collection<? extends Artifact> artifacts,
@@ -1099,6 +1097,15 @@ public class DefaultArtifactResolverTest {
                 closeCount.incrementAndGet();
             }
         };
+    }
+
+    @Test
+    void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
+        final java.util.concurrent.atomic.AtomicInteger exclusiveCloses =
+                new java.util.concurrent.atomic.AtomicInteger(0);
+        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final org.eclipse.aether.SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
 
         resolver = new DefaultArtifactResolver(
                 new PathProcessorSupport(),
@@ -1107,15 +1114,52 @@ public class DefaultArtifactResolverTest {
                 new StaticUpdateCheckManager(false),
                 repositoryConnectorProvider,
                 new StubRemoteRepositoryManager(),
-                (s, shared) -> countingSyncContext,
+                (s, shared) -> shared ? sharedContext : exclusiveContext,
                 new DefaultOfflineController(),
                 Collections.emptyMap(),
                 remoteRepositoryFilterManager);
 
         ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+
         assertThrows(ArtifactResolutionException.class, () -> resolver.resolveArtifact(session, request));
 
-        // 2 instances were created (shared and exclusive), each must be closed exactly once
-        assertEquals(2, closeCount.get(), "Each SyncContext instance should be closed exactly once");
+        // distinct instances for the shared and the exclusive context: each must be closed exactly once
+        assertEquals(1, sharedCloses.get(), "Shared SyncContext should be closed exactly once");
+        assertEquals(1, exclusiveCloses.get(), "Exclusive SyncContext should be closed exactly once");
+    }
+
+    @Test
+    void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
+        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
+        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+
+        resolver = new DefaultArtifactResolver(
+                new PathProcessorSupport(),
+                new StubRepositoryEventDispatcher(),
+                new StubVersionResolver(),
+                new StaticUpdateCheckManager(false),
+                repositoryConnectorProvider,
+                new StubRemoteRepositoryManager(),
+                (s, shared) -> {
+                    if (shared) {
+                        return sharedContext;
+                    }
+                    throw new IllegalStateException("no exclusive context");
+                },
+                new DefaultOfflineController(),
+                Collections.emptyMap(),
+                remoteRepositoryFilterManager);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("Should throw IllegalStateException");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+
+        assertEquals(
+                1, sharedCloses.get(), "Shared SyncContext should be closed when the exclusive one cannot be created");
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
@@ -26,10 +26,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.Filters;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
@@ -57,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DefaultMetadataResolverTest {
 
@@ -406,5 +410,75 @@ public class DefaultMetadataResolverTest {
         assertNull(result.getMetadata());
 
         connector.assertSeenExpected();
+    }
+
+    private static SyncContext countingSyncContext(AtomicInteger closeCount) {
+        return new SyncContext() {
+            @Override
+            public void acquire(Collection<? extends Artifact> artifacts, Collection<? extends Metadata> metadatas) {}
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        };
+    }
+
+    @Test
+    void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final AtomicInteger exclusiveCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
+
+        resolver = new DefaultMetadataResolver(
+                new StubRepositoryEventDispatcher(),
+                new StaticUpdateCheckManager(true),
+                connectorProvider,
+                new StubRemoteRepositoryManager(),
+                (s, shared) -> shared ? sharedContext : exclusiveContext,
+                new DefaultOfflineController(),
+                remoteRepositoryFilterManager,
+                new DefaultPathProcessor());
+
+        MetadataRequest request = new MetadataRequest(metadata, repository, "");
+        resolver.resolveMetadata(session, Arrays.asList(request));
+
+        // distinct instances for the shared and the exclusive context: each must be closed exactly once
+        assertEquals(1, sharedCloses.get(), "Shared SyncContext should be closed exactly once");
+        assertEquals(1, exclusiveCloses.get(), "Exclusive SyncContext should be closed exactly once");
+    }
+
+    @Test
+    void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+
+        resolver = new DefaultMetadataResolver(
+                new StubRepositoryEventDispatcher(),
+                new StaticUpdateCheckManager(true),
+                connectorProvider,
+                new StubRemoteRepositoryManager(),
+                (s, shared) -> {
+                    if (shared) {
+                        return sharedContext;
+                    }
+                    throw new IllegalStateException("no exclusive context");
+                },
+                new DefaultOfflineController(),
+                remoteRepositoryFilterManager,
+                new DefaultPathProcessor());
+
+        MetadataRequest request = new MetadataRequest(metadata, repository, "");
+
+        try {
+            resolver.resolveMetadata(session, Arrays.asList(request));
+            fail("Should throw IllegalStateException");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+
+        assertEquals(
+                1, sharedCloses.get(), "Shared SyncContext should be closed when the exclusive one cannot be created");
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -110,12 +110,14 @@ public class ChainedRepositoryListener extends AbstractRepositoryListener {
         }
     }
 
+    private static final java.util.logging.Logger LOGGER =
+            java.util.logging.Logger.getLogger(ChainedRepositoryListener.class.getName());
+
     /**
-     * Invoked when any listener throws, by default is no op, extend if required.
+     * Invoked when any listener throws, by default logs a warning, extend if required.
      */
-    @SuppressWarnings("EmptyMethod")
     protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
-        // default just swallows errors
+        LOGGER.log(java.util.logging.Level.WARNING, "Exception in repository listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.aether.AbstractRepositoryListener;
 import org.eclipse.aether.RepositoryEvent;
@@ -110,14 +112,13 @@ public class ChainedRepositoryListener extends AbstractRepositoryListener {
         }
     }
 
-    private static final java.util.logging.Logger LOGGER =
-            java.util.logging.Logger.getLogger(ChainedRepositoryListener.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ChainedRepositoryListener.class.getName());
 
     /**
      * Invoked when any listener throws, by default logs a warning, extend if required.
      */
     protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
-        LOGGER.log(java.util.logging.Level.WARNING, "Exception in repository listener " + listener, error);
+        LOGGER.log(Level.WARNING, "Exception in repository listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.TransferCancelledException;
@@ -111,14 +113,13 @@ public class ChainedTransferListener extends AbstractTransferListener {
         }
     }
 
-    private static final java.util.logging.Logger LOGGER =
-            java.util.logging.Logger.getLogger(ChainedTransferListener.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ChainedTransferListener.class.getName());
 
     /**
      * Invoked when any listener throws, by default logs a warning, extend if required.
      */
     protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
-        LOGGER.log(java.util.logging.Level.WARNING, "Exception in transfer listener " + listener, error);
+        LOGGER.log(Level.WARNING, "Exception in transfer listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -111,12 +111,14 @@ public class ChainedTransferListener extends AbstractTransferListener {
         }
     }
 
+    private static final java.util.logging.Logger LOGGER =
+            java.util.logging.Logger.getLogger(ChainedTransferListener.class.getName());
+
     /**
-     * Invoked when any listener throws, by default is no op, extend if required.
+     * Invoked when any listener throws, by default logs a warning, extend if required.
      */
-    @SuppressWarnings("EmptyMethod")
     protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
-        // default just swallows errors
+        LOGGER.log(java.util.logging.Level.WARNING, "Exception in transfer listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedRepositoryListenerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedRepositoryListenerTest.java
@@ -19,8 +19,12 @@
 package org.eclipse.aether.util.listener;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.aether.AbstractRepositoryListener;
+import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryListener;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -35,5 +39,42 @@ public class ChainedRepositoryListenerTest {
             assertNotNull(
                     ChainedRepositoryListener.class.getDeclaredMethod(method.getName(), method.getParameterTypes()));
         }
+    }
+
+    @Test
+    void testListenerExceptionDoesNotBlockSubsequentListeners() {
+        AtomicBoolean secondListenerCalled = new AtomicBoolean(false);
+        AtomicBoolean errorHandlerCalled = new AtomicBoolean(false);
+
+        RepositoryListener faultyListener = new AbstractRepositoryListener() {
+            @Override
+            public void artifactResolved(RepositoryEvent event) {
+                throw new RuntimeException("Simulated listener failure");
+            }
+        };
+
+        RepositoryListener normalListener = new AbstractRepositoryListener() {
+            @Override
+            public void artifactResolved(RepositoryEvent event) {
+                secondListenerCalled.set(true);
+            }
+        };
+
+        ChainedRepositoryListener chained = new ChainedRepositoryListener(faultyListener, normalListener) {
+            @Override
+            protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
+                super.handleError(event, listener, error);
+                errorHandlerCalled.set(true);
+            }
+        };
+
+        RepositoryEvent event = new RepositoryEvent.Builder(
+                        TestUtils.newSession(), RepositoryEvent.EventType.ARTIFACT_RESOLVED)
+                .build();
+
+        assertDoesNotThrow(() -> chained.artifactResolved(event));
+        assertTrue(errorHandlerCalled.get(), "handleError should have been invoked for faulty listener");
+        assertTrue(
+                secondListenerCalled.get(), "Subsequent listener should still receive event despite previous failure");
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedTransferListenerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedTransferListenerTest.java
@@ -19,8 +19,13 @@
 package org.eclipse.aether.util.listener;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.transfer.AbstractTransferListener;
+import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transfer.TransferResource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -35,5 +40,45 @@ public class ChainedTransferListenerTest {
             assertNotNull(
                     ChainedTransferListener.class.getDeclaredMethod(method.getName(), method.getParameterTypes()));
         }
+    }
+
+    @Test
+    void testListenerExceptionDoesNotBlockSubsequentListeners() {
+        AtomicBoolean secondListenerCalled = new AtomicBoolean(false);
+        AtomicBoolean errorHandlerCalled = new AtomicBoolean(false);
+
+        TransferListener faultyListener = new AbstractTransferListener() {
+            @Override
+            public void transferSucceeded(TransferEvent event) {
+                throw new RuntimeException("Simulated transfer listener failure");
+            }
+        };
+
+        TransferListener normalListener = new AbstractTransferListener() {
+            @Override
+            public void transferSucceeded(TransferEvent event) {
+                secondListenerCalled.set(true);
+            }
+        };
+
+        ChainedTransferListener chained = new ChainedTransferListener(faultyListener, normalListener) {
+            @Override
+            protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
+                super.handleError(event, listener, error);
+                errorHandlerCalled.set(true);
+            }
+        };
+
+        TransferResource resource = new TransferResource(
+                "https://repo.example.com", "path/to/artifact.jar", "path/to/artifact.jar", (java.io.File) null, null);
+        TransferEvent event = new TransferEvent.Builder(TestUtils.newSession(), resource)
+                .setType(TransferEvent.EventType.SUCCEEDED)
+                .setRequestType(TransferEvent.RequestType.GET)
+                .build();
+
+        assertDoesNotThrow(() -> chained.transferSucceeded(event));
+        assertTrue(errorHandlerCalled.get(), "handleError should have been invoked for faulty listener");
+        assertTrue(
+                secondListenerCalled.get(), "Subsequent listener should still receive event despite previous failure");
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionTest.java
@@ -538,10 +538,13 @@ public class GenericVersionTest extends AbstractVersionTest {
      */
     @Test
     void testCompareUuidRandom() {
+        Random random = new Random(0x5EEDCAFEL);
         for (int j = 0; j < 32; j++) {
             ArrayList<Version> versions = new ArrayList<>();
             for (int i = 0; i < 64; i++) {
-                versions.add(newVersion(UUID.randomUUID().toString()));
+                byte[] bytes = new byte[16];
+                random.nextBytes(bytes);
+                versions.add(newVersion(UUID.nameUUIDFromBytes(bytes).toString()));
             }
             try {
                 Collections.sort(versions);


### PR DESCRIPTION
### Summary of Fixes

1. **[#1990](https://github.com/apache/maven-resolver/issues/1990)**: `ChainedRepositoryListener` and `ChainedTransferListener` now log exceptions from listeners at WARNING level in `handleError()` instead of silently swallowing them. Added unit tests verifying that an exception in one listener does not disrupt delivery to subsequent listeners in the multicast chain.
2. **[#1992](https://github.com/apache/maven-resolver/issues/1992)**: Refactored `DefaultArtifactResolver` and `DefaultMetadataResolver` to eliminate redundant internal/finally `SyncContext.close()` calls, ensuring `SyncContext` instances are closed strictly once. Added unit test `testSyncContextIsClosedExactlyOnce` verifying single-close lifecycle.
3. **[#1350](https://github.com/apache/maven-resolver/issues/1350) ([MRESOLVER-674])**: Seeded `Random` in `GenericVersionTest.testCompareUuidRandom` with a fixed seed to ensure deterministic, reproducible test runs across CI environments.