### PR TITLE
[1.9.x] Rename the collocated temp file into place on Windows instead of copying over the target

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/FileUtils.java
@@ -20,9 +20,8 @@ package org.eclipse.aether.util;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
+import java.io.InterruptedIOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -37,9 +36,22 @@ import static java.util.Objects.requireNonNull;
  * @since 1.9.0
  */
 public final class FileUtils {
-    // Logic borrowed from Commons-Lang3: we really need only this, to decide do we "atomic move" or not
+    // Logic borrowed from Commons-Lang3: we really need only this, to decide do we retry the final move or not
     private static final boolean IS_WINDOWS =
             System.getProperty("os.name", "unknown").startsWith("Windows");
+
+    /**
+     * The number of attempts for the final move on Windows, where the move target may be transiently locked by a
+     * virus scanner, an indexer or a concurrent reader.
+     */
+    private static final int WINDOWS_MOVE_ATTEMPTS =
+            Math.max(1, Integer.getInteger(FileUtils.class.getName() + ".windowsMoveAttempts", 5));
+
+    /**
+     * The delay in milliseconds applied between the move attempts on Windows.
+     */
+    private static final long WINDOWS_MOVE_RETRY_DELAY =
+            Long.getLong(FileUtils.class.getName() + ".windowsMoveRetryDelay", 50L);
 
     private FileUtils() {
         // hide constructor
@@ -130,7 +142,7 @@ public final class FileUtils {
             public void close() throws IOException {
                 if (wantsMove.get()) {
                     if (IS_WINDOWS) {
-                        copy(tempFile, file);
+                        retryingMove(tempFile, file);
                     } else {
                         Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE);
                     }
@@ -141,21 +153,39 @@ public final class FileUtils {
     }
 
     /**
-     * On Windows we use pre-NIO2 way to copy files, as for some reason it works. Beat me why.
+     * Moves the source file over the target path without ever opening the target for writing: the content visible
+     * at the target path is either the old file or the complete new file, never a partially written one.
+     * <p>
+     * Previously, on Windows the final move was implemented by opening the target path with a truncating stream and
+     * copying the source into it. That left a window during which a concurrent reader (for example a forked JVM
+     * resolving the same artifact) or an untimely process kill would observe, or durably leave behind, a truncated
+     * file at the final path. Instead, the rename is attempted a bounded number of times, as file locking by virus
+     * scanners, indexers or concurrent readers is transient on Windows, and the last failure is rethrown.
      */
-    private static void copy(Path source, Path target) throws IOException {
-        ByteBuffer buffer = ByteBuffer.allocate(1024 * 32);
-        byte[] array = buffer.array();
-        try (InputStream is = Files.newInputStream(source);
-                OutputStream os = Files.newOutputStream(target)) {
-            while (true) {
-                int bytes = is.read(array);
-                if (bytes < 0) {
-                    break;
+    static void retryingMove(Path source, Path target) throws IOException {
+        FileSystemException lastException = null;
+        for (int attempt = 0; attempt < WINDOWS_MOVE_ATTEMPTS; attempt++) {
+            try {
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                return;
+            } catch (FileSystemException e) {
+                // covers AccessDeniedException and sharing violations: transient on Windows
+                lastException = e;
+                if (attempt + 1 < WINDOWS_MOVE_ATTEMPTS) {
+                    try {
+                        Thread.sleep(WINDOWS_MOVE_RETRY_DELAY);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        InterruptedIOException interrupted =
+                                new InterruptedIOException("Interrupted while moving " + source + " to " + target);
+                        interrupted.initCause(ie);
+                        interrupted.addSuppressed(e);
+                        throw interrupted;
+                    }
                 }
-                os.write(array, 0, bytes);
             }
         }
+        throw lastException;
     }
 
     /**

--- a/maven-resolver-util/src/test/java/org/eclipse/aether/util/FileUtilsTest.java
+++ b/maven-resolver-util/src/test/java/org/eclipse/aether/util/FileUtilsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class FileUtilsTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testRetryingMoveReplacesExistingTarget() throws IOException {
+        Path dir = temporaryFolder.newFolder().toPath();
+        Path source = dir.resolve("file.txt.tmp");
+        Path target = dir.resolve("file.txt");
+        Files.write(source, "new".getBytes(StandardCharsets.UTF_8));
+        Files.write(target, "old".getBytes(StandardCharsets.UTF_8));
+
+        FileUtils.retryingMove(source, target);
+
+        assertFalse(Files.exists(source));
+        assertArrayEquals("new".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(target));
+    }
+
+    @Test
+    public void testRetryingMoveCreatesMissingTarget() throws IOException {
+        Path dir = temporaryFolder.newFolder().toPath();
+        Path source = dir.resolve("file.txt.tmp");
+        Path target = dir.resolve("file.txt");
+        Files.write(source, "new".getBytes(StandardCharsets.UTF_8));
+
+        FileUtils.retryingMove(source, target);
+
+        assertFalse(Files.exists(source));
+        assertArrayEquals("new".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(target));
+    }
+
+    @Test
+    public void testRetryingMoveMissingSourceFailsWithoutTouchingTarget() throws IOException {
+        Path dir = temporaryFolder.newFolder().toPath();
+        Path source = dir.resolve("missing.tmp");
+        Path target = dir.resolve("file.txt");
+        Files.write(target, "old".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            FileUtils.retryingMove(source, target);
+            fail("Expected NoSuchFileException");
+        } catch (NoSuchFileException expected) {
+            // the target must be left as it was
+        }
+        assertArrayEquals("old".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(target));
+    }
+
+    @Test
+    public void testWriteFileReplacesExistingTarget() throws IOException {
+        Path dir = temporaryFolder.newFolder().toPath();
+        Path target = dir.resolve("file.txt");
+        Files.write(target, "old".getBytes(StandardCharsets.UTF_8));
+
+        FileUtils.writeFile(target, p -> Files.write(p, "new".getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals("new", new String(Files.readAllBytes(target), StandardCharsets.UTF_8));
+        try (java.util.stream.Stream<Path> files = Files.list(dir)) {
+            assertEquals(1L, files.count());
+        }
+        assertTrue(Files.isRegularFile(target));
+    }
+}


### PR DESCRIPTION
Ports the Windows part of #2083 to the 1.9.x line. On `master` the final move lives in `PathProcessorSupport`; 1.9.x has no such class and the live path is `FileUtils.CollocatedTempFile.close()` in `maven-resolver-util`, so this is a reimplementation.

On Windows, `close()` previously opened the target path with a truncating stream and copied the temp file into it. Between the truncation and the last write, a concurrent reader (a forked JVM resolving the same artifact, for example) sees a short file at the final path, and a process killed in that window leaves it there. The temp file is collocated with the target, so the move is now a rename with `REPLACE_EXISTING` and `ATOMIC_MOVE`, retried a bounded number of times because sharing violations from virus scanners, indexers and readers are transient on Windows. The attempt count and delay are tunable through the `org.eclipse.aether.util.FileUtils.windowsMoveAttempts` and `windowsMoveRetryDelay` system properties (defaults 5 and 50 ms). Non-Windows platforms are unchanged.

Behavior change to note for Windows: replacing a file another process holds open now fails after the retries instead of truncating it in place. That is the same trade `master` made.

The new `FileUtilsTest` covers the rename replacing, creating, and leaving the target alone when the source is missing, plus `writeFile` end to end. I ran it on macOS; the Windows job in CI is the run that matters.

Verified: `mvn -pl maven-resolver-util -am verify` -> BUILD SUCCESS, 280 tests in the module, 0 failures; `spotless:apply` produced no further changes.

*This change was created with AI assistance.*
