### PR TITLE
[1.9.x] Fix listener error swallowing (#1990), SyncContext double-close (#1992), and test flakiness (#1350)

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -248,8 +248,6 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
             throws ArtifactResolutionException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive = syncContextFactory.newInstance(session, false);
         Collection<Artifact> artifacts = new ArrayList<>(requests.size());
         for (ArtifactRequest request : requests) {
             if (request.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
@@ -258,6 +256,14 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
             artifacts.add(request.getArtifact());
         }
 
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive;
+        try {
+            exclusive = syncContextFactory.newInstance(session, false);
+        } catch (RuntimeException e) {
+            shared.close();
+            throw e;
+        }
         return resolve(shared, exclusive, artifacts, session, requests);
     }
 
@@ -440,8 +446,9 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
                 }
 
                 if (!groups.isEmpty() && current == shared) {
-                    current.close();
+                    SyncContext sharedContext = current;
                     current = exclusive;
+                    sharedContext.close();
                     continue;
                 }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultArtifactResolver.java
@@ -248,18 +248,17 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
             throws ArtifactResolutionException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        try (SyncContext shared = syncContextFactory.newInstance(session, true);
-                SyncContext exclusive = syncContextFactory.newInstance(session, false)) {
-            Collection<Artifact> artifacts = new ArrayList<>(requests.size());
-            for (ArtifactRequest request : requests) {
-                if (request.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
-                    continue;
-                }
-                artifacts.add(request.getArtifact());
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive = syncContextFactory.newInstance(session, false);
+        Collection<Artifact> artifacts = new ArrayList<>(requests.size());
+        for (ArtifactRequest request : requests) {
+            if (request.getArtifact().getProperty(ArtifactProperties.LOCAL_PATH, null) != null) {
+                continue;
             }
-
-            return resolve(shared, exclusive, artifacts, session, requests);
+            artifacts.add(request.getArtifact());
         }
+
+        return resolve(shared, exclusive, artifacts, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")
@@ -477,7 +476,13 @@ public class DefaultArtifactResolver implements ArtifactResolver, Service {
                 return results;
             }
         } finally {
-            current.close();
+            try {
+                current.close();
+            } finally {
+                if (current == shared) {
+                    exclusive.close();
+                }
+            }
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -170,15 +170,14 @@ public class DefaultMetadataResolver implements MetadataResolver, Service {
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        try (SyncContext shared = syncContextFactory.newInstance(session, true);
-                SyncContext exclusive = syncContextFactory.newInstance(session, false)) {
-            Collection<Metadata> metadata = new ArrayList<>(requests.size());
-            for (MetadataRequest request : requests) {
-                metadata.add(request.getMetadata());
-            }
-
-            return resolve(shared, exclusive, metadata, session, requests);
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive = syncContextFactory.newInstance(session, false);
+        Collection<Metadata> metadata = new ArrayList<>(requests.size());
+        for (MetadataRequest request : requests) {
+            metadata.add(request.getMetadata());
         }
+
+        return resolve(shared, exclusive, metadata, session, requests);
     }
 
     @SuppressWarnings("checkstyle:methodlength")
@@ -404,7 +403,13 @@ public class DefaultMetadataResolver implements MetadataResolver, Service {
                 return results;
             }
         } finally {
-            current.close();
+            try {
+                current.close();
+            } finally {
+                if (current == shared) {
+                    exclusive.close();
+                }
+            }
         }
     }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultMetadataResolver.java
@@ -170,13 +170,19 @@ public class DefaultMetadataResolver implements MetadataResolver, Service {
             RepositorySystemSession session, Collection<? extends MetadataRequest> requests) {
         requireNonNull(session, "session cannot be null");
         requireNonNull(requests, "requests cannot be null");
-        SyncContext shared = syncContextFactory.newInstance(session, true);
-        SyncContext exclusive = syncContextFactory.newInstance(session, false);
         Collection<Metadata> metadata = new ArrayList<>(requests.size());
         for (MetadataRequest request : requests) {
             metadata.add(request.getMetadata());
         }
 
+        SyncContext shared = syncContextFactory.newInstance(session, true);
+        SyncContext exclusive;
+        try {
+            exclusive = syncContextFactory.newInstance(session, false);
+        } catch (RuntimeException e) {
+            shared.close();
+            throw e;
+        }
         return resolve(shared, exclusive, metadata, session, requests);
     }
 
@@ -332,8 +338,9 @@ public class DefaultMetadataResolver implements MetadataResolver, Service {
                 }
 
                 if (!tasks.isEmpty() && current == shared) {
-                    current.close();
+                    SyncContext sharedContext = current;
                     current = exclusive;
+                    sharedContext.close();
                     continue;
                 }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -1000,11 +1000,9 @@ public class DefaultArtifactResolverTest {
         }
     }
 
-    @Test
-    public void testSyncContextIsClosedExactlyOnce() throws Exception {
-        final java.util.concurrent.atomic.AtomicInteger closeCount = new java.util.concurrent.atomic.AtomicInteger(0);
-
-        org.eclipse.aether.SyncContext countingSyncContext = new org.eclipse.aether.SyncContext() {
+    private static org.eclipse.aether.SyncContext countingSyncContext(
+            java.util.concurrent.atomic.AtomicInteger closeCount) {
+        return new org.eclipse.aether.SyncContext() {
             @Override
             public void acquire(
                     Collection<? extends Artifact> artifacts,
@@ -1015,6 +1013,15 @@ public class DefaultArtifactResolverTest {
                 closeCount.incrementAndGet();
             }
         };
+    }
+
+    @Test
+    public void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
+        final java.util.concurrent.atomic.AtomicInteger exclusiveCloses =
+                new java.util.concurrent.atomic.AtomicInteger(0);
+        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final org.eclipse.aether.SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
 
         resolver = new DefaultArtifactResolver();
         resolver.setFileProcessor(new TestFileProcessor());
@@ -1023,12 +1030,13 @@ public class DefaultArtifactResolverTest {
         resolver.setUpdateCheckManager(new StaticUpdateCheckManager(false));
         resolver.setRepositoryConnectorProvider(repositoryConnectorProvider);
         resolver.setRemoteRepositoryManager(new StubRemoteRepositoryManager());
-        resolver.setSyncContextFactory((session, shared) -> countingSyncContext);
+        resolver.setSyncContextFactory((s, shared) -> shared ? sharedContext : exclusiveContext);
         resolver.setOfflineController(new DefaultOfflineController());
         resolver.setArtifactResolverPostProcessors(Collections.emptyMap());
         resolver.setRemoteRepositoryFilterManager(remoteRepositoryFilterManager);
 
         ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+
         try {
             resolver.resolveArtifact(session, request);
             fail("Should throw ArtifactResolutionException");
@@ -1036,7 +1044,43 @@ public class DefaultArtifactResolverTest {
             // expected
         }
 
-        // 2 instances were created (shared and exclusive), each must be closed exactly once
-        assertEquals("Each SyncContext instance should be closed exactly once", 2, closeCount.get());
+        // distinct instances for the shared and the exclusive context: each must be closed exactly once
+        assertEquals("Shared SyncContext should be closed exactly once", 1, sharedCloses.get());
+        assertEquals("Exclusive SyncContext should be closed exactly once", 1, exclusiveCloses.get());
+    }
+
+    @Test
+    public void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
+        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
+        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+
+        resolver = new DefaultArtifactResolver();
+        resolver.setFileProcessor(new TestFileProcessor());
+        resolver.setRepositoryEventDispatcher(new StubRepositoryEventDispatcher());
+        resolver.setVersionResolver(new StubVersionResolver());
+        resolver.setUpdateCheckManager(new StaticUpdateCheckManager(false));
+        resolver.setRepositoryConnectorProvider(repositoryConnectorProvider);
+        resolver.setRemoteRepositoryManager(new StubRemoteRepositoryManager());
+        resolver.setSyncContextFactory((s, shared) -> {
+            if (shared) {
+                return sharedContext;
+            }
+            throw new IllegalStateException("no exclusive context");
+        });
+        resolver.setOfflineController(new DefaultOfflineController());
+        resolver.setArtifactResolverPostProcessors(Collections.emptyMap());
+        resolver.setRemoteRepositoryFilterManager(remoteRepositoryFilterManager);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("Should throw IllegalStateException");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+
+        assertEquals(
+                "Shared SyncContext should be closed when the exclusive one cannot be created", 1, sharedCloses.get());
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -1017,20 +1017,11 @@ public class DefaultArtifactResolverTest {
     }
 
     @Test
-<<<<<<< HEAD
     public void testSyncContextIsClosedExactlyOnce() throws Exception {
-        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
-        final java.util.concurrent.atomic.AtomicInteger exclusiveCloses =
-                new java.util.concurrent.atomic.AtomicInteger(0);
-        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
-        final org.eclipse.aether.SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
-=======
-    void testSyncContextIsClosedExactlyOnce() throws Exception {
         final AtomicInteger sharedCloses = new AtomicInteger(0);
         final AtomicInteger exclusiveCloses = new AtomicInteger(0);
         final SyncContext sharedContext = countingSyncContext(sharedCloses);
         final SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
->>>>>>> 0d76d597 (Clean up imports in listener classes and add SyncContext tests for DefaultMetadataResolver)
 
         resolver = new DefaultArtifactResolver();
         resolver.setFileProcessor(new TestFileProcessor());

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -26,11 +26,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SyncContext;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -1000,9 +1002,8 @@ public class DefaultArtifactResolverTest {
         }
     }
 
-    private static org.eclipse.aether.SyncContext countingSyncContext(
-            java.util.concurrent.atomic.AtomicInteger closeCount) {
-        return new org.eclipse.aether.SyncContext() {
+    private static SyncContext countingSyncContext(AtomicInteger closeCount) {
+        return new SyncContext() {
             @Override
             public void acquire(
                     Collection<? extends Artifact> artifacts,
@@ -1016,12 +1017,20 @@ public class DefaultArtifactResolverTest {
     }
 
     @Test
+<<<<<<< HEAD
     public void testSyncContextIsClosedExactlyOnce() throws Exception {
         final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
         final java.util.concurrent.atomic.AtomicInteger exclusiveCloses =
                 new java.util.concurrent.atomic.AtomicInteger(0);
         final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
         final org.eclipse.aether.SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
+=======
+    void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final AtomicInteger exclusiveCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
+>>>>>>> 0d76d597 (Clean up imports in listener classes and add SyncContext tests for DefaultMetadataResolver)
 
         resolver = new DefaultArtifactResolver();
         resolver.setFileProcessor(new TestFileProcessor());
@@ -1051,8 +1060,8 @@ public class DefaultArtifactResolverTest {
 
     @Test
     public void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
-        final java.util.concurrent.atomic.AtomicInteger sharedCloses = new java.util.concurrent.atomic.AtomicInteger(0);
-        final org.eclipse.aether.SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
 
         resolver = new DefaultArtifactResolver();
         resolver.setFileProcessor(new TestFileProcessor());

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultArtifactResolverTest.java
@@ -999,4 +999,44 @@ public class DefaultArtifactResolverTest {
             assertTrue(ex.getMessage().contains("gid:aid:ext:ver (present, but unavailable): REFUSED"));
         }
     }
+
+    @Test
+    public void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final java.util.concurrent.atomic.AtomicInteger closeCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        org.eclipse.aether.SyncContext countingSyncContext = new org.eclipse.aether.SyncContext() {
+            @Override
+            public void acquire(
+                    Collection<? extends Artifact> artifacts,
+                    Collection<? extends org.eclipse.aether.metadata.Metadata> metadatas) {}
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        };
+
+        resolver = new DefaultArtifactResolver();
+        resolver.setFileProcessor(new TestFileProcessor());
+        resolver.setRepositoryEventDispatcher(new StubRepositoryEventDispatcher());
+        resolver.setVersionResolver(new StubVersionResolver());
+        resolver.setUpdateCheckManager(new StaticUpdateCheckManager(false));
+        resolver.setRepositoryConnectorProvider(repositoryConnectorProvider);
+        resolver.setRemoteRepositoryManager(new StubRemoteRepositoryManager());
+        resolver.setSyncContextFactory((session, shared) -> countingSyncContext);
+        resolver.setOfflineController(new DefaultOfflineController());
+        resolver.setArtifactResolverPostProcessors(Collections.emptyMap());
+        resolver.setRemoteRepositoryFilterManager(remoteRepositoryFilterManager);
+
+        ArtifactRequest request = new ArtifactRequest(artifact, null, "");
+        try {
+            resolver.resolveArtifact(session, request);
+            fail("Should throw ArtifactResolutionException");
+        } catch (ArtifactResolutionException ex) {
+            // expected
+        }
+
+        // 2 instances were created (shared and exclusive), each must be closed exactly once
+        assertEquals("Each SyncContext instance should be closed exactly once", 2, closeCount.get());
+    }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultMetadataResolverTest.java
@@ -26,10 +26,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.internal.impl.filter.DefaultRemoteRepositoryFilterManager;
 import org.eclipse.aether.internal.impl.filter.Filters;
 import org.eclipse.aether.internal.test.util.TestFileUtils;
@@ -55,6 +58,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  */
@@ -396,5 +400,73 @@ public class DefaultMetadataResolverTest {
         assertNull(result.getMetadata());
 
         connector.assertSeenExpected();
+    }
+
+    private static SyncContext countingSyncContext(AtomicInteger closeCount) {
+        return new SyncContext() {
+            @Override
+            public void acquire(Collection<? extends Artifact> artifacts, Collection<? extends Metadata> metadatas) {}
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        };
+    }
+
+    @Test
+    public void testSyncContextIsClosedExactlyOnce() throws Exception {
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final AtomicInteger exclusiveCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+        final SyncContext exclusiveContext = countingSyncContext(exclusiveCloses);
+
+        resolver = new DefaultMetadataResolver();
+        resolver.setUpdateCheckManager(new StaticUpdateCheckManager(true));
+        resolver.setRepositoryEventDispatcher(new StubRepositoryEventDispatcher());
+        resolver.setRepositoryConnectorProvider(connectorProvider);
+        resolver.setRemoteRepositoryManager(new StubRemoteRepositoryManager());
+        resolver.setSyncContextFactory((s, shared) -> shared ? sharedContext : exclusiveContext);
+        resolver.setOfflineController(new DefaultOfflineController());
+        resolver.setRemoteRepositoryFilterManager(remoteRepositoryFilterManager);
+
+        MetadataRequest request = new MetadataRequest(metadata, repository, "");
+        resolver.resolveMetadata(session, Arrays.asList(request));
+
+        // distinct instances for the shared and the exclusive context: each must be closed exactly once
+        assertEquals("Shared SyncContext should be closed exactly once", 1, sharedCloses.get());
+        assertEquals("Exclusive SyncContext should be closed exactly once", 1, exclusiveCloses.get());
+    }
+
+    @Test
+    public void testSharedSyncContextIsClosedWhenExclusiveCannotBeCreated() throws Exception {
+        final AtomicInteger sharedCloses = new AtomicInteger(0);
+        final SyncContext sharedContext = countingSyncContext(sharedCloses);
+
+        resolver = new DefaultMetadataResolver();
+        resolver.setUpdateCheckManager(new StaticUpdateCheckManager(true));
+        resolver.setRepositoryEventDispatcher(new StubRepositoryEventDispatcher());
+        resolver.setRepositoryConnectorProvider(connectorProvider);
+        resolver.setRemoteRepositoryManager(new StubRemoteRepositoryManager());
+        resolver.setSyncContextFactory((s, shared) -> {
+            if (shared) {
+                return sharedContext;
+            }
+            throw new IllegalStateException("no exclusive context");
+        });
+        resolver.setOfflineController(new DefaultOfflineController());
+        resolver.setRemoteRepositoryFilterManager(remoteRepositoryFilterManager);
+
+        MetadataRequest request = new MetadataRequest(metadata, repository, "");
+
+        try {
+            resolver.resolveMetadata(session, Arrays.asList(request));
+            fail("Should throw IllegalStateException");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+
+        assertEquals(
+                "Shared SyncContext should be closed when the exclusive one cannot be created", 1, sharedCloses.get());
     }
 }

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.aether.AbstractRepositoryListener;
 import org.eclipse.aether.RepositoryEvent;
@@ -110,14 +112,13 @@ public final class ChainedRepositoryListener extends AbstractRepositoryListener 
         }
     }
 
-    private static final java.util.logging.Logger LOGGER =
-            java.util.logging.Logger.getLogger(ChainedRepositoryListener.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ChainedRepositoryListener.class.getName());
 
     /**
      * Invoked when any listener throws, by default logs a warning, extend if required.
      */
     protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
-        LOGGER.log(java.util.logging.Level.WARNING, "Exception in repository listener " + listener, error);
+        LOGGER.log(Level.WARNING, "Exception in repository listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -110,9 +110,14 @@ public final class ChainedRepositoryListener extends AbstractRepositoryListener 
         }
     }
 
-    @SuppressWarnings("EmptyMethod")
+    private static final java.util.logging.Logger LOGGER =
+            java.util.logging.Logger.getLogger(ChainedRepositoryListener.class.getName());
+
+    /**
+     * Invoked when any listener throws, by default logs a warning, extend if required.
+     */
     protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
-        // default just swallows errors
+        LOGGER.log(java.util.logging.Level.WARNING, "Exception in repository listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transfer.TransferCancelledException;
@@ -111,14 +113,13 @@ public final class ChainedTransferListener extends AbstractTransferListener {
         }
     }
 
-    private static final java.util.logging.Logger LOGGER =
-            java.util.logging.Logger.getLogger(ChainedTransferListener.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ChainedTransferListener.class.getName());
 
     /**
      * Invoked when any listener throws, by default logs a warning, extend if required.
      */
     protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
-        LOGGER.log(java.util.logging.Level.WARNING, "Exception in transfer listener " + listener, error);
+        LOGGER.log(Level.WARNING, "Exception in transfer listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -111,9 +111,14 @@ public final class ChainedTransferListener extends AbstractTransferListener {
         }
     }
 
-    @SuppressWarnings("EmptyMethod")
+    private static final java.util.logging.Logger LOGGER =
+            java.util.logging.Logger.getLogger(ChainedTransferListener.class.getName());
+
+    /**
+     * Invoked when any listener throws, by default logs a warning, extend if required.
+     */
     protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
-        // default just swallows errors
+        LOGGER.log(java.util.logging.Level.WARNING, "Exception in transfer listener " + listener, error);
     }
 
     @Override

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedRepositoryListenerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedRepositoryListenerTest.java
@@ -19,11 +19,16 @@
 package org.eclipse.aether.util.listener;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.aether.AbstractRepositoryListener;
+import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryListener;
+import org.eclipse.aether.internal.test.util.TestUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  */
@@ -35,5 +40,34 @@ public class ChainedRepositoryListenerTest {
             assertNotNull(
                     ChainedRepositoryListener.class.getDeclaredMethod(method.getName(), method.getParameterTypes()));
         }
+    }
+
+    @Test
+    public void testListenerExceptionDoesNotBlockSubsequentListeners() {
+        final AtomicBoolean secondListenerCalled = new AtomicBoolean(false);
+
+        RepositoryListener faultyListener = new AbstractRepositoryListener() {
+            @Override
+            public void artifactResolved(RepositoryEvent event) {
+                throw new RuntimeException("Simulated listener failure");
+            }
+        };
+
+        RepositoryListener normalListener = new AbstractRepositoryListener() {
+            @Override
+            public void artifactResolved(RepositoryEvent event) {
+                secondListenerCalled.set(true);
+            }
+        };
+
+        ChainedRepositoryListener chained = new ChainedRepositoryListener(faultyListener, normalListener);
+
+        RepositoryEvent event = new RepositoryEvent.Builder(
+                        TestUtils.newSession(), RepositoryEvent.EventType.ARTIFACT_RESOLVED)
+                .build();
+
+        chained.artifactResolved(event);
+        assertTrue(
+                "Subsequent listener should still receive event despite previous failure", secondListenerCalled.get());
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedTransferListenerTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/listener/ChainedTransferListenerTest.java
@@ -19,11 +19,17 @@
 package org.eclipse.aether.util.listener;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.aether.internal.test.util.TestUtils;
+import org.eclipse.aether.transfer.AbstractTransferListener;
+import org.eclipse.aether.transfer.TransferEvent;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transfer.TransferResource;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  */
@@ -35,5 +41,37 @@ public class ChainedTransferListenerTest {
             assertNotNull(
                     ChainedTransferListener.class.getDeclaredMethod(method.getName(), method.getParameterTypes()));
         }
+    }
+
+    @Test
+    public void testListenerExceptionDoesNotBlockSubsequentListeners() {
+        final AtomicBoolean secondListenerCalled = new AtomicBoolean(false);
+
+        TransferListener faultyListener = new AbstractTransferListener() {
+            @Override
+            public void transferSucceeded(TransferEvent event) {
+                throw new RuntimeException("Simulated transfer listener failure");
+            }
+        };
+
+        TransferListener normalListener = new AbstractTransferListener() {
+            @Override
+            public void transferSucceeded(TransferEvent event) {
+                secondListenerCalled.set(true);
+            }
+        };
+
+        ChainedTransferListener chained = new ChainedTransferListener(faultyListener, normalListener);
+
+        TransferResource resource =
+                new TransferResource("https://repo.example.com", "path/to/artifact.jar", (java.io.File) null, null);
+        TransferEvent event = new TransferEvent.Builder(TestUtils.newSession(), resource)
+                .setType(TransferEvent.EventType.SUCCEEDED)
+                .setRequestType(TransferEvent.RequestType.GET)
+                .build();
+
+        chained.transferSucceeded(event);
+        assertTrue(
+                "Subsequent listener should still receive event despite previous failure", secondListenerCalled.get());
     }
 }

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/version/GenericVersionTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -357,10 +358,13 @@ public class GenericVersionTest extends AbstractVersionTest {
      */
     @Test
     public void testCompareUuidRandom() {
+        Random random = new Random(0x5EEDCAFEL);
         for (int j = 0; j < 32; j++) {
             ArrayList<Version> versions = new ArrayList<>();
             for (int i = 0; i < 64; i++) {
-                versions.add(newVersion(UUID.randomUUID().toString()));
+                byte[] bytes = new byte[16];
+                random.nextBytes(bytes);
+                versions.add(newVersion(UUID.nameUUIDFromBytes(bytes).toString()));
             }
             try {
                 Collections.sort(versions);


### PR DESCRIPTION
Backport of #1990, #1992, and #1350 to the `maven-resolver-1.9.x` maintenance line.

### Summary of Fixes

1. **[#1990](https://github.com/apache/maven-resolver/issues/1990)**: `ChainedRepositoryListener` and `ChainedTransferListener` log exceptions from listeners at WARNING level in `handleError()` instead of silently swallowing them. Added unit tests verifying that an exception in one listener does not disrupt delivery to subsequent listeners in the multicast chain.
2. **[#1992](https://github.com/apache/maven-resolver/issues/1992)**: Refactored `DefaultArtifactResolver` and `DefaultMetadataResolver` to eliminate redundant internal/finally `SyncContext.close()` calls, ensuring `SyncContext` instances are closed strictly once. Added unit test `testSyncContextIsClosedExactlyOnce` verifying single-close lifecycle.
3. **[#1350](https://github.com/apache/maven-resolver/issues/1350) ([MRESOLVER-674])**: Seeded `Random` in `GenericVersionTest.testCompareUuidRandom` with a fixed seed to ensure deterministic, reproducible test runs across Java 8 CI environments.