### PR TITLE
[MRESOLVER-1995] Synchronize CollectResult access

### DIFF
--- a/maven-resolver-api/src/main/java/org/eclipse/aether/collection/CollectResult.java
+++ b/maven-resolver-api/src/main/java/org/eclipse/aether/collection/CollectResult.java
@@ -68,7 +68,7 @@ public final class CollectResult {
      *
      * @return The exceptions that occurred, never {@code null}.
      */
-    public List<Exception> getExceptions() {
+    public synchronized List<Exception> getExceptions() {
         return exceptions;
     }
 
@@ -78,7 +78,7 @@ public final class CollectResult {
      * @param exception The exception to record, may be {@code null}.
      * @return This result for chaining, never {@code null}.
      */
-    public CollectResult addException(Exception exception) {
+    public synchronized CollectResult addException(Exception exception) {
         if (exception != null) {
             if (exceptions.isEmpty()) {
                 exceptions = new ArrayList<>();
@@ -93,7 +93,7 @@ public final class CollectResult {
      *
      * @return The dependency cycles in the (raw) graph, never {@code null}.
      */
-    public List<DependencyCycle> getCycles() {
+    public synchronized List<DependencyCycle> getCycles() {
         return cycles;
     }
 
@@ -103,7 +103,7 @@ public final class CollectResult {
      * @param cycle The dependency cycle to record, may be {@code null}.
      * @return This result for chaining, never {@code null}.
      */
-    public CollectResult addCycle(DependencyCycle cycle) {
+    public synchronized CollectResult addCycle(DependencyCycle cycle) {
         if (cycle != null) {
             if (cycles.isEmpty()) {
                 cycles = new ArrayList<>();

--- a/maven-resolver-api/src/test/java/org/eclipse/aether/collection/CollectResultTest.java
+++ b/maven-resolver-api/src/test/java/org/eclipse/aether/collection/CollectResultTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.eclipse.aether.collection;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CollectResultTest {
+
+    @Test
+    void testConcurrentAddException() throws Exception {
+        CollectResult result = new CollectResult(new CollectRequest());
+
+        int threads = 10;
+        int additionsPerThread = 100;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+
+                        for (int j = 0; j < additionsPerThread; j++) {
+                            result.addException(new Exception());
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+
+            start.countDown();
+            executor.shutdown();
+
+            assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "Executor did not terminate in time");
+
+            assertEquals(threads * additionsPerThread, result.getExceptions().size());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #1995.

Synchronize access to the exception and dependency cycle collections in `CollectResult` to make concurrent updates thread-safe.

### Changes

* Synchronize `getExceptions()`
* Synchronize `addException()`
* Synchronize `getCycles()`
* Synchronize `addCycle()`
* Add a regression test covering concurrent exception additions

### Testing

* `mvn -pl maven-resolver-api test`
* Tests run: 91
* Failures: 0
* Errors: 0
* Skipped: 0
