### PR TITLE
Create the local repository directory before resolving its real path

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -149,6 +149,8 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         this.trackingFilename = requireNonNull(trackingFilename);
         this.trackingFileManager = requireNonNull(trackingFileManager);
         this.localPathPrefixComposer = requireNonNull(localPathPrefixComposer);
+        // a fresh local repository does not exist yet; toRealPath() requires it to
+        Files.createDirectories(getRepository().getBasePath());
         this.realBasePath = getRepository().getBasePath().toRealPath();
     }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactoryTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactoryTest.java
@@ -18,8 +18,11 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -34,6 +37,7 @@ import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.eclipse.aether.util.StringDigestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,5 +148,31 @@ public class EnhancedLocalRepositoryManagerFactoryTest {
         LocalArtifactRequest fromImpostor =
                 new LocalArtifactRequest(artifact, Collections.singletonList(impostor), context);
         assertFalse(manager.find(session, fromImpostor).isAvailable());
+    }
+
+    @Test
+    void newInstanceForNotYetExistingBasedir() throws Exception {
+        // a fresh local repository (first build on a machine, or a new -Dmaven.repo.local) does not exist yet
+        Path missing = basedir.resolve("not-yet-created");
+        assertFalse(Files.exists(missing));
+
+        LocalRepositoryManager manager = factory.newInstance(session, new LocalRepository(missing));
+
+        assertInstanceOf(EnhancedLocalRepositoryManager.class, manager);
+    }
+
+    @Test
+    void providerSelectsEnhancedManagerForNotYetExistingBasedir() throws Exception {
+        // the provider treats NoLocalRepositoryManagerException as "try the next factory", so a failing
+        // enhanced factory would silently degrade the whole session to the untracked simple manager
+        Path missing = basedir.resolve("not-yet-created");
+        Map<String, LocalRepositoryManagerFactory> factories = new HashMap<>();
+        factories.put(EnhancedLocalRepositoryManagerFactory.NAME, factory);
+        factories.put(SimpleLocalRepositoryManagerFactory.NAME, new SimpleLocalRepositoryManagerFactory());
+        DefaultLocalRepositoryProvider provider = new DefaultLocalRepositoryProvider(factories);
+
+        LocalRepositoryManager manager = provider.newLocalRepositoryManager(session, new LocalRepository(missing));
+
+        assertInstanceOf(EnhancedLocalRepositoryManager.class, manager);
     }
 }


### PR DESCRIPTION
Since #2104 `EnhancedLocalRepositoryManager` resolves the real path of its base directory in the constructor, and `Path.toRealPath()` requires the path to exist.

A local repository that has not been created yet (first build on a machine, or a new `-Dmaven.repo.local`) therefore made the enhanced factory throw `NoLocalRepositoryManagerException`. `DefaultLocalRepositoryProvider` treats that as "try the next factory" and quietly selected `SimpleLocalRepositoryManager`, so the whole first session ran without `_remote.repositories` tracking. Before #2104 the real path was computed lazily, only for files that already existed, so the directory was always present.

The fix creates the directory before resolving it. Maven creates it on first write anyway and the enhanced manager needs it for its tracking files, so nothing observable changes for a usable local repository; an unwritable location still fails the same way it did before.

Two tests cover the factory directly and the provider's fallback selection with a not-yet-existing base directory; both fail on master with the `NoSuchFileException` cause.

*This change was created with AI assistance.*