### PR TITLE
[MRESOLVER-379] Preserve relocated candidates from version ranges

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -314,7 +314,7 @@ public class BfDependencyCollector extends DependencyCollectorDelegate {
                                 descriptorResult.getRelocations(),
                                 disableVersionManagementSubsequently);
                     }
-                    return;
+                    continue;
                 } else {
                     d = args.pool.intern(d.setArtifact(args.pool.intern(d.getArtifact())));
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
@@ -257,7 +257,7 @@ public class DfDependencyCollector extends DependencyCollectorDelegate {
                             d,
                             descriptorResult.getRelocations(),
                             disableVersionManagementSubsequently);
-                    return;
+                    continue;
                 } else {
                     d = args.pool.intern(d.setArtifact(args.pool.intern(d.getArtifact())));
 

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_BF.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_BF.txt
@@ -1,2 +1,4 @@
 transitiveDepsUseRangesAndRelocationDirtyTree:aid:ext:1 compile
 +- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:3 compile
++- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:2 compile
+\- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:1 compile

--- a/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_DF.txt
+++ b/maven-resolver-impl/src/test/resources/artifact-descriptions/transitiveDepsUseRangesAndRelocationDirtyTreeResult_DF.txt
@@ -1,2 +1,4 @@
 transitiveDepsUseRangesAndRelocationDirtyTree:aid:ext:1 compile
-\- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:1 compile
++- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:1 compile
++- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:2 compile
+\- transitiveDepsUseRangesAndRelocationDirtyTree:relocatedcid:ext:3 compile


### PR DESCRIPTION
## Summary

- Continue processing version-range candidates after handling a relocation in both the BF and DF dependency collectors.
- Update the existing range-plus-relocation dirty-tree fixtures so that all relocated candidates are retained.
- Preserve the collector-specific ordering: descending for BF and resolver order for DF.

## Problem

For a dependency such as `A:1 -> B:[1,3]`, where `B:1`, `B:2`, and
`B:3` relocate to `C:1`, `C:2`, and `C:3`, the relocation branch
returned from `processDependency` after processing one range candidate.

As a result:

- DF retained only `C:1`.
- BF retained only `C:3`, because BF iterates range candidates in
  descending order.

The remaining versions from `VersionRangeResult` were never processed.

## Fix

Replace the method-level `return` with a loop-level `continue` in the
relocation branches of both collectors.

This completes processing of the current relocation chain and then
resumes the surrounding range-candidate loop. Version selection and
conflict resolution behavior are unchanged.

## Tests

The existing
`testTransitiveDepsUseRangesAndRelocationDirtyTree` test is inherited by
all three concrete collector test variants.

Red phase, before the runtime change:

- DF expected 3 candidates but received 1 (`C:1`).
- BF with skipper expected 3 candidates but received 1 (`C:3`).
- BF without skipper expected 3 candidates but received 1 (`C:3`).

Green phase:

- Focused regression tests: 3 passed.
- Full BF/DF collector suites: 65 passed.
- `maven-resolver-impl` and prerequisite reactor modules: 1,223 tests,
  0 failures, 0 errors.
- Checkstyle, Spotless, and Apache RAT passed.
- Windows/JDK 21 full `mvn verify`: the first 14 reactor modules passed
  before `FileTransporterTest` hit three unrelated symbolic-link
  privilege errors.
- After excluding that environment-blocked test class, the first 28
  reactor modules passed, including all production modules. The
  unrelated `maven-resolver-demo-snippets` module later failed while
  downloading Guava 19.0 from Maven Central with a connection timeout.

Fixes #1051

*This change was created with AI assistance and manually reviewed and tested.*

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] This pull request addresses one issue without unrelated changes.
- [x] The pull request description explains what changes, how, and why.
- [x] The commit has a meaningful subject and body.
- [x] The behavioral regression test fails without the runtime change.
- [ ] Full `mvn verify` completed successfully. It was attempted; all
      production modules passed, but local verification was blocked by
      Windows symbolic-link privileges and a Maven Central connection timeout.
- [ ] `mvn -Prun-its verify` completed successfully. The additional IT
      profiles are unrelated to the modified collector behavior and were
      not run after the external-network failure above.
- [x] I hereby declare this contribution to be licenced under the
      [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an
      [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).