### PR TITLE
Log expired not-found markers from the current session at debug level

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
@@ -77,6 +77,14 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
         }
     });
 
+    // instance bound private key
+    static final Object SESSION_NOT_FOUNDS = Keys.of(new Object() {
+        @Override
+        public String toString() {
+            return "updateCheckManager.notFounds";
+        }
+    });
+
     /**
      * Manages the session state, i.e. influences if the same download requests to artifacts/metadata will happen
      * multiple times within the same RepositorySystemSession. If "enabled" will enable the session state. If "bypass"
@@ -459,6 +467,27 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
         return updatePolicyAnalyzer.isUpdatedRequired(session, lastModified, policy);
     }
 
+    private String getNotFoundKey(Path touchPath, String dataKey) {
+        return touchPath.toAbsolutePath() + "|" + dataKey;
+    }
+
+    /**
+     * Records that a not-found marker has been written during this session, so that a later success from a sibling
+     * repository can tell the ordinary fall-through between repositories apart from a stale marker left by a
+     * previous session. Unlike {@link #setUpdated(RepositorySystemSession, String)} this is not subject to
+     * {@link #CONFIG_PROP_SESSION_STATE}, as it only influences logging.
+     */
+    @SuppressWarnings("unchecked")
+    private void setNotFound(RepositorySystemSession session, String notFoundKey) {
+        Object notFounds = session.getData().computeIfAbsent(SESSION_NOT_FOUNDS, () -> new ConcurrentHashMap<>(64));
+        ((Map<String, Boolean>) notFounds).put(notFoundKey, Boolean.TRUE);
+    }
+
+    private boolean isNotFoundInSession(RepositorySystemSession session, String notFoundKey) {
+        Object notFounds = session.getData().get(SESSION_NOT_FOUNDS);
+        return notFounds instanceof Map && ((Map<?, ?>) notFounds).containsKey(notFoundKey);
+    }
+
     private Properties read(Path touchPath) {
         Properties props = trackingFileManager.read(touchPath);
         return (props != null) ? props : new Properties();
@@ -476,9 +505,13 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
         String transferKey = getTransferKey(session, check.getRepository());
 
         setUpdated(session, updateKey);
-        Map<String, String> staleSiblingNotFounds = check.getException() == null
-                ? getStaleSiblingNotFounds(read(touchPath), dataKey, check.getItem(), check.getRepository())
-                : Collections.emptyMap();
+        Map<String, String> staleSiblingNotFounds = Collections.emptyMap();
+        if (check.getException() == null) {
+            staleSiblingNotFounds = getStaleSiblingNotFounds(
+                    session, read(touchPath), touchPath, dataKey, check.getItem(), check.getRepository());
+        } else if (check.getException() instanceof ArtifactNotFoundException) {
+            setNotFound(session, getNotFoundKey(touchPath, dataKey));
+        }
         Properties props = write(touchPath, dataKey, transferKey, check.getException(), staleSiblingNotFounds);
 
         if (Files.exists(artifactPath) && !hasErrors(props)) {
@@ -493,22 +526,40 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager {
      * resolution of the artifact to whatever lower-prioritized repository serves it. Expiring the marker forces a
      * confirming re-check of the suppressed repository (subject to the update policy) the next time it is
      * consulted, and the reroute is surfaced at WARN level instead of happening silently.
+     * <p>
+     * A marker written earlier in the same session is a different situation: repositories are consulted in
+     * order, so the first repository answering not-found and a later one serving the artifact is the ordinary
+     * fall-through, not a suppressed repository. Such markers are expired all the same, but only logged at DEBUG.
      */
     private Map<String, String> getStaleSiblingNotFounds(
-            Properties props, String dataKey, Artifact artifact, RemoteRepository repository) {
+            RepositorySystemSession session,
+            Properties props,
+            Path touchPath,
+            String dataKey,
+            Artifact artifact,
+            RemoteRepository repository) {
         Map<String, String> removals = null;
         for (Object k : props.keySet()) {
             String key = k.toString();
             if (key.endsWith(ERROR_KEY_SUFFIX)) {
                 String otherDataKey = key.substring(0, key.length() - ERROR_KEY_SUFFIX.length());
                 if (!otherDataKey.equals(dataKey) && NOT_FOUND.equals(props.getProperty(key))) {
-                    LOGGER.warn(
-                            "{} was downloaded from {} while a cached not-found from a previous attempt suppresses"
-                                    + " re-checking {}; expiring the cached not-found so that repository is checked"
-                                    + " again on the next resolution",
-                            artifact,
-                            repository.getUrl(),
-                            otherDataKey);
+                    if (isNotFoundInSession(session, getNotFoundKey(touchPath, otherDataKey))) {
+                        LOGGER.debug(
+                                "{} was downloaded from {} after {} answered not-found earlier in this session;"
+                                        + " not caching that not-found",
+                                artifact,
+                                repository.getUrl(),
+                                otherDataKey);
+                    } else {
+                        LOGGER.warn(
+                                "{} was downloaded from {} while a not-found cached by a previous session suppresses"
+                                        + " re-checking {}; expiring the cached not-found so that repository is"
+                                        + " checked again on the next resolution",
+                                artifact,
+                                repository.getUrl(),
+                                otherDataKey);
+                    }
                     if (removals == null) {
                         removals = new HashMap<>();
                     }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
@@ -18,9 +18,12 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.PrintStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Properties;
@@ -98,6 +101,22 @@ public class DefaultUpdateCheckManagerTest {
 
     static void resetSessionData(RepositorySystemSession session) {
         session.getData().set(DefaultUpdateCheckManager.SESSION_CHECKS, null);
+        session.getData().set(DefaultUpdateCheckManager.SESSION_NOT_FOUNDS, null);
+    }
+
+    /**
+     * Runs the action while capturing what the slf4j-simple binding (bound to {@code System.err}) writes.
+     */
+    private static String captureStdErr(Runnable action) throws Exception {
+        PrintStream original = System.err;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try (PrintStream capture = new PrintStream(buffer, true, "UTF-8")) {
+            System.setErr(capture);
+            action.run();
+        } finally {
+            System.setErr(original);
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private UpdateCheck<Metadata, MetadataTransferException> newMetadataCheck() {
@@ -165,6 +184,50 @@ public class DefaultUpdateCheckManagerTest {
             props.load(fis);
         }
         assertEquals("some error", props.getProperty("file:///other-repo/.error"));
+    }
+
+    @Test
+    void testTouchArtifactWarnsAboutSiblingNotFoundFromPreviousSession() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // a previous session cached a not-found answer from another repository
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> notFound = newArtifactCheck();
+        notFound.setRepository(other);
+        notFound.setAuthoritativeRepository(other);
+        notFound.setException(new ArtifactNotFoundException(artifact, other));
+        manager.touchArtifact(session, notFound);
+        assertTrue(touchFile.exists());
+
+        // in a new session the other repository is never contacted because of the cached not-found, so a
+        // successful download from a sibling repository is a silent reroute worth a warning
+        resetSessionData(session);
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        String log = captureStdErr(() -> manager.touchArtifact(session, success));
+        assertTrue(log.contains("WARN"), log);
+        assertTrue(log.contains("file:///other-repo/"), log);
+        assertFalse(touchFile.exists());
+    }
+
+    @Test
+    void testTouchArtifactDoesNotWarnAboutSiblingNotFoundFromSameSession() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // repositories are consulted in order within one session: the first answers not-found ...
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> notFound = newArtifactCheck();
+        notFound.setRepository(other);
+        notFound.setAuthoritativeRepository(other);
+        notFound.setException(new ArtifactNotFoundException(artifact, other));
+        manager.touchArtifact(session, notFound);
+        assertTrue(touchFile.exists());
+
+        // ... and the next one serves the artifact. That is the ordinary fall-through, not a stale marker
+        // suppressing a repository, so it must not be reported as a warning; the marker is still expired
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        String log = captureStdErr(() -> manager.touchArtifact(session, success));
+        assertFalse(log.contains("WARN"), log);
+        assertFalse(touchFile.exists());
     }
 
     @Test


### PR DESCRIPTION
Since #2082, when an artifact is downloaded successfully, not-found markers that other repositories left for it in the same `.lastUpdated` file are expired, and each expiry is logged at WARN as a possible sign of a stale or spoofed not-found.

That warning also fires in the ordinary case. Repositories are consulted in order and each one is touched before the next is tried, so with repositories `[A, B]` and an artifact that only exists on B, every first-time download writes A's not-found marker and then warns about expiring it, once for the POM and once for the JAR. On a fresh local repository that is one warning per file for every artifact served by a non-first repository.

The manager now remembers which not-found markers it wrote during the current session. Expiring one of those is the normal fall-through between repositories and is logged at DEBUG; a marker left by a previous session still warns, since that is the case the expiry exists for. The expiry behaviour is unchanged in both cases, and the message no longer speaks of a "previous attempt" when the marker is seconds old.

Two tests cover both cases.

*This change was created with AI assistance.*