### PR TITLE
bug: LRM may be created for non-existent directories

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -149,6 +149,7 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         this.trackingFilename = requireNonNull(trackingFilename);
         this.trackingFileManager = requireNonNull(trackingFileManager);
         this.localPathPrefixComposer = requireNonNull(localPathPrefixComposer);
+        Files.createDirectories(getRepository().getBasePath());
         this.realBasePath = getRepository().getBasePath().toRealPath();
     }
 


### PR DESCRIPTION
And it caused this:

```
    Suppressed: org.eclipse.aether.repository.NoLocalRepositoryManagerException: No manager available for local repository (/home/cstamas/Worx/maveniverse/checksum/it/plugin3-its/target/local-repo) of type default
        at org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory.newInstance (EnhancedLocalRepositoryManagerFactory.java:163)
        at org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider.newLocalRepositoryManager (DefaultLocalRepositoryProvider.java:73)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.createLocalRepositoryManager (DefaultRepositorySystem.java:570)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.newLocalRepositoryManager (DefaultRepositorySystem.java:529)
        at org.apache.maven.plugins.invoker.InstallMojo.createSystemSessionForLocalRepo (InstallMojo.java:418)
        at org.apache.maven.plugins.invoker.InstallMojo.installArtifacts (InstallMojo.java:363)
        at org.apache.maven.plugins.invoker.InstallMojo.execute (InstallMojo.java:177)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:127)
        at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:336)
        at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:324)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:220)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:181)
        at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:79)
        at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:169)
        at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:166)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:106)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:74)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:121)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:267)
        at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:179)
        at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
        at org.apache.maven.cli.MavenCli.execute (MavenCli.java:1017)
        at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:299)
        at org.apache.maven.cli.MavenCli.main (MavenCli.java:219)
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
        at java.lang.reflect.Method.invoke (Method.java:580)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:362)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
    Caused by: java.nio.file.NoSuchFileException: /home/cstamas/Worx/maveniverse/checksum/it/plugin3-its/target/local-repo
        at sun.nio.fs.UnixException.translateToIOException (UnixException.java:92)
        at sun.nio.fs.UnixException.rethrowAsIOException (UnixException.java:106)
        at sun.nio.fs.UnixException.rethrowAsIOException (UnixException.java:111)
        at sun.nio.fs.UnixPath.toRealPath (UnixPath.java:834)
        at org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManager.<init> (EnhancedLocalRepositoryManager.java:152)
        at org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory.newInstance (EnhancedLocalRepositoryManagerFactory.java:161)
        at org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider.newLocalRepositoryManager (DefaultLocalRepositoryProvider.java:73)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.createLocalRepositoryManager (DefaultRepositorySystem.java:570)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.newLocalRepositoryManager (DefaultRepositorySystem.java:529)
        at org.apache.maven.plugins.invoker.InstallMojo.createSystemSessionForLocalRepo (InstallMojo.java:418)
        at org.apache.maven.plugins.invoker.InstallMojo.installArtifacts (InstallMojo.java:363)
```

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
