### PR TITLE
[1.9.x] Bring five changes over from master

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/AbstractChecksumPolicy.java
@@ -55,7 +55,11 @@ abstract class AbstractChecksumPolicy implements ChecksumPolicy {
             throws ChecksumFailureException {
         requireNonNull(algorithm, "algorithm cannot be null");
         requireNonNull(exception, "exception cannot be null");
-        logger.debug("Could not validate {} checksum for {}", algorithm, resource.getResourceName(), exception);
+        logger.debug(
+                "Could not validate {} checksum for {}",
+                algorithm,
+                LogSanitizer.sanitize(resource.getResourceName()),
+                exception);
     }
 
     @Override

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager.java
@@ -100,6 +100,44 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
 
     public static final boolean DEFAULT_AUTH_TO_DESCRIPTOR_REPOSITORIES = false;
 
+    /**
+     * Flag indicating whether a repository declared by a remote artifact descriptor (POM) may weaken the checksum
+     * policy of the operator-defined mirror it is merged into. When disabled (the default), the effective checksum
+     * policy of a mirror never becomes weaker than what the mirror itself declares for the same nature: a recessive
+     * raw repository may still enable a nature or influence update policies, but a weaker checksum policy (e.g.
+     * {@code <checksumPolicy>ignore</checksumPolicy>} in a transitive POM) is not honored and a warning is logged
+     * instead. Enabling this restores the legacy weakest-wins merge, which let any POM in the dependency graph
+     * degrade or switch off checksum verification for downloads routed through the mirror.
+     *
+     * @since 1.9.28
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_RAW_CHECKSUM_POLICY_DOWNGRADE}
+     */
+    public static final String CONFIG_PROP_RAW_CHECKSUM_POLICY_DOWNGRADE =
+            "aether.remoteRepositoryManager.rawRepositoryChecksumPolicyDowngrade";
+
+    public static final boolean DEFAULT_RAW_CHECKSUM_POLICY_DOWNGRADE = false;
+
+    /**
+     * Flag indicating whether the merge of a repository's release and snapshot policies (used when a single
+     * effective policy has to serve both natures, most notably for metadata of nature RELEASE_OR_SNAPSHOT such as
+     * {@code maven-metadata.xml} version lists) may pick the <em>weaker</em> of the two checksum policies, which was
+     * the legacy behavior. When disabled (the default), the stronger of the two checksum policies wins, so enabling
+     * snapshots with a lenient checksum policy no longer silently downgrades checksum enforcement below what the
+     * operator configured for releases (or vice versa). An explicit checksum policy set on the session (e.g. via
+     * {@code --strict-checksums}) takes precedence over either behavior, as before.
+     *
+     * @since 1.9.28
+     * @configurationSource {@link RepositorySystemSession#getConfigProperties()}
+     * @configurationType {@link java.lang.Boolean}
+     * @configurationDefaultValue {@link #DEFAULT_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY}
+     */
+    public static final String CONFIG_PROP_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY =
+            "aether.remoteRepositoryManager.natureMergeWeakestChecksumPolicy";
+
+    public static final boolean DEFAULT_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY = false;
+
     private UpdatePolicyAnalyzer updatePolicyAnalyzer;
 
     private ChecksumPolicyProvider checksumPolicyProvider;
@@ -185,7 +223,8 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
                 if (key.equals(getKey(dominantRepository))) {
                     if (!dominantRepository.getMirroredRepositories().isEmpty()
                             && !repository.getMirroredRepositories().isEmpty()) {
-                        RemoteRepository mergedRepository = mergeMirrors(session, dominantRepository, repository);
+                        RemoteRepository mergedRepository =
+                                mergeMirrors(session, dominantRepository, repository, recessiveIsRaw);
                         if (mergedRepository != dominantRepository) {
                             it.set(mergedRepository);
                         }
@@ -254,8 +293,51 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
         return repository.getId();
     }
 
+    private static RepositoryPolicy clampChecksumPolicy(
+            RepositoryPolicy merged, RepositoryPolicy floor, RemoteRepository rec) {
+        if (merged == null || floor == null) {
+            return merged;
+        }
+        if (checksumPolicyRank(merged.getChecksumPolicy()) < checksumPolicyRank(floor.getChecksumPolicy())) {
+            LOGGER.warn(
+                    "Ignoring checksum policy '{}' contributed by repository {} ({}) declared by a remote artifact"
+                            + " descriptor: it would downgrade the checksum policy '{}' of the mirror serving it;"
+                            + " set {}=true to restore the legacy weakest-wins merge",
+                    merged.getChecksumPolicy(),
+                    rec.getId(),
+                    rec.getUrl(),
+                    floor.getChecksumPolicy(),
+                    CONFIG_PROP_RAW_CHECKSUM_POLICY_DOWNGRADE);
+            return new RepositoryPolicy(merged.isEnabled(), merged.getUpdatePolicy(), floor.getChecksumPolicy());
+        }
+        return merged;
+    }
+
+    private static int checksumPolicyRank(String policy) {
+        if (policy == null) {
+            return -1;
+        }
+        switch (policy) {
+            case RepositoryPolicy.CHECKSUM_POLICY_FAIL:
+                return 2;
+            case RepositoryPolicy.CHECKSUM_POLICY_WARN:
+                return 1;
+            case RepositoryPolicy.CHECKSUM_POLICY_IGNORE:
+                return 0;
+            default:
+                // unknown (potentially attacker-supplied) values rank below any known policy, so they can never
+                // displace an operator-configured one
+                return -1;
+        }
+    }
+
     private RemoteRepository mergeMirrors(
-            RepositorySystemSession session, RemoteRepository dominant, RemoteRepository recessive) {
+            RepositorySystemSession session,
+            RemoteRepository dominant,
+            RemoteRepository recessive,
+            boolean recessiveIsRaw) {
+        boolean rawChecksumPolicyDowngrade = ConfigUtils.getBoolean(
+                session, DEFAULT_RAW_CHECKSUM_POLICY_DOWNGRADE, CONFIG_PROP_RAW_CHECKSUM_POLICY_DOWNGRADE);
         RemoteRepository.Builder merged = null;
         RepositoryPolicy releases = null, snapshots = null;
 
@@ -277,6 +359,13 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
 
             releases = merge(session, releases, rec.getPolicy(false), false);
             snapshots = merge(session, snapshots, rec.getPolicy(true), false);
+
+            if (recessiveIsRaw && !rawChecksumPolicyDowngrade) {
+                // "recessive" originates from a remote artifact descriptor (POM): remotely supplied input must
+                // never weaken the checksum policy the operator configured on the mirror itself
+                releases = clampChecksumPolicy(releases, dominant.getPolicy(false), rec);
+                snapshots = clampChecksumPolicy(snapshots, dominant.getPolicy(true), rec);
+            }
 
             merged.addMirroredRepository(rec);
         }
@@ -329,6 +418,15 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
             //noinspection StatementWithEmptyBody
             if (globalPolicy && checksums != null && !checksums.isEmpty()) {
                 // use global override
+            } else if (globalPolicy
+                    && !ConfigUtils.getBoolean(
+                            session,
+                            DEFAULT_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY,
+                            CONFIG_PROP_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY)) {
+                // merging the release and snapshot policies of a single repository into one effective policy
+                // (e.g. for metadata of nature RELEASE_OR_SNAPSHOT): the result must not be weaker than what the
+                // operator configured for either nature, so the stronger checksum policy wins
+                checksums = strongerChecksumPolicy(policy1.getChecksumPolicy(), policy2.getChecksumPolicy());
             } else {
                 checksums = checksumPolicyProvider.getEffectiveChecksumPolicy(
                         session, policy1.getChecksumPolicy(), policy2.getChecksumPolicy());
@@ -347,6 +445,13 @@ public class DefaultRemoteRepositoryManager implements RemoteRepositoryManager, 
         }
 
         return policy;
+    }
+
+    private static String strongerChecksumPolicy(String policy1, String policy2) {
+        if (checksumPolicyRank(policy2) > checksumPolicyRank(policy1)) {
+            return policy2;
+        }
+        return policy1;
     }
 
     private RepositoryPolicy merge(RepositoryPolicy policy, String updates, String checksums) {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManager.java
@@ -79,6 +79,13 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager, Service {
         }
     };
 
+    static final Object SESSION_NOT_FOUNDS = new Object() {
+        @Override
+        public String toString() {
+            return "updateCheckManager.notFounds";
+        }
+    };
+
     static final String CONFIG_PROP_SESSION_STATE = "aether.updateCheckManager.sessionState";
 
     private static final int STATE_ENABLED = 0;
@@ -457,6 +464,27 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager, Service {
         return updatePolicyAnalyzer.isUpdatedRequired(session, lastModified, policy);
     }
 
+    private String getNotFoundKey(File touchFile, String dataKey) {
+        return touchFile.getAbsolutePath() + "|" + dataKey;
+    }
+
+    /**
+     * Records that a not-found marker has been written during this session, so that a later success from a sibling
+     * repository can tell the ordinary fall-through between repositories apart from a stale marker left by a
+     * previous session. Unlike {@link #setUpdated(RepositorySystemSession, String)} this is not subject to
+     * {@link #CONFIG_PROP_SESSION_STATE}, as it only influences logging.
+     */
+    @SuppressWarnings("unchecked")
+    private void setNotFound(RepositorySystemSession session, String notFoundKey) {
+        Object notFounds = session.getData().computeIfAbsent(SESSION_NOT_FOUNDS, () -> new ConcurrentHashMap<>(64));
+        ((Map<String, Boolean>) notFounds).put(notFoundKey, Boolean.TRUE);
+    }
+
+    private boolean isNotFoundInSession(RepositorySystemSession session, String notFoundKey) {
+        Object notFounds = session.getData().get(SESSION_NOT_FOUNDS);
+        return notFounds instanceof Map && ((Map<?, ?>) notFounds).containsKey(notFoundKey);
+    }
+
     private Properties read(File touchFile) {
         Properties props = trackingFileManager.read(touchFile);
         return (props != null) ? props : new Properties();
@@ -473,11 +501,70 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager, Service {
         String transferKey = getTransferKey(session, check.getRepository());
 
         setUpdated(session, updateKey);
-        Properties props = write(touchFile, dataKey, transferKey, check.getException());
+        Map<String, String> staleSiblingNotFounds = Collections.emptyMap();
+        if (check.getException() == null) {
+            staleSiblingNotFounds = getStaleSiblingNotFounds(
+                    session, read(touchFile), touchFile, dataKey, check.getItem(), check.getRepository());
+        } else if (check.getException() instanceof ArtifactNotFoundException) {
+            setNotFound(session, getNotFoundKey(touchFile, dataKey));
+        }
+        Properties props = write(touchFile, dataKey, transferKey, check.getException(), staleSiblingNotFounds);
 
         if (artifactFile.exists() && !hasErrors(props)) {
             trackingFileManager.delete(touchFile);
         }
+    }
+
+    /**
+     * Collects, for removal, cached not-found markers left by other repositories for an artifact that has just
+     * been successfully downloaded. A cached not-found silently suppresses any remote contact with the repository
+     * that issued it, so a single spoofed or transient "not found" answer would otherwise durably reroute
+     * resolution of the artifact to whatever lower-prioritized repository serves it. Expiring the marker forces a
+     * confirming re-check of the suppressed repository (subject to the update policy) the next time it is
+     * consulted, and the reroute is surfaced at WARN level instead of happening silently.
+     * <p>
+     * A marker written earlier in the same session is a different situation: repositories are consulted in
+     * order, so the first repository answering not-found and a later one serving the artifact is the ordinary
+     * fall-through, not a suppressed repository. Such markers are expired all the same, but only logged at DEBUG.
+     */
+    private Map<String, String> getStaleSiblingNotFounds(
+            RepositorySystemSession session,
+            Properties props,
+            File touchFile,
+            String dataKey,
+            Artifact artifact,
+            RemoteRepository repository) {
+        Map<String, String> removals = null;
+        for (Object k : props.keySet()) {
+            String key = k.toString();
+            if (key.endsWith(ERROR_KEY_SUFFIX)) {
+                String otherDataKey = key.substring(0, key.length() - ERROR_KEY_SUFFIX.length());
+                if (!otherDataKey.equals(dataKey) && NOT_FOUND.equals(props.getProperty(key))) {
+                    if (isNotFoundInSession(session, getNotFoundKey(touchFile, otherDataKey))) {
+                        LOGGER.debug(
+                                "{} was downloaded from {} after {} answered not-found earlier in this session;"
+                                        + " not caching that not-found",
+                                artifact,
+                                repository.getUrl(),
+                                otherDataKey);
+                    } else {
+                        LOGGER.warn(
+                                "{} was downloaded from {} while a not-found cached by a previous session suppresses"
+                                        + " re-checking {}; expiring the cached not-found so that repository is"
+                                        + " checked again on the next resolution",
+                                artifact,
+                                repository.getUrl(),
+                                otherDataKey);
+                    }
+                    if (removals == null) {
+                        removals = new HashMap<>();
+                    }
+                    removals.put(key, null);
+                    removals.put(otherDataKey + UPDATED_KEY_SUFFIX, null);
+                }
+            }
+        }
+        return removals != null ? removals : Collections.emptyMap();
     }
 
     private boolean hasErrors(Properties props) {
@@ -500,11 +587,12 @@ public class DefaultUpdateCheckManager implements UpdateCheckManager, Service {
         String transferKey = getTransferKey(session, metadataFile, check.getRepository());
 
         setUpdated(session, updateKey);
-        write(touchFile, dataKey, transferKey, check.getException());
+        write(touchFile, dataKey, transferKey, check.getException(), Collections.emptyMap());
     }
 
-    private Properties write(File touchFile, String dataKey, String transferKey, Exception error) {
-        Map<String, String> updates = new HashMap<>();
+    private Properties write(
+            File touchFile, String dataKey, String transferKey, Exception error, Map<String, String> extraUpdates) {
+        Map<String, String> updates = new HashMap<>(extraUpdates);
 
         String timestamp = Long.toString(System.currentTimeMillis());
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LogSanitizer.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/LogSanitizer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+/**
+ * Sanitizes strings that may carry remote-derived bytes (artifact coordinates, checksum values, transfer error
+ * messages) before they are logged or persisted. Bytes received from a remote repository must not be able to
+ * influence terminal rendering: raw control characters such as ESC (ANSI escape sequences) or CR (line rewrite)
+ * embedded in, for example, a transitive POM's coordinates could otherwise erase or forge log lines - including
+ * the sole integrity WARNING emitted under the default "warn" checksum policy.
+ *
+ * @since 1.9.28
+ */
+final class LogSanitizer {
+    private LogSanitizer() {}
+
+    /**
+     * Replaces every ISO control character below U+0020 (except LF and TAB) as well as DEL (U+007F) with its
+     * visible {@code \}{@code uXXXX} escape, preserving the evidence while neutralizing terminal escape
+     * sequences. Returns the input instance unchanged (no allocation) when nothing needs escaping; returns
+     * {@code null} for {@code null} input.
+     */
+    static String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        StringBuilder result = null;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if ((c < 0x20 && c != '\n' && c != '\t') || c == 0x7f) {
+                if (result == null) {
+                    result = new StringBuilder(value.length() + 16);
+                    result.append(value, 0, i);
+                }
+                result.append(String.format("\\u%04X", (int) c));
+            } else if (result != null) {
+                result.append(c);
+            }
+        }
+        return result == null ? value : result.toString();
+    }
+}

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/WarnChecksumPolicy.java
@@ -34,8 +34,8 @@ final class WarnChecksumPolicy extends AbstractChecksumPolicy {
     public boolean onTransferChecksumFailure(ChecksumFailureException exception) {
         logger.warn(
                 "Could not validate integrity of download from {}{}",
-                resource.getRepositoryUrl(),
-                resource.getResourceName(),
+                LogSanitizer.sanitize(resource.getRepositoryUrl()),
+                LogSanitizer.sanitize(resource.getResourceName()),
                 exception);
         return true;
     }

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/DataPool.java
@@ -188,7 +188,7 @@ public final class DataPool {
     }
 
     public DescriptorKey toKey(ArtifactDescriptorRequest request) {
-        return new DescriptorKey(request.getArtifact());
+        return new DescriptorKey(request.getArtifact(), request.getRepositories());
     }
 
     public ArtifactDescriptorResult getDescriptor(DescriptorKey key, ArtifactDescriptorRequest request) {
@@ -210,7 +210,20 @@ public final class DataPool {
     }
 
     public void putDescriptor(DescriptorKey key, ArtifactDescriptorException e) {
-        descriptors.intern(key, BadDescriptor.INSTANCE);
+        descriptors.intern(key, new BadDescriptor(e));
+    }
+
+    /**
+     * Returns the failure reason of a previously cached bad descriptor, or {@code null} if the given key does not
+     * map to a cached failure. Only the exception message is retained (not the exception itself), to avoid pinning
+     * the originating request in the session-wide pool.
+     */
+    public String getDescriptorFailure(DescriptorKey key) {
+        Descriptor descriptor = descriptors.get(key);
+        if (descriptor instanceof BadDescriptor) {
+            return ((BadDescriptor) descriptor).reason;
+        }
+        return null;
     }
 
     private List<Dependency> intern(List<Dependency> dependencies) {
@@ -253,10 +266,12 @@ public final class DataPool {
 
     public static final class DescriptorKey {
         private final Artifact artifact;
+        private final List<RemoteRepository> repositories;
         private final int hashCode;
 
-        private DescriptorKey(Artifact artifact) {
+        private DescriptorKey(Artifact artifact, List<RemoteRepository> repositories) {
             this.artifact = artifact;
+            this.repositories = repositories;
             this.hashCode = Objects.hashCode(artifact);
         }
 
@@ -269,7 +284,7 @@ public final class DataPool {
                 return false;
             }
             DescriptorKey that = (DescriptorKey) o;
-            return Objects.equals(artifact, that.artifact);
+            return Objects.equals(artifact, that.artifact) && repositoriesEquals(repositories, that.repositories);
         }
 
         @Override
@@ -279,7 +294,8 @@ public final class DataPool {
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + "{" + "artifact='" + artifact + '\'' + '}';
+            return getClass().getSimpleName() + "{" + "artifact='" + artifact + '\'' + ", repositories='" + repositories
+                    + '\'' + '}';
         }
     }
 
@@ -324,7 +340,11 @@ public final class DataPool {
 
     static final class BadDescriptor extends Descriptor {
 
-        static final BadDescriptor INSTANCE = new BadDescriptor();
+        final String reason;
+
+        BadDescriptor(ArtifactDescriptorException exception) {
+            this.reason = exception != null ? exception.getMessage() : null;
+        }
 
         public ArtifactDescriptorResult toResult(ArtifactDescriptorRequest request) {
             return NO_DESCRIPTOR;
@@ -389,41 +409,41 @@ public final class DataPool {
                 return false;
             }
             ConstraintKey that = (ConstraintKey) obj;
-            return artifact.equals(that.artifact) && equals(repositories, that.repositories);
-        }
-
-        private static boolean equals(List<RemoteRepository> repos1, List<RemoteRepository> repos2) {
-            if (repos1.size() != repos2.size()) {
-                return false;
-            }
-            for (Iterator<RemoteRepository> it1 = repos1.iterator(), it2 = repos2.iterator();
-                    it1.hasNext() && it2.hasNext(); ) {
-                RemoteRepository repo1 = it1.next();
-                RemoteRepository repo2 = it2.next();
-                if (repo1.isRepositoryManager() != repo2.isRepositoryManager()) {
-                    return false;
-                }
-                if (repo1.isRepositoryManager()) {
-                    if (!equals(repo1.getMirroredRepositories(), repo2.getMirroredRepositories())) {
-                        return false;
-                    }
-                } else if (!repo1.getUrl().equals(repo2.getUrl())) {
-                    return false;
-                } else if (repo1.getPolicy(true).isEnabled()
-                        != repo2.getPolicy(true).isEnabled()) {
-                    return false;
-                } else if (repo1.getPolicy(false).isEnabled()
-                        != repo2.getPolicy(false).isEnabled()) {
-                    return false;
-                }
-            }
-            return true;
+            return artifact.equals(that.artifact) && repositoriesEquals(repositories, that.repositories);
         }
 
         @Override
         public int hashCode() {
             return hashCode;
         }
+    }
+
+    private static boolean repositoriesEquals(List<RemoteRepository> repos1, List<RemoteRepository> repos2) {
+        if (repos1.size() != repos2.size()) {
+            return false;
+        }
+        for (Iterator<RemoteRepository> it1 = repos1.iterator(), it2 = repos2.iterator();
+                it1.hasNext() && it2.hasNext(); ) {
+            RemoteRepository repo1 = it1.next();
+            RemoteRepository repo2 = it2.next();
+            if (repo1.isRepositoryManager() != repo2.isRepositoryManager()) {
+                return false;
+            }
+            if (repo1.isRepositoryManager()) {
+                if (!repositoriesEquals(repo1.getMirroredRepositories(), repo2.getMirroredRepositories())) {
+                    return false;
+                }
+            } else if (!repo1.getUrl().equals(repo2.getUrl())) {
+                return false;
+            } else if (repo1.getPolicy(true).isEnabled()
+                    != repo2.getPolicy(true).isEnabled()) {
+                return false;
+            } else if (repo1.getPolicy(false).isEnabled()
+                    != repo2.getPolicy(false).isEnabled()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static final class GraphKey {

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector.java
@@ -461,6 +461,15 @@ public class BfDependencyCollector extends DependencyCollectorDelegate implement
             }
 
         } else if (descriptorResult == DataPool.NO_DESCRIPTOR) {
+            String reason = pool.getDescriptorFailure(key);
+            results.addException(
+                    context.dependency,
+                    new ArtifactDescriptorException(
+                            new ArtifactDescriptorResult(descriptorRequest),
+                            "Artifact descriptor resolution of " + descriptorRequest.getArtifact()
+                                    + " already failed in this session"
+                                    + (reason != null && !reason.isEmpty() ? ": " + reason : "")),
+                    context.parents);
             return null;
         }
 

--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector.java
@@ -388,6 +388,15 @@ public class DfDependencyCollector extends DependencyCollectorDelegate implement
             }
 
         } else if (descriptorResult == DataPool.NO_DESCRIPTOR) {
+            String reason = pool.getDescriptorFailure(key);
+            results.addException(
+                    d,
+                    new ArtifactDescriptorException(
+                            new ArtifactDescriptorResult(descriptorRequest),
+                            "Artifact descriptor resolution of " + descriptorRequest.getArtifact()
+                                    + " already failed in this session"
+                                    + (reason != null && !reason.isEmpty() ? ": " + reason : "")),
+                    args.nodes.nodes);
             return null;
         }
 

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManagerTest.java
@@ -102,8 +102,81 @@ public class DefaultRemoteRepositoryManagerTest {
 
         RepositoryPolicy effectivePolicy = manager.getPolicy(session, repo, true, true);
         assertTrue(effectivePolicy.isEnabled());
-        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_IGNORE, effectivePolicy.getChecksumPolicy());
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_FAIL, effectivePolicy.getChecksumPolicy());
         assertEquals(RepositoryPolicy.UPDATE_POLICY_ALWAYS, effectivePolicy.getUpdatePolicy());
+    }
+
+    @Test
+    public void testGetPolicyNatureMergePicksStrongerChecksumPolicy() {
+        RepositoryPolicy snapshotPolicy = new RepositoryPolicy(
+                true, RepositoryPolicy.UPDATE_POLICY_ALWAYS, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
+        RepositoryPolicy releasePolicy =
+                new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+
+        RemoteRepository repo = new RemoteRepository.Builder("id", "type", "http://localhost")
+                .setSnapshotPolicy(snapshotPolicy)
+                .setReleasePolicy(releasePolicy)
+                .build();
+
+        RepositoryPolicy effectivePolicy = manager.getPolicy(session, repo, true, true);
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_FAIL, effectivePolicy.getChecksumPolicy());
+    }
+
+    @Test
+    public void testGetPolicyLegacyWeakestChecksumPolicyNatureMerge() {
+        RepositoryPolicy snapshotPolicy = new RepositoryPolicy(
+                true, RepositoryPolicy.UPDATE_POLICY_ALWAYS, RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
+        RepositoryPolicy releasePolicy =
+                new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
+
+        RemoteRepository repo = new RemoteRepository.Builder("id", "type", "http://localhost")
+                .setSnapshotPolicy(snapshotPolicy)
+                .setReleasePolicy(releasePolicy)
+                .build();
+
+        session.setConfigProperty(
+                DefaultRemoteRepositoryManager.CONFIG_PROP_NATURE_MERGE_WEAKEST_CHECKSUM_POLICY, true);
+
+        RepositoryPolicy effectivePolicy = manager.getPolicy(session, repo, true, true);
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_IGNORE, effectivePolicy.getChecksumPolicy());
+    }
+
+    @Test
+    public void testGetPolicySessionChecksumPolicyOverridesNatureMerge() {
+        RepositoryPolicy snapshotPolicy = new RepositoryPolicy(
+                true, RepositoryPolicy.UPDATE_POLICY_ALWAYS, RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
+        RepositoryPolicy releasePolicy =
+                new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
+
+        RemoteRepository repo = new RemoteRepository.Builder("id", "type", "http://localhost")
+                .setSnapshotPolicy(snapshotPolicy)
+                .setReleasePolicy(releasePolicy)
+                .build();
+
+        session.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_WARN);
+
+        RepositoryPolicy effectivePolicy = manager.getPolicy(session, repo, true, true);
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_WARN, effectivePolicy.getChecksumPolicy());
+    }
+
+    @Test
+    public void testGetPolicySingleNatureKeepsItsChecksumPolicy() {
+        RepositoryPolicy snapshotPolicy = new RepositoryPolicy(
+                true, RepositoryPolicy.UPDATE_POLICY_ALWAYS, RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
+        RepositoryPolicy releasePolicy =
+                new RepositoryPolicy(true, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_FAIL);
+
+        RemoteRepository repo = new RemoteRepository.Builder("id", "type", "http://localhost")
+                .setSnapshotPolicy(snapshotPolicy)
+                .setReleasePolicy(releasePolicy)
+                .build();
+
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL,
+                manager.getPolicy(session, repo, true, false).getChecksumPolicy());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_IGNORE,
+                manager.getPolicy(session, repo, false, true).getChecksumPolicy());
     }
 
     @Test
@@ -363,5 +436,154 @@ public class DefaultRemoteRepositoryManagerTest {
 
         assertEquals(1, result.size());
         assertSame(auth, result.get(0).getAuthentication());
+    }
+
+    @Test
+    public void testAggregateMirrorReposRawRecessiveCannotWeakenMirrorChecksumPolicy() {
+        RemoteRepository dominant1 = newRepo(
+                        "a",
+                        "https://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .build();
+        RemoteRepository dominantMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .addMirroredRepository(dominant1)
+                .build();
+
+        RemoteRepository recessive1 = newRepo(
+                        "evil",
+                        "http://evil",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE)
+                .build();
+        final RemoteRepository recessiveMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE)
+                .addMirroredRepository(recessive1)
+                .build();
+        session.setMirrorSelector(new MirrorSelector() {
+            public RemoteRepository getMirror(RemoteRepository repository) {
+                return recessiveMirror1;
+            }
+        });
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Arrays.asList(dominantMirror1), Arrays.asList(recessive1), true);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getMirroredRepositories().size());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL,
+                result.get(0).getPolicy(false).getChecksumPolicy());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_FAIL,
+                result.get(0).getPolicy(true).getChecksumPolicy());
+    }
+
+    @Test
+    public void testAggregateMirrorReposRawRecessiveMayWeakenMirrorChecksumPolicyWhenAllowed() {
+        RemoteRepository dominant1 = newRepo(
+                        "a",
+                        "https://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .build();
+        RemoteRepository dominantMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .addMirroredRepository(dominant1)
+                .build();
+
+        RemoteRepository recessive1 = newRepo(
+                        "evil",
+                        "http://evil",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE)
+                .build();
+        final RemoteRepository recessiveMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE)
+                .addMirroredRepository(recessive1)
+                .build();
+        session.setMirrorSelector(new MirrorSelector() {
+            public RemoteRepository getMirror(RemoteRepository repository) {
+                return recessiveMirror1;
+            }
+        });
+        session.setConfigProperty(DefaultRemoteRepositoryManager.CONFIG_PROP_RAW_CHECKSUM_POLICY_DOWNGRADE, true);
+
+        List<RemoteRepository> result =
+                manager.aggregateRepositories(session, Arrays.asList(dominantMirror1), Arrays.asList(recessive1), true);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getMirroredRepositories().size());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_IGNORE,
+                result.get(0).getPolicy(false).getChecksumPolicy());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_IGNORE,
+                result.get(0).getPolicy(true).getChecksumPolicy());
+    }
+
+    @Test
+    public void testAggregateMirrorReposNonRawMergeKeepsLegacyChecksumPolicyMerge() {
+        RemoteRepository dominant1 = newRepo(
+                        "a",
+                        "https://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .build();
+        RemoteRepository dominantMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL)
+                .addMirroredRepository(dominant1)
+                .build();
+
+        RemoteRepository recessive1 = newRepo(
+                        "b",
+                        "https://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_WARN)
+                .build();
+        RemoteRepository recessiveMirror1 = newRepo(
+                        "x",
+                        "file://",
+                        true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_WARN)
+                .addMirroredRepository(recessive1)
+                .build();
+
+        List<RemoteRepository> result = manager.aggregateRepositories(
+                session, Arrays.asList(dominantMirror1), Arrays.asList(recessiveMirror1), false);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getMirroredRepositories().size());
+        assertEquals(
+                RepositoryPolicy.CHECKSUM_POLICY_WARN,
+                result.get(0).getPolicy(false).getChecksumPolicy());
     }
 }

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/DefaultUpdateCheckManagerTest.java
@@ -18,10 +18,15 @@
  */
 package org.eclipse.aether.internal.impl;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.PrintStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Properties;
 import java.util.TimeZone;
 
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -44,6 +49,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -100,6 +106,23 @@ public class DefaultUpdateCheckManagerTest {
 
     static void resetSessionData(RepositorySystemSession session) {
         session.getData().set(DefaultUpdateCheckManager.SESSION_CHECKS, null);
+        session.getData().set(DefaultUpdateCheckManager.SESSION_NOT_FOUNDS, null);
+    }
+
+    /**
+     * Runs the action while capturing what the slf4j-simple binding (bound to {@code System.err}) writes.
+     */
+    private static String captureStdErr(Runnable action) {
+        PrintStream original = System.err;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream capture = new PrintStream(buffer, true);
+        try {
+            System.setErr(capture);
+            action.run();
+        } finally {
+            System.setErr(original);
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private UpdateCheck<Metadata, MetadataTransferException> newMetadataCheck() {
@@ -119,6 +142,97 @@ public class DefaultUpdateCheckManagerTest {
         check.setRepository(repository);
         check.setPolicy(RepositoryPolicy.UPDATE_POLICY_INTERVAL + ":10");
         return check;
+    }
+
+    @Test
+    public void testTouchArtifactExpiresSiblingCachedNotFoundOnSuccessfulDownload() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // a previous attempt cached a not-found answer from another repository
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> notFound = newArtifactCheck();
+        notFound.setRepository(other);
+        notFound.setAuthoritativeRepository(other);
+        notFound.setException(new ArtifactNotFoundException(artifact, other));
+        manager.touchArtifact(session, notFound);
+        assertTrue(touchFile.exists());
+
+        // the artifact is then successfully downloaded from a sibling repository: the stale not-found marker
+        // must not survive and silently keep suppressing the other repository (here no errors remain at all,
+        // so the whole touch file is deleted)
+        resetSessionData(session);
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        manager.touchArtifact(session, success);
+        assertFalse(touchFile.exists());
+    }
+
+    @Test
+    public void testTouchArtifactKeepsSiblingTransferErrorOnSuccessfulDownload() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // a previous attempt cached a transfer error (not a not-found) from another repository
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> failed = newArtifactCheck();
+        failed.setRepository(other);
+        failed.setAuthoritativeRepository(other);
+        failed.setException(new ArtifactTransferException(artifact, other, "some error"));
+        manager.touchArtifact(session, failed);
+        assertTrue(touchFile.exists());
+
+        // only cached not-found markers are expired by a sibling success; transfer errors stay cached
+        resetSessionData(session);
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        manager.touchArtifact(session, success);
+        assertTrue(touchFile.exists());
+        Properties props = new Properties();
+        try (FileInputStream fis = new FileInputStream(touchFile)) {
+            props.load(fis);
+        }
+        assertEquals("some error", props.getProperty("file:///other-repo/.error"));
+    }
+
+    @Test
+    public void testTouchArtifactWarnsAboutSiblingNotFoundFromPreviousSession() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // a previous session cached a not-found answer from another repository
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> notFound = newArtifactCheck();
+        notFound.setRepository(other);
+        notFound.setAuthoritativeRepository(other);
+        notFound.setException(new ArtifactNotFoundException(artifact, other));
+        manager.touchArtifact(session, notFound);
+        assertTrue(touchFile.exists());
+
+        // in a new session the other repository is never contacted because of the cached not-found, so a
+        // successful download from a sibling repository is a silent reroute worth a warning
+        resetSessionData(session);
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        String log = captureStdErr(() -> manager.touchArtifact(session, success));
+        assertTrue(log, log.contains("WARN"));
+        assertTrue(log, log.contains("file:///other-repo/"));
+        assertFalse(touchFile.exists());
+    }
+
+    @Test
+    public void testTouchArtifactDoesNotWarnAboutSiblingNotFoundFromSameSession() throws Exception {
+        File touchFile = new File(artifact.getFile().getPath() + ".lastUpdated");
+
+        // repositories are consulted in order within one session: the first answers not-found ...
+        RemoteRepository other = new RemoteRepository.Builder("other", "default", "file:///other-repo").build();
+        UpdateCheck<Artifact, ArtifactTransferException> notFound = newArtifactCheck();
+        notFound.setRepository(other);
+        notFound.setAuthoritativeRepository(other);
+        notFound.setException(new ArtifactNotFoundException(artifact, other));
+        manager.touchArtifact(session, notFound);
+        assertTrue(touchFile.exists());
+
+        // ... and the next one serves the artifact. That is the ordinary fall-through, not a stale marker
+        // suppressing a repository, so it must not be reported as a warning; the marker is still expired
+        UpdateCheck<Artifact, ArtifactTransferException> success = newArtifactCheck();
+        String log = captureStdErr(() -> manager.touchArtifact(session, success));
+        assertFalse(log, log.contains("WARN"));
+        assertFalse(touchFile.exists());
     }
 
     @Test(expected = Exception.class)

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/LogSanitizerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/LogSanitizerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.internal.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class LogSanitizerTest {
+
+    private static final char ESC = '\u001B';
+
+    private static final char DEL = '\u007F';
+
+    @Test
+    public void nullPassesThrough() {
+        assertNull(LogSanitizer.sanitize(null));
+    }
+
+    @Test
+    public void cleanStringReturnsSameInstance() {
+        String clean = "org.apache.maven.resolver:artifact:jar:1.0 from https://repo.example.com/";
+        assertSame(clean, LogSanitizer.sanitize(clean));
+    }
+
+    @Test
+    public void newlineAndTabArePreserved() {
+        String value = "line1\nline2\tcolumn";
+        assertSame(value, LogSanitizer.sanitize(value));
+    }
+
+    @Test
+    public void escapeSequenceIsNeutralized() {
+        // ESC[2K erases the current terminal line, CR returns the cursor: together they cancel a WARNING line
+        assertEquals("abc\\u001B[2K\\u000Ddef", LogSanitizer.sanitize("abc" + ESC + "[2K\rdef"));
+    }
+
+    @Test
+    public void carriageReturnIsEscaped() {
+        assertEquals("evil\\u000D[INFO] BUILD SUCCESS", LogSanitizer.sanitize("evil\r[INFO] BUILD SUCCESS"));
+    }
+
+    @Test
+    public void deleteAndLowControlsAreEscaped() {
+        assertEquals("a\\u007Fb\\u0000c\\u0008d", LogSanitizer.sanitize("a" + DEL + "b\u0000c\bd"));
+    }
+
+    @Test
+    public void sanitizedOutputContainsNoRawControls() {
+        StringBuilder hostile = new StringBuilder("x");
+        for (char c = 0; c < 0x20; c++) {
+            hostile.append(c);
+        }
+        hostile.append(DEL).append('y');
+        String sanitized = LogSanitizer.sanitize(hostile.toString());
+        for (int i = 0; i < sanitized.length(); i++) {
+            char c = sanitized.charAt(i);
+            assertFalse("raw control char at index " + i, (c < 0x20 && c != '\n' && c != '\t') || c == DEL);
+        }
+    }
+}

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DataPoolTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/collect/DataPoolTest.java
@@ -24,6 +24,7 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
@@ -31,6 +32,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class DataPoolTest {
 
@@ -61,6 +64,68 @@ public class DataPoolTest {
         assertEquals(result.getManagedDependencies(), cached.getManagedDependencies());
         assertEquals(result.getRepositories(), cached.getRepositories());
         assertEquals(result.getAliases(), cached.getAliases());
+    }
+
+    @Test
+    public void testDescriptorCachingIsRepositoryScoped() {
+        RemoteRepository repoA =
+                new RemoteRepository.Builder("repo-a", "default", "https://repo-a.example.com/").build();
+        RemoteRepository repoB =
+                new RemoteRepository.Builder("repo-b", "default", "https://repo-b.example.com/").build();
+
+        ArtifactDescriptorRequest requestA = new ArtifactDescriptorRequest();
+        requestA.setArtifact(new DefaultArtifact("gid:aid:1"));
+        requestA.setRepositories(Collections.singletonList(repoA));
+        ArtifactDescriptorResult result = new ArtifactDescriptorResult(requestA);
+        result.setArtifact(requestA.getArtifact());
+
+        DataPool pool = newDataPool();
+        pool.putDescriptor(pool.toKey(requestA), result);
+
+        // same artifact, same repositories (equal id + url): must hit
+        ArtifactDescriptorRequest sameAsA = new ArtifactDescriptorRequest();
+        sameAsA.setArtifact(new DefaultArtifact("gid:aid:1"));
+        sameAsA.setRepositories(Collections.singletonList(
+                new RemoteRepository.Builder("repo-a", "default", "https://repo-a.example.com/").build()));
+        assertNotNull(pool.getDescriptor(pool.toKey(sameAsA), sameAsA));
+
+        // same artifact, different repositories: must NOT replay the cached descriptor
+        ArtifactDescriptorRequest requestB = new ArtifactDescriptorRequest();
+        requestB.setArtifact(new DefaultArtifact("gid:aid:1"));
+        requestB.setRepositories(Collections.singletonList(repoB));
+        assertNull(pool.getDescriptor(pool.toKey(requestB), requestB));
+    }
+
+    @Test
+    public void testBadDescriptorCachingIsRepositoryScoped() {
+        RemoteRepository repoA =
+                new RemoteRepository.Builder("repo-a", "default", "https://repo-a.example.com/").build();
+        RemoteRepository repoB =
+                new RemoteRepository.Builder("repo-b", "default", "https://repo-b.example.com/").build();
+
+        ArtifactDescriptorRequest requestA = new ArtifactDescriptorRequest();
+        requestA.setArtifact(new DefaultArtifact("gid:aid:1"));
+        requestA.setRepositories(Collections.singletonList(repoA));
+
+        DataPool pool = newDataPool();
+        DataPool.DescriptorKey keyA = pool.toKey(requestA);
+        pool.putDescriptor(
+                keyA, new ArtifactDescriptorException(new ArtifactDescriptorResult(requestA), "descriptor is bad"));
+
+        // same artifact, same repositories: cached failure replays (as the sentinel) and carries its reason
+        ArtifactDescriptorRequest sameAsA = new ArtifactDescriptorRequest();
+        sameAsA.setArtifact(new DefaultArtifact("gid:aid:1"));
+        sameAsA.setRepositories(Collections.singletonList(
+                new RemoteRepository.Builder("repo-a", "default", "https://repo-a.example.com/").build()));
+        assertSame(DataPool.NO_DESCRIPTOR, pool.getDescriptor(pool.toKey(sameAsA), sameAsA));
+        assertEquals("descriptor is bad", pool.getDescriptorFailure(pool.toKey(sameAsA)));
+
+        // same artifact, different repositories: the failure must NOT be replayed cross-context
+        ArtifactDescriptorRequest requestB = new ArtifactDescriptorRequest();
+        requestB.setArtifact(new DefaultArtifact("gid:aid:1"));
+        requestB.setRepositories(Collections.singletonList(repoB));
+        assertNull(pool.getDescriptor(pool.toKey(requestB), requestB));
+        assertNull(pool.getDescriptorFailure(pool.toKey(requestB)));
     }
 
     @Test

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/HttpTransporter.java
@@ -81,7 +81,6 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
@@ -119,6 +118,14 @@ final class HttpTransporter extends AbstractTransporter {
     static final String PREEMPTIVE_PUT_AUTH = "aether.connector.http.preemptivePutAuth";
 
     static final String USE_SYSTEM_PROPERTIES = "aether.connector.http.useSystemProperties";
+
+    static final String FOLLOW_INSECURE_REDIRECTS = "aether.connector.http.followInsecureRedirects";
+
+    static final boolean DEFAULT_FOLLOW_INSECURE_REDIRECTS = false;
+
+    static final String ORIGIN_SCOPED_HEADERS = "aether.connector.http.originScopedHeaders";
+
+    static final boolean DEFAULT_ORIGIN_SCOPED_HEADERS = true;
 
     static final String HTTP_RETRY_HANDLER_NAME = "aether.connector.http.retryHandler.name";
 
@@ -283,6 +290,13 @@ final class HttpTransporter extends AbstractTransporter {
                 ConfigurationProperties.DEFAULT_FOLLOW_REDIRECTS,
                 ConfigurationProperties.HTTP_FOLLOW_REDIRECTS + "." + repository.getId(),
                 ConfigurationProperties.HTTP_FOLLOW_REDIRECTS);
+        boolean followInsecureRedirects = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_FOLLOW_INSECURE_REDIRECTS,
+                FOLLOW_INSECURE_REDIRECTS + "." + repository.getId(),
+                FOLLOW_INSECURE_REDIRECTS,
+                "aether.transport.http.followInsecureRedirects." + repository.getId(),
+                "aether.transport.http.followInsecureRedirects");
 
         Charset credentialsCharset = Charset.forName(credentialEncoding);
         Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
@@ -328,7 +342,7 @@ final class HttpTransporter extends AbstractTransporter {
 
         HttpClientBuilder builder = HttpClientBuilder.create()
                 .setUserAgent(userAgent)
-                .setRedirectStrategy(LaxRedirectStrategy.INSTANCE)
+                .setRedirectStrategy(new ResolverRedirectStrategy(followInsecureRedirects))
                 .setDefaultSocketConfig(socketConfig)
                 .setDefaultRequestConfig(requestConfig)
                 .setServiceUnavailableRetryStrategy(serviceUnavailableRetryStrategy)
@@ -338,6 +352,16 @@ final class HttpTransporter extends AbstractTransporter {
                 .setConnectionManagerShared(true)
                 .setDefaultCredentialsProvider(toCredentialsProvider(server, repoAuthContext, proxy, proxyAuthContext))
                 .setProxy(proxy);
+        boolean originScopedHeaders = ConfigUtils.getBoolean(
+                session,
+                DEFAULT_ORIGIN_SCOPED_HEADERS,
+                ORIGIN_SCOPED_HEADERS + "." + repository.getId(),
+                ORIGIN_SCOPED_HEADERS,
+                "aether.transport.http.originScopedHeaders." + repository.getId(),
+                "aether.transport.http.originScopedHeaders");
+        if (originScopedHeaders && !this.headers.isEmpty()) {
+            builder.addInterceptorLast(new OriginScopedHeadersInterceptor(server, this.headers.keySet()));
+        }
         final boolean useSystemProperties = ConfigUtils.getBoolean(
                 session, false, USE_SYSTEM_PROPERTIES + "." + repository.getId(), USE_SYSTEM_PROPERTIES);
         if (useSystemProperties) {
@@ -416,12 +440,27 @@ final class HttpTransporter extends AbstractTransporter {
 
     private static CredentialsProvider toCredentialsProvider(
             HttpHost server, AuthenticationContext serverAuthCtx, HttpHost proxy, AuthenticationContext proxyAuthCtx) {
-        CredentialsProvider provider = toCredentialsProvider(server.getHostName(), AuthScope.ANY_PORT, serverAuthCtx);
+        CredentialsProvider provider =
+                toCredentialsProvider(server.getHostName(), effectivePort(server), serverAuthCtx);
         if (proxy != null) {
             CredentialsProvider p = toCredentialsProvider(proxy.getHostName(), proxy.getPort(), proxyAuthCtx);
             provider = new DemuxCredentialsProvider(provider, p, proxy);
         }
         return provider;
+    }
+
+    /**
+     * Determines the effective port of the given host: the explicit port if present, otherwise the default port
+     * implied by the scheme. Used to bind repository credentials to the repository's own origin (host and port)
+     * instead of {@link AuthScope#ANY_PORT}: with any-port scoping, a request landing on the same host but a
+     * different port - for example after an https-to-http downgrade redirect - would still be eligible to
+     * receive the credentials.
+     */
+    static int effectivePort(HttpHost host) {
+        if (host.getPort() >= 0) {
+            return host.getPort();
+        }
+        return "https".equalsIgnoreCase(host.getSchemeName()) ? 443 : 80;
     }
 
     private static CredentialsProvider toCredentialsProvider(String host, int port, AuthenticationContext ctx) {

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/OriginScopedHeadersInterceptor.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/OriginScopedHeadersInterceptor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.http;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+/**
+ * Scopes operator-configured request headers ({@code aether.transport.http.headers} /
+ * {@code aether.connector.http.headers}) to the repository origin.
+ * <p>
+ * Configured headers are stamped on every request the transport creates and frequently carry credentials
+ * ({@code Authorization}, cookies, private token headers). Apache HttpClient's redirect execution re-sends the
+ * original request headers on each redirect hop, including hops that leave the repository origin, which would
+ * replay those credentials to the redirect target. This interceptor runs in the protocol layer - which HttpClient
+ * re-enters for every redirect hop - and removes the configured headers from any request whose target host is not
+ * the repository origin (same scheme, host and effective port). Challenge- and preemptive-authentication headers
+ * are attached below the protocol layer and are host-scoped by the credentials provider already; they are not
+ * affected by this interceptor.
+ *
+ * @since 1.9.28
+ */
+final class OriginScopedHeadersInterceptor implements HttpRequestInterceptor {
+    private final HttpHost origin;
+
+    private final Set<String> headerNames;
+
+    OriginScopedHeadersInterceptor(HttpHost origin, Collection<?> headerNames) {
+        this.origin = origin;
+        this.headerNames = new HashSet<>();
+        for (Object headerName : headerNames) {
+            if (headerName != null) {
+                this.headerNames.add(String.valueOf(headerName));
+            }
+        }
+    }
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) {
+        if (headerNames.isEmpty()) {
+            return;
+        }
+        Object attribute = context != null ? context.getAttribute(HttpCoreContext.HTTP_TARGET_HOST) : null;
+        // fail closed: when the target host cannot be determined, do not attach configured headers
+        if (!(attribute instanceof HttpHost) || !isSameOrigin(origin, (HttpHost) attribute)) {
+            for (String headerName : headerNames) {
+                request.removeHeaders(headerName);
+            }
+        }
+    }
+
+    static boolean isSameOrigin(HttpHost origin, HttpHost target) {
+        return origin.getSchemeName().equalsIgnoreCase(target.getSchemeName())
+                && origin.getHostName().equalsIgnoreCase(target.getHostName())
+                && schemeDefaultPort(origin) == schemeDefaultPort(target);
+    }
+
+    /**
+     * Determines the effective port of the given host: the explicit port if present, otherwise the default port
+     * implied by the scheme.
+     */
+    static int schemeDefaultPort(HttpHost host) {
+        if (host.getPort() >= 0) {
+            return host.getPort();
+        }
+        return "https".equalsIgnoreCase(host.getSchemeName()) ? 443 : 80;
+    }
+}

--- a/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/ResolverRedirectStrategy.java
+++ b/maven-resolver-transport-http/src/main/java/org/eclipse/aether/transport/http/ResolverRedirectStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.http;
+
+import java.net.URI;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * A redirect strategy that refuses protocol downgrades: a redirect from an {@code https} URL to an {@code http}
+ * URL strips transport encryption from artifact and checksum bytes and makes repository credentials eligible for
+ * transmission over plaintext, so it fails the transfer instead of being followed silently, unless explicitly
+ * allowed via {@link HttpTransporter#FOLLOW_INSECURE_REDIRECTS}. All other redirects behave exactly as
+ * {@link LaxRedirectStrategy} handled them before.
+ *
+ * @since 1.9.28
+ */
+final class ResolverRedirectStrategy extends LaxRedirectStrategy {
+    private final boolean followInsecureRedirects;
+
+    ResolverRedirectStrategy(boolean followInsecureRedirects) {
+        this.followInsecureRedirects = followInsecureRedirects;
+    }
+
+    @Override
+    public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context)
+            throws ProtocolException {
+        boolean redirected = super.isRedirected(request, response, context);
+        if (redirected && !followInsecureRedirects) {
+            Header locationHeader = response.getFirstHeader("location");
+            if (locationHeader != null) {
+                URI location = createLocationURI(locationHeader.getValue());
+                String locationScheme = location.getScheme();
+                String currentScheme = currentScheme(request, context);
+                if (locationScheme != null
+                        && "https".equalsIgnoreCase(currentScheme)
+                        && !"https".equalsIgnoreCase(locationScheme)) {
+                    throw new ProtocolException("Insecure redirect to '" + location
+                            + "' not followed: protocol downgrade from https to " + locationScheme
+                            + " would expose credentials and artifact content; set the configuration property "
+                            + HttpTransporter.FOLLOW_INSECURE_REDIRECTS
+                            + "=true to allow it");
+                }
+            }
+        }
+        return redirected;
+    }
+
+    private static String currentScheme(HttpRequest request, HttpContext context) {
+        HttpHost target = context != null ? HttpClientContext.adapt(context).getTargetHost() : null;
+        if (target != null) {
+            return target.getSchemeName();
+        }
+        if (request instanceof HttpUriRequest) {
+            URI uri = ((HttpUriRequest) request).getURI();
+            if (uri != null && uri.isAbsolute()) {
+                return uri.getScheme();
+            }
+        }
+        return null;
+    }
+}

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/OriginScopedHeadersInterceptorTest.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/OriginScopedHeadersInterceptorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.http;
+
+import java.util.Arrays;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * UT for {@link OriginScopedHeadersInterceptor}: operator-configured static headers must only be attached to
+ * requests whose target host matches the configured repository origin.
+ */
+public class OriginScopedHeadersInterceptorTest {
+    private static final HttpHost ORIGIN = new HttpHost("repo.example.com", -1, "https");
+
+    private final OriginScopedHeadersInterceptor interceptor =
+            new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList("Authorization", "Private-Token"));
+
+    private static HttpRequest newRequestWithConfiguredHeaders() {
+        HttpRequest request = new BasicHttpRequest("GET", "/repo/artifact-1.0.jar");
+        request.setHeader("Authorization", "Bearer secret-token");
+        request.setHeader("Private-Token", "glpat-secret");
+        request.setHeader("Accept", "application/octet-stream");
+        return request;
+    }
+
+    private static HttpContext contextTargeting(HttpHost target) {
+        HttpContext context = new HttpCoreContext();
+        if (target != null) {
+            context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+        }
+        return context;
+    }
+
+    private static void assertConfiguredHeadersPresent(HttpRequest request) {
+        assertTrue(request.containsHeader("Authorization"));
+        assertTrue(request.containsHeader("Private-Token"));
+        assertTrue(request.containsHeader("Accept"));
+    }
+
+    private static void assertConfiguredHeadersStripped(HttpRequest request) {
+        assertFalse(request.containsHeader("Authorization"));
+        assertFalse(request.containsHeader("Private-Token"));
+        // headers not coming from the configured map are left alone
+        assertTrue(request.containsHeader("Accept"));
+    }
+
+    @Test
+    public void keepsHeadersForOrigin() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    public void keepsHeadersForOriginWithExplicitDefaultPort() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 443, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    public void keepsHeadersForOriginWithDifferentHostCase() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("REPO.Example.COM", -1, "HTTPS")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    public void stripsHeadersForCrossHostTarget() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    public void stripsHeadersForSchemeDowngradeOnSameHost() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", -1, "http")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    public void stripsHeadersForDifferentPortOnSameHost() throws Exception {
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(new HttpHost("repo.example.com", 8443, "https")));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    public void stripsHeadersWhenTargetHostUnknown() throws Exception {
+        // fail closed: no determinable target means configured headers are not attached
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        interceptor.process(request, contextTargeting(null));
+        assertConfiguredHeadersStripped(request);
+    }
+
+    @Test
+    public void noConfiguredHeadersIsNoOp() throws Exception {
+        OriginScopedHeadersInterceptor empty =
+                new OriginScopedHeadersInterceptor(ORIGIN, Arrays.asList(new Object[] {null}));
+        HttpRequest request = newRequestWithConfiguredHeaders();
+        empty.process(request, contextTargeting(new HttpHost("cdn.example.net", -1, "https")));
+        assertConfiguredHeadersPresent(request);
+    }
+
+    @Test
+    public void effectivePortFollowsScheme() {
+        assertEquals(443, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "https")));
+        assertEquals(80, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", -1, "http")));
+        assertEquals(8081, OriginScopedHeadersInterceptor.schemeDefaultPort(new HttpHost("h", 8081, "https")));
+    }
+}

--- a/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/ResolverRedirectStrategyTest.java
+++ b/maven-resolver-transport-http/src/test/java/org/eclipse/aether/transport/http/ResolverRedirectStrategyTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.transport.http;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * UT for {@link ResolverRedirectStrategy}: https-to-http downgrade redirects must not be followed silently, and
+ * repository credentials must be bound to the repository's scheme-implied port.
+ */
+public class ResolverRedirectStrategyTest {
+    private static HttpResponse redirectResponse(String location) {
+        HttpResponse response = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 302, "Found"));
+        response.setHeader("Location", location);
+        return response;
+    }
+
+    private static HttpContext contextWithTarget(HttpHost target) {
+        HttpClientContext context = HttpClientContext.create();
+        context.setAttribute(HttpCoreContext.HTTP_TARGET_HOST, target);
+        return context;
+    }
+
+    @Test
+    public void httpsToHttpRedirectRefusedByDefault() {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        try {
+            strategy.isRedirected(request, response, context);
+            fail("Expected ProtocolException");
+        } catch (ProtocolException e) {
+            assertTrue(e.getMessage().contains(HttpTransporter.FOLLOW_INSECURE_REDIRECTS));
+        }
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void httpsToHttpCrossHostRedirectRefusedByDefault() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://evil.example.org/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        strategy.isRedirected(request, response, context);
+    }
+
+    @Test
+    public void httpsToHttpsRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("https://mirror.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    public void relativeRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("/elsewhere/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    public void httpToHttpRedirectFollowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://mirror.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 80, "http"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test
+    public void httpsToHttpRedirectFollowedWhenExplicitlyAllowed() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(true);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpContext context = contextWithTarget(new HttpHost("repo.example.com", 443, "https"));
+
+        assertTrue(strategy.isRedirected(request, response, context));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void currentSchemeFallsBackToRequestUriWithoutContextTarget() throws ProtocolException {
+        ResolverRedirectStrategy strategy = new ResolverRedirectStrategy(false);
+        HttpGet request = new HttpGet("https://repo.example.com/g/a/1.0/a-1.0.jar");
+        HttpResponse response = redirectResponse("http://repo.example.com/g/a/1.0/a-1.0.jar");
+
+        strategy.isRedirected(request, response, HttpClientContext.create());
+    }
+
+    @Test
+    public void repositoryCredentialScopeIsBoundToSchemeImpliedPort() {
+        assertEquals(443, HttpTransporter.effectivePort(new HttpHost("repo.example.com", -1, "https")));
+        assertEquals(80, HttpTransporter.effectivePort(new HttpHost("repo.example.com", -1, "http")));
+        assertEquals(8443, HttpTransporter.effectivePort(new HttpHost("repo.example.com", 8443, "https")));
+        assertEquals(8081, HttpTransporter.effectivePort(new HttpHost("repo.example.com", 8081, "http")));
+    }
+}

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/ChecksumUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/ChecksumUtils.java
@@ -37,6 +37,13 @@ import java.util.Map;
  */
 public final class ChecksumUtils {
 
+    /**
+     * Upper bound (in characters) for data read from a checksum file, see {@link #read(File)}. Every sane
+     * checksum file format fits well within this limit; longer input is rejected as malformed instead of being
+     * buffered into memory.
+     */
+    private static final int MAX_CHECKSUM_FILE_CHARS = 8192;
+
     private ChecksumUtils() {
         // hide constructor
     }
@@ -51,23 +58,13 @@ public final class ChecksumUtils {
      */
     @Deprecated
     public static String read(File checksumFile) throws IOException {
-        String checksum = "";
+        String checksum;
         try (BufferedReader br = new BufferedReader(
                 new InputStreamReader(new FileInputStream(checksumFile), StandardCharsets.UTF_8), 512)) {
-            while (true) {
-                String line = br.readLine();
-                if (line == null) {
-                    break;
-                }
-                line = line.trim();
-                if (line.length() > 0) {
-                    checksum = line;
-                    break;
-                }
-            }
+            checksum = readFirstNonEmptyLine(br, checksumFile.toString());
         }
 
-        if (checksum.matches(".+= [0-9A-Fa-f]+")) {
+        if (isAlgorithmHeaderFormat(checksum)) {
             int lastSpacePos = checksum.lastIndexOf(' ');
             checksum = checksum.substring(lastSpacePos + 1);
         } else {
@@ -79,6 +76,52 @@ public final class ChecksumUtils {
         }
 
         return checksum;
+    }
+
+    /**
+     * Reads the first non-empty line, enforcing {@link #MAX_CHECKSUM_FILE_CHARS} on the total amount of data
+     * consumed. Returns the trimmed line, or an empty string if the stream holds no non-empty line.
+     */
+    private static String readFirstNonEmptyLine(BufferedReader reader, String source) throws IOException {
+        StringBuilder buffer = new StringBuilder(64);
+        int read = 0;
+        int c;
+        while ((c = reader.read()) != -1) {
+            if (++read > MAX_CHECKSUM_FILE_CHARS) {
+                throw new IOException("Checksum file " + source + " is malformed: longer than "
+                        + MAX_CHECKSUM_FILE_CHARS + " characters");
+            }
+            if (c == '\n' || c == '\r') {
+                String line = buffer.toString().trim();
+                if (!line.isEmpty()) {
+                    return line;
+                }
+                buffer.setLength(0);
+            } else {
+                buffer.append((char) c);
+            }
+        }
+        return buffer.toString().trim();
+    }
+
+    /**
+     * Non-backtracking equivalent of {@code line.matches(".+= [0-9A-Fa-f]+")}: at least one character, followed
+     * by "= ", followed by one or more hex digits reaching the end of the line ("&lt;algorithm&gt; (&lt;file&gt;)
+     * = &lt;hex&gt;" style checksum lines).
+     */
+    private static boolean isAlgorithmHeaderFormat(String line) {
+        int lastSpacePos = line.lastIndexOf(' ');
+        if (lastSpacePos < 2 || lastSpacePos == line.length() - 1 || line.charAt(lastSpacePos - 1) != '=') {
+            return false;
+        }
+        for (int i = lastSpacePos + 1; i < line.length(); i++) {
+            char ch = line.charAt(i);
+            boolean hex = (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+            if (!hex) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/ChecksumUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/ChecksumUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import static org.eclipse.aether.internal.test.util.TestFileUtils.createTempFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ChecksumUtilsTest {
+
+    @Test
+    public void testReadStandardChecksum() throws IOException {
+        File file = createTempFile("  \n\r  1234567890abcdef1234567890abcdef12345678  test.jar\n");
+        assertEquals("1234567890abcdef1234567890abcdef12345678", ChecksumUtils.read(file));
+    }
+
+    @Test
+    public void testReadAlgorithmHeaderFormat() throws IOException {
+        File file = createTempFile("SHA1 (test.jar) = 1234567890abcdef1234567890abcdef12345678\n");
+        assertEquals("1234567890abcdef1234567890abcdef12345678", ChecksumUtils.read(file));
+    }
+
+    @Test
+    public void testReadBoundedLengthExceeded() throws IOException {
+        File file = createTempFile("a".getBytes(StandardCharsets.UTF_8), 9000);
+        try {
+            ChecksumUtils.read(file);
+            fail("Expected IOException due to exceeding 8192 characters");
+        } catch (IOException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Brings the 1.9.x line level with `master` on five changes it never received.

| Change | What `master` has that 1.9.x does not |
| --- | --- |
| Checksum reads and logged values | `LogSanitizer`, absent on 1.9.x, and an upper bound on checksum file reads in `ChecksumUtils` |
| Header scoping across redirects | `OriginScopedHeadersInterceptor` and `ResolverRedirectStrategy`, neither present on 1.9.x |
| Checksum policy merge | The policy strength comparator and mirror clamping in `DefaultRemoteRepositoryManager` |
| Descriptor cache key | `DataPool.toKey` keying on `(artifact, repositories)`; 1.9.x keys on the artifact alone, so a descriptor read from one repository can be handed back for a request naming another |
| Not-found markers | Expiry of stale markers once an artifact is downloaded |

The transport module differs between the lines: `master` renamed it to `maven-resolver-transport-apache`, so the header-scoping change is applied against 1.9.x's `maven-resolver-transport-http` rather than lifted.

Two further changes from the same batch are deliberately not here: bounding RFC 9457 error-body reads, and requiring verification before relabeling a resolved artifact. Both are on `master` but need a hand-port on this line (no SPI reporter, `File` instead of `Path`) and are left for a separate PR.

Verified: `mvn clean install` -> BUILD SUCCESS, 1078 tests, 0 failures, 0 errors; `spotless:check` clean across all 18 modules.

*This change was created with AI assistance.*

