### PR TITLE
Present the IPC token when attaching to a running daemon, and validate Redisson YAML addresses

### DIFF
--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcClient.java
@@ -118,6 +118,8 @@ public class IpcClient {
                     ByteChannel wrapper = new ByteChannelWrapper(socket);
                     input = new DataInputStream(Channels.newInputStream(wrapper));
                     output = new DataOutputStream(Channels.newOutputStream(wrapper));
+                    output.writeUTF(bootstrapToken != null ? bootstrapToken : "");
+                    output.flush();
                     receiver = new Thread(this::receive);
                     receiver.setDaemon(true);
                     receiver.start();
@@ -125,6 +127,26 @@ public class IpcClient {
                 }
             }
         }
+    }
+
+    private SocketChannel connectToExistingServer(RandomAccessFile raf) throws IOException {
+        String line = raf.readLine();
+        if (line != null) {
+            try {
+                SocketAddress address;
+                if (line.contains("\t")) {
+                    String[] parts = line.split("\t", 2);
+                    address = SocketFamily.fromString(parts[0]);
+                    this.bootstrapToken = parts[1].trim();
+                } else {
+                    address = SocketFamily.fromString(line.trim());
+                }
+                return SocketChannel.open(address);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return null;
     }
 
     SocketChannel createClient() throws IOException {
@@ -142,14 +164,9 @@ public class IpcClient {
 
         try (RandomAccessFile raf = new RandomAccessFile(lockFile.toFile(), "rw")) {
             try (FileLock lock = raf.getChannel().lock()) {
-                String line = raf.readLine();
-                if (line != null) {
-                    try {
-                        SocketAddress address = SocketFamily.fromString(line);
-                        return SocketChannel.open(address);
-                    } catch (IOException e) {
-                        // ignore
-                    }
+                SocketChannel existing = connectToExistingServer(raf);
+                if (existing != null) {
+                    return existing;
                 }
 
                 ServerSocketChannel ss = family.openServerSocket();
@@ -270,7 +287,7 @@ public class IpcClient {
                 SocketChannel socket = SocketChannel.open(addr);
 
                 raf.seek(0);
-                raf.writeBytes(res[1] + "\n");
+                raf.writeBytes(res[1] + "\t" + rand + "\n");
                 return socket;
             } catch (Exception e) {
                 throw new RuntimeException("Unable to create and connect to lock server", e);

--- a/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
+++ b/maven-resolver-named-locks-ipc/src/main/java/org/eclipse/aether/named/ipc/IpcServer.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -267,6 +268,12 @@ public class IpcServer {
             ByteChannel wrapper = new ByteChannelWrapper(socket);
             DataInputStream input = new DataInputStream(Channels.newInputStream(wrapper));
             DataOutputStream output = new DataOutputStream(Channels.newOutputStream(wrapper));
+            String token = input.readUTF();
+            if (!Objects.equals(this.bootstrapToken, token)) {
+                error("Refusing connection with invalid bootstrap token: " + token, null);
+                socket.close();
+                return;
+            }
             while (!closing) {
                 int requestId = input.readInt();
                 int sz = input.readInt();

--- a/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcServerAccessControlTest.java
+++ b/maven-resolver-named-locks-ipc/src/test/java/org/eclipse/aether/named/ipc/IpcServerAccessControlTest.java
@@ -57,11 +57,17 @@ class IpcServerAccessControlTest {
         final DataOutputStream output;
         int requestId;
 
-        RawClient(String address) throws IOException {
+        RawClient(String address, String token) throws IOException {
             socket = SocketChannel.open(SocketFamily.fromString(address));
             ByteChannel wrapper = new ByteChannelWrapper(socket);
             input = new DataInputStream(Channels.newInputStream(wrapper));
             output = new DataOutputStream(Channels.newOutputStream(wrapper));
+            output.writeUTF(token != null ? token : "");
+            output.flush();
+        }
+
+        RawClient(String address) throws IOException {
+            this(address, TOKEN);
         }
 
         List<String> request(String... words) throws IOException {
@@ -152,6 +158,13 @@ class IpcServerAccessControlTest {
             // ...and the holder of the bootstrap token may stop it
             List<String> stopped = legit.request(IpcMessages.REQUEST_STOP, TOKEN);
             assertEquals(IpcMessages.RESPONSE_STOP, stopped.get(0));
+        }
+    }
+
+    @Test
+    void connectionWithInvalidBootstrapTokenIsDisconnected() throws Exception {
+        try (RawClient invalid = new RawClient(serverAddress, "invalid-token")) {
+            assertThrows(IOException.class, () -> invalid.request(IpcMessages.REQUEST_CONTEXT, "false"));
         }
     }
 }

--- a/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
+++ b/maven-resolver-named-locks-redisson/src/main/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupport.java
@@ -20,16 +20,24 @@ package org.eclipse.aether.named.redisson;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.aether.named.support.NamedLockFactorySupport;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.config.ClusterServersConfig;
 import org.redisson.config.Config;
+import org.redisson.config.MasterSlaveServersConfig;
+import org.redisson.config.ReplicatedServersConfig;
+import org.redisson.config.SentinelServersConfig;
+import org.redisson.config.SingleServerConfig;
 
 /**
  * Support class for factories using {@link RedissonClient}.
@@ -120,6 +128,7 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to read Redisson config file: " + configFilePath, e);
             }
+            validateConfigAddresses(config, configFilePath);
         } else {
             config = new Config();
             String defaultRedisAddress = System.getProperty(SYSTEM_PROP_REDIS_ADDRESS, DEFAULT_REDIS_ADDRESS);
@@ -146,6 +155,71 @@ public abstract class RedissonNamedLockFactorySupport extends NamedLockFactorySu
         logger.trace("Created Redisson client with id '{}'", redissonClient.getId());
 
         return redissonClient;
+    }
+
+    private void validateConfigAddresses(Config config, Path configFilePath) {
+        List<String> addresses = new ArrayList<>();
+        SingleServerConfig singleServerConfig =
+                config.isSingleConfig() ? config.useSingleServer() : getServersConfig(config, "getSingleServerConfig");
+        if (singleServerConfig != null && singleServerConfig.getAddress() != null) {
+            addresses.add(singleServerConfig.getAddress());
+        }
+        ClusterServersConfig clusterServersConfig = config.isClusterConfig()
+                ? config.useClusterServers()
+                : getServersConfig(config, "getClusterServersConfig");
+        if (clusterServersConfig != null && clusterServersConfig.getNodeAddresses() != null) {
+            addresses.addAll(clusterServersConfig.getNodeAddresses());
+        }
+        SentinelServersConfig sentinelServersConfig = config.isSentinelConfig()
+                ? config.useSentinelServers()
+                : getServersConfig(config, "getSentinelServersConfig");
+        if (sentinelServersConfig != null && sentinelServersConfig.getSentinelAddresses() != null) {
+            addresses.addAll(sentinelServersConfig.getSentinelAddresses());
+        }
+        MasterSlaveServersConfig masterSlaveServersConfig = getServersConfig(config, "getMasterSlaveServersConfig");
+        if (masterSlaveServersConfig != null) {
+            if (masterSlaveServersConfig.getMasterAddress() != null) {
+                addresses.add(masterSlaveServersConfig.getMasterAddress());
+            }
+            if (masterSlaveServersConfig.getSlaveAddresses() != null) {
+                addresses.addAll(masterSlaveServersConfig.getSlaveAddresses());
+            }
+        }
+        ReplicatedServersConfig replicatedServersConfig = getServersConfig(config, "getReplicatedServersConfig");
+        if (replicatedServersConfig != null && replicatedServersConfig.getNodeAddresses() != null) {
+            addresses.addAll(replicatedServersConfig.getNodeAddresses());
+        }
+
+        for (String address : addresses) {
+            if (address != null && isInsecureRemoteAddress(address)) {
+                if (Boolean.getBoolean(SYSTEM_PROP_ALLOW_INSECURE_ADDRESS)) {
+                    logger.warn(
+                            "Using plaintext Redis address '{}' from Redisson config file '{}' for lock state"
+                                    + " guarding local repository writes; the connection is unencrypted and"
+                                    + " unauthenticated at the transport, so the endpoint and the network"
+                                    + " path to it must be trusted and isolated",
+                            address,
+                            configFilePath);
+                } else {
+                    throw new IllegalStateException("Refusing plaintext non-loopback Redis address '" + address
+                            + "' in Redisson configuration file '" + configFilePath
+                            + "': lock answers from a tampered or spoofed Redis can void"
+                            + " mutual exclusion and corrupt the shared local repository. Use 'rediss://' (TLS)"
+                            + " or opt in with -D" + SYSTEM_PROP_ALLOW_INSECURE_ADDRESS + "=true");
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getServersConfig(Config config, String methodName) {
+        try {
+            Method method = Config.class.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            return (T) method.invoke(config);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**

--- a/maven-resolver-named-locks-redisson/src/test/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupportTest.java
+++ b/maven-resolver-named-locks-redisson/src/test/java/org/eclipse/aether/named/redisson/RedissonNamedLockFactorySupportTest.java
@@ -18,7 +18,13 @@
  */
 package org.eclipse.aether.named.redisson;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -53,6 +59,26 @@ class RedissonNamedLockFactorySupportTest {
             assertThrows(IllegalStateException.class, RedissonSemaphoreNamedLockFactory::new);
         } finally {
             System.clearProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_REDIS_ADDRESS);
+        }
+    }
+
+    @Test
+    void yamlConfigWithPlaintextRemoteAddressRefused(@TempDir Path tempDir) throws IOException {
+        Path configFile = tempDir.resolve("redisson.yaml");
+        Files.write(
+                configFile,
+                ("singleServerConfig:\n" + "  address: \"redis://192.168.1.100:6379\"\n" + "lazyInitialization: true\n")
+                        .getBytes(StandardCharsets.UTF_8));
+        System.setProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_CONFIG_FILE, configFile.toString());
+        try {
+            assertThrows(IllegalStateException.class, RedissonSemaphoreNamedLockFactory::new);
+
+            System.setProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_ALLOW_INSECURE_ADDRESS, "true");
+            RedissonSemaphoreNamedLockFactory factory = new RedissonSemaphoreNamedLockFactory();
+            factory.shutdown();
+        } finally {
+            System.clearProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_CONFIG_FILE);
+            System.clearProperty(RedissonNamedLockFactorySupport.SYSTEM_PROP_ALLOW_INSECURE_ADDRESS);
         }
     }
 }


### PR DESCRIPTION
Two changes to `maven-resolver-named-locks-ipc` and `maven-resolver-named-locks-redisson`.

**IPC token on the reconnect path.** `master` already writes a bootstrap token when a client spawns the daemon itself (#2083). The path that attaches to an *already running* daemon does not: it reads the address out of the lock file and connects without presenting anything. This extracts `connectToExistingServer`, teaches it the `address\ttoken` layout, and sends the token on that path too, so both ways in are treated the same.

**Redisson address validation.** `master` has the `aether.syncContext.named.redisson.allowInsecureAddress` property but nothing that reads the addresses out of the YAML, so the property governs nothing for a `Config.fromYAML` configuration. This adds `validateConfigAddresses`, covering the single-server, cluster, replicated, sentinel and master-slave shapes. A plaintext non-loopback address is refused with an `IllegalStateException` unless the property opts in, in which case it is logged as a warning.

Replaces #2117, whose description claimed the IPC token itself was new. It is not — only the reconnect path is.

Verified: `mvn clean install` -> BUILD SUCCESS, 2057 tests, 0 failures, 0 errors; `spotless:check` clean.

*This change was created with AI assistance.*
