### PR TITLE
[1.9.x] Reject locally cached artifacts whose on-disk path spells different coordinates

### DIFF
--- a/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
+++ b/maven-resolver-impl/src/main/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManager.java
@@ -19,6 +19,8 @@
 package org.eclipse.aether.internal.impl;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +36,9 @@ import org.eclipse.aether.repository.LocalArtifactRegistration;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.ConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,11 +65,24 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
 
     private static final String LOCAL_REPO_ID = "";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnhancedLocalRepositoryManager.class);
+
+    private static final String CONFIG_PROP_VERIFY_REAL_PATH = "aether.enhancedLocalRepository.verifyRealPath";
+
+    private static final boolean DEFAULT_VERIFY_REAL_PATH = true;
+
     private final String trackingFilename;
 
     private final TrackingFileManager trackingFileManager;
 
     private final LocalPathPrefixComposer localPathPrefixComposer;
+
+    /**
+     * Real (symlink-resolved) path of the local repository base directory, resolved on first use and cached: it
+     * cannot change during the lifetime of this manager. Resolved lazily rather than in the constructor because a
+     * fresh local repository does not exist on disk yet, and {@code toRealPath()} requires it to.
+     */
+    private volatile Path realBasePath;
 
     EnhancedLocalRepositoryManager(
             File basedir,
@@ -118,6 +136,9 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         Artifact artifact = request.getArtifact();
         LocalArtifactResult result = new LocalArtifactResult(request);
 
+        boolean verifyRealPath =
+                ConfigUtils.getBoolean(session, DEFAULT_VERIFY_REAL_PATH, CONFIG_PROP_VERIFY_REAL_PATH);
+
         String path;
         File file;
 
@@ -125,7 +146,7 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         if (Objects.equals(artifact.getVersion(), artifact.getBaseVersion())) {
             path = getPathForLocalArtifact(artifact);
             file = new File(getRepository().getBasedir(), path);
-            checkFind(file, result);
+            checkFind(file, result, verifyRealPath);
         }
 
         if (!result.isAvailable()) {
@@ -133,7 +154,7 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
                 path = getPathForRemoteArtifact(artifact, repository, request.getContext());
                 file = new File(getRepository().getBasedir(), path);
 
-                checkFind(file, result);
+                checkFind(file, result, verifyRealPath);
 
                 if (result.isAvailable()) {
                     break;
@@ -144,8 +165,58 @@ class EnhancedLocalRepositoryManager extends SimpleLocalRepositoryManager {
         return result;
     }
 
-    private void checkFind(File file, LocalArtifactResult result) {
-        if (file.isFile()) {
+    /**
+     * Returns the real (symlink-resolved) base directory, resolving it on first use.
+     */
+    private Path realBasePath() throws IOException {
+        Path resolved = realBasePath;
+        if (resolved == null) {
+            synchronized (this) {
+                resolved = realBasePath;
+                if (resolved == null) {
+                    resolved = getRepository().getBasedir().toPath().toRealPath();
+                    realBasePath = resolved;
+                }
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Verifies that the on-disk path of a locally cached artifact spells the requested path. On case-insensitive
+     * or normalization-preserving filesystems (the macOS and Windows defaults) a file cached for one set of
+     * coordinates also answers lookups for coordinates differing only in case or Unicode normalization, while the
+     * tracking data is compared exactly: the aliased file is then treated as present-but-untracked and accepted
+     * with no download and no checksum verification. Such aliases are treated as "not present" instead (fail
+     * closed), forcing a proper download for the requested coordinates. The comparison is relative to the
+     * symlink-resolved base directory, so a symlinked base directory is supported; symbolic links below the base
+     * directory are not, and {@code aether.enhancedLocalRepository.verifyRealPath} opts out.
+     */
+    private boolean hasFaithfulRealPath(File file) {
+        try {
+            String requested = getRepository()
+                    .getBasedir()
+                    .toPath()
+                    .relativize(file.toPath())
+                    .toString();
+            String real = realBasePath().relativize(file.toPath().toRealPath()).toString();
+            if (!requested.equals(real)) {
+                LOGGER.warn(
+                        "Rejecting locally cached artifact {}: its on-disk path {} does not match the requested"
+                                + " coordinates (filesystem case/normalization alias); treating it as not present",
+                        file,
+                        real);
+                return false;
+            }
+            return true;
+        } catch (IOException | IllegalArgumentException e) {
+            // the real identity of the file cannot be established: fail closed, forcing a re-download
+            return false;
+        }
+    }
+
+    private void checkFind(File file, LocalArtifactResult result, boolean verifyRealPath) {
+        if (file.isFile() && (!verifyRealPath || hasFaithfulRealPath(file))) {
             result.setFile(file);
 
             Properties props = readRepos(file);

--- a/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
+++ b/maven-resolver-impl/src/test/java/org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerTest.java
@@ -193,6 +193,36 @@ public class EnhancedLocalRepositoryManagerTest {
     }
 
     @Test
+    public void testFindLocalArtifactVerifiesRealPath() throws Exception {
+        addLocalArtifact(artifact);
+
+        // the happy path must stay available with verification enabled (the default)
+        LocalArtifactResult result = manager.find(session, new LocalArtifactRequest(artifact, null, null));
+        assertTrue(result.isAvailable());
+    }
+
+    @Test
+    public void testFindCaseAliasedArtifactIsNotAvailable() throws Exception {
+        addLocalArtifact(artifact);
+
+        // Same coordinates but a different spelling. On a case-insensitive filesystem the cached file answers
+        // this lookup through an alias and must be rejected; on a case-sensitive one no such file exists.
+        Artifact aliased = new DefaultArtifact("GID", "aid", "", "jar", "1-test");
+        LocalArtifactResult result = manager.find(session, new LocalArtifactRequest(aliased, null, null));
+        assertFalse(result.isAvailable());
+    }
+
+    @Test
+    public void testVerifyRealPathCanBeDisabled() throws Exception {
+        addLocalArtifact(artifact);
+        session.setConfigProperty("aether.enhancedLocalRepository.verifyRealPath", Boolean.FALSE.toString());
+
+        // opting out must not disturb an ordinary lookup
+        LocalArtifactResult result = manager.find(session, new LocalArtifactRequest(artifact, null, null));
+        assertTrue(result.isAvailable());
+    }
+
+    @Test
     public void testFindLocalArtifact() throws Exception {
         addLocalArtifact(artifact);
 


### PR DESCRIPTION
Ports master's real-path check for locally cached artifacts to the 1.9.x line, which does not have it.

On case-insensitive or normalization-preserving filesystems (the macOS and Windows defaults) a file cached for one set of coordinates also answers lookups for coordinates that differ only in case or Unicode normalization. The tracking data is compared exactly, so the aliased file is treated as present-but-untracked and accepted with no download and no checksum verification. `checkFind` now compares the requested relative path against the symlink-resolved real path and treats a mismatch as not present.

Two deliberate differences from master, both forced by the line:

- **The base path is resolved lazily.** Master resolves it in the constructor, which had to gain `throws IOException` and a `Files.createDirectories` call because a fresh local repository does not exist yet. On 1.9.x that would push the checked exception through `EnhancedLocalRepositoryManagerFactory.newInstance`, so the value is resolved on first use instead. The `&&` short-circuit in `checkFind` means it is only reached once a file is known to exist, so the fresh-repository case never gets there.
- **The property is `aether.enhancedLocalRepository.verifyRealPath`**, matching this line's existing `aether.enhancedLocalRepository.trackingFilename`. Master uses `aether.lrm.enhanced.verifyRealPath` via its newer `PREFIX_LRM` namespace, which 1.9.x does not have.

Master is on `Path` throughout (`checkFind(Path…)`, `Files.isRegularFile`, `result.setPath`); 1.9.x is on `File`, so this is a port rather than a cherry-pick.

On the tests: `testFindCaseAliasedArtifactIsNotAvailable` only exercises the new branch on a case-insensitive filesystem — elsewhere the aliased file simply does not exist and the assertion holds for the ordinary reason. I confirmed the guard is what makes it pass, by re-running it with `verifyRealPath=false` and observing the alias resolve (`available = true`) on a case-insensitive volume. The other two tests are portable: verification enabled must not disturb an ordinary lookup, and the opt-out must not either.

Verified: `mvn clean install` -> BUILD SUCCESS, 1044 tests, 0 failures, 0 errors.

*This change was created with AI assistance.*
